### PR TITLE
Group admin has LID in the JID field. Use PhoneNumber instead

### DIFF
--- a/src/views/components/GroupList.js
+++ b/src/views/components/GroupList.js
@@ -89,7 +89,7 @@ export default {
             
             // Check if current user is an admin in participants
             const currentUserJID = `${this.currentUserId}@s.whatsapp.net`;
-            const participant = group.Participants.find(p => p.JID === currentUserJID);
+            const participant = group.Participants.find(p => p.PhoneNumber === currentUserJID);
             return participant && participant.IsAdmin;
         },
         async handleSeeRequestedMember(group_id) {


### PR DESCRIPTION
I reproduced a bug that localy.
On my device, The groups JID's are LID's.
I saw that PhoneNumber has the right data that matches.

## Context
- Explain briefly the changes about

##  Test Results
<!--
- Attach the screenshot of the result or something
-->
- what you have done to test it