### PR TITLE
feat: add multiple basic auth account

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,9 +12,9 @@
 - Compress video before send
 - Change OS name become your app (it's the device name when connect via mobile)
     - `--os=Chrome` or `--os=MyApplication`
-- Basic Auth
-    - `--basic-auth=kemal:secret`, or you can simplify
-    - `-b=kemal:secret`
+- Basic Auth (able to add multi account)
+    - `--basic-auth=kemal:secret,toni:password,userName:secretPassword`, or you can simplify
+    - `-b=kemal:secret,toni:password,userName:secretPassword`
 - Customizable port and debug mode
     - `--port 8000`
     - `--debug true`

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -74,16 +74,21 @@ func runRest(_ *cobra.Command, _ []string) {
 	}))
 
 	if config.AppBasicAuthCredential != "" {
-		ba := strings.Split(config.AppBasicAuthCredential, ":")
-		if len(ba) != 2 {
-			log.Fatalln("Basic auth is not valid, please this following format <user>:<secret>")
+		account := make(map[string]string, 0)
+		multipleBA := strings.Split(config.AppBasicAuthCredential, ",")
+		for _, basicAuth := range multipleBA {
+			ba := strings.Split(basicAuth, ":")
+			if len(ba) != 2 {
+				log.Fatalln("Basic auth is not valid, please this following format <user>:<secret>")
+			}
+			account[ba[0]] = ba[1]
 		}
 
-		app.Use(basicauth.New(basicauth.Config{
-			Users: map[string]string{
-				ba[0]: ba[1],
-			},
-		}))
+		if account != nil {
+			app.Use(basicauth.New(basicauth.Config{
+				Users: account,
+			}))
+		}
 	}
 
 	db := utils.InitWaDB()


### PR DESCRIPTION
### Context

- Currently we just able create basic auth with 1 user, now we can add multiple credential basic auth to login