### PR TITLE
IPv6 support.

### DIFF
--- a/src/cmd/rest.go
+++ b/src/cmd/rest.go
@@ -40,6 +40,7 @@ func restServer(_ *cobra.Command, _ []string) {
 	app := fiber.New(fiber.Config{
 		Views:     engine,
 		BodyLimit: int(config.WhatsappSettingMaxVideoSize),
+		Network:   "tcp",
 	})
 
 	app.Static("/statics", "./statics")


### PR DESCRIPTION
## Context
I'm hosting my app on railway, which supports [private networking only on IPv6](https://docs.railway.com/guides/private-networking).

The WhatsApp API was only listening for IPv4, so I had to update fiber's "Network" variable.

Default is tcp4. tcp6 listens on only IPv6 connections, and [tcp listens on both](https://github.com/gofiber/fiber/blob/3b2af61152d0dc9bb75bd9451e506274266b638e/listen.go#L69).

Will not break anything AFAIK.