### PR TITLE
Updated quotedMessage to include original message ID for correlation

### DIFF
--- a/src/pkg/whatsapp/whatsapp.go
+++ b/src/pkg/whatsapp/whatsapp.go
@@ -297,7 +297,7 @@ func forwardToWebhook(evt *events.Message) error {
 	var quotedmessage any
 	if evt.Message.ExtendedTextMessage != nil && evt.Message.ExtendedTextMessage.ContextInfo != nil {
 		if conversation := evt.Message.ExtendedTextMessage.ContextInfo.QuotedMessage.GetConversation(); conversation != "" {
-			quotedmessage = conversation
+			quotedmessage = evt.Message.ExtendedTextMessage.ContextInfo
 		}
 	}
 

--- a/whatsapp-api.service
+++ b/whatsapp-api.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=WhatsApp API Service
+After=network-online.target
+
+[Service]
+User=root
+ExecStart=/opt/go-whatsapp-web-multidevice/whatsapp --webhook="http://127.0.0.1:1880/webhooks/whatsapp"
+Environment=PYTHONUNBUFFERED=1
+Restart=on-failure
+Type=exec
+
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I've updated this to include the message context when the incoming message is a reply. This means that the message ID of the message being replied-to is included, which is very helpful (otherwise there is no way to correlate a specific message).

In my application, I send a series of messages to the user, and save the corresponding message ID after sending. When the user replies to a specific message, I am able to reference the correlated ID and my application can then handle that in context.