### PR TITLE
Resolve send API duration issue

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -409,6 +409,10 @@ paths:
                   type: boolean
                   example: false
                   description: Whether this is a forwarded message
+                duration:
+                  type: integer
+                  example: 3600
+                  description: Disappearing message duration in seconds (optional)
       responses:
         '200':
           description: OK
@@ -464,6 +468,10 @@ paths:
                   type: boolean
                   example: false
                   description: Compress image
+                duration:
+                  type: integer
+                  example: 3600
+                  description: Disappearing message duration in seconds (optional)
                 is_forwarded:
                   type: boolean
                   example: false
@@ -617,6 +625,10 @@ paths:
                   type: boolean
                   example: false
                   description: Compress video
+                duration:
+                  type: integer
+                  example: 3600
+                  description: Disappearing message duration in seconds (optional)
                 is_forwarded:
                   type: boolean
                   example: false

--- a/src/domains/send/audio.go
+++ b/src/domains/send/audio.go
@@ -7,4 +7,5 @@ type AudioRequest struct {
 	Audio       *multipart.FileHeader `json:"audio" form:"audio"`
 	AudioURL    *string               `json:"audio_url" form:"audio_url"`
 	IsForwarded bool                  `json:"is_forwarded" form:"is_forwarded"`
+	Duration    *int                  `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/audio.go
+++ b/src/domains/send/audio.go
@@ -3,9 +3,7 @@ package send
 import "mime/multipart"
 
 type AudioRequest struct {
-	Phone       string                `json:"phone" form:"phone"`
+	BaseRequest
 	Audio       *multipart.FileHeader `json:"audio" form:"audio"`
 	AudioURL    *string               `json:"audio_url" form:"audio_url"`
-	IsForwarded bool                  `json:"is_forwarded" form:"is_forwarded"`
-	Duration    *int                  `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/base.go
+++ b/src/domains/send/base.go
@@ -1,0 +1,7 @@
+package send
+
+type BaseRequest struct {
+	Phone      string `json:"phone" form:"phone"`
+	Duration   *int   `json:"duration,omitempty" form:"duration"`
+	IsForwarded bool  `json:"is_forwarded,omitempty" form:"is_forwarded"`
+}

--- a/src/domains/send/contact.go
+++ b/src/domains/send/contact.go
@@ -1,9 +1,7 @@
 package send
 
 type ContactRequest struct {
-	Phone        string `json:"phone" form:"phone"`
+	BaseRequest
 	ContactName  string `json:"contact_name" form:"contact_name"`
 	ContactPhone string `json:"contact_phone" form:"contact_phone"`
-	IsForwarded  bool   `json:"is_forwarded" form:"is_forwarded"`
-	Duration     *int   `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/contact.go
+++ b/src/domains/send/contact.go
@@ -5,4 +5,5 @@ type ContactRequest struct {
 	ContactName  string `json:"contact_name" form:"contact_name"`
 	ContactPhone string `json:"contact_phone" form:"contact_phone"`
 	IsForwarded  bool   `json:"is_forwarded" form:"is_forwarded"`
+	Duration     *int   `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/file.go
+++ b/src/domains/send/file.go
@@ -3,9 +3,7 @@ package send
 import "mime/multipart"
 
 type FileRequest struct {
-	Phone       string                `json:"phone" form:"phone"`
+	BaseRequest
 	File        *multipart.FileHeader `json:"file" form:"file"`
 	Caption     string                `json:"caption" form:"caption"`
-	IsForwarded bool                  `json:"is_forwarded" form:"is_forwarded"`
-	Duration    *int                  `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/file.go
+++ b/src/domains/send/file.go
@@ -7,4 +7,5 @@ type FileRequest struct {
 	File        *multipart.FileHeader `json:"file" form:"file"`
 	Caption     string                `json:"caption" form:"caption"`
 	IsForwarded bool                  `json:"is_forwarded" form:"is_forwarded"`
+	Duration    *int                  `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/image.go
+++ b/src/domains/send/image.go
@@ -3,12 +3,10 @@ package send
 import "mime/multipart"
 
 type ImageRequest struct {
-	Phone       string                `json:"phone" form:"phone"`
+	BaseRequest
 	Caption     string                `json:"caption" form:"caption"`
 	Image       *multipart.FileHeader `json:"image" form:"image"`
 	ImageURL    *string               `json:"image_url" form:"image_url"`
 	ViewOnce    bool                  `json:"view_once" form:"view_once"`
 	Compress    bool                  `json:"compress"`
-	IsForwarded bool                  `json:"is_forwarded" form:"is_forwarded"`
-	Duration    *int                  `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/image.go
+++ b/src/domains/send/image.go
@@ -10,4 +10,5 @@ type ImageRequest struct {
 	ViewOnce    bool                  `json:"view_once" form:"view_once"`
 	Compress    bool                  `json:"compress"`
 	IsForwarded bool                  `json:"is_forwarded" form:"is_forwarded"`
+	Duration    *int                  `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/link.go
+++ b/src/domains/send/link.go
@@ -5,4 +5,5 @@ type LinkRequest struct {
 	Caption     string `json:"caption"`
 	Link        string `json:"link"`
 	IsForwarded bool   `json:"is_forwarded" form:"is_forwarded"`
+	Duration    *int   `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/link.go
+++ b/src/domains/send/link.go
@@ -1,9 +1,7 @@
 package send
 
 type LinkRequest struct {
-	Phone       string `json:"phone" form:"phone"`
+	BaseRequest
 	Caption     string `json:"caption"`
 	Link        string `json:"link"`
-	IsForwarded bool   `json:"is_forwarded" form:"is_forwarded"`
-	Duration    *int   `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/location.go
+++ b/src/domains/send/location.go
@@ -1,9 +1,7 @@
 package send
 
 type LocationRequest struct {
-	Phone       string `json:"phone" form:"phone"`
-	Latitude    string `json:"latitude" form:"latitude"`
-	Longitude   string `json:"longitude" form:"longitude"`
-	IsForwarded bool   `json:"is_forwarded" form:"is_forwarded"`
-	Duration    *int   `json:"duration,omitempty" form:"duration"`
+	BaseRequest
+	Latitude  string `json:"latitude" form:"latitude"`
+	Longitude string `json:"longitude" form:"longitude"`
 }

--- a/src/domains/send/location.go
+++ b/src/domains/send/location.go
@@ -5,4 +5,5 @@ type LocationRequest struct {
 	Latitude    string `json:"latitude" form:"latitude"`
 	Longitude   string `json:"longitude" form:"longitude"`
 	IsForwarded bool   `json:"is_forwarded" form:"is_forwarded"`
+	Duration    *int   `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/poll.go
+++ b/src/domains/send/poll.go
@@ -5,4 +5,5 @@ type PollRequest struct {
 	Question  string   `json:"question" form:"question"`
 	Options   []string `json:"options" form:"options"`
 	MaxAnswer int      `json:"max_answer" form:"max_answer"`
+	Duration  *int     `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/poll.go
+++ b/src/domains/send/poll.go
@@ -1,9 +1,8 @@
 package send
 
 type PollRequest struct {
-	Phone     string   `json:"phone" form:"phone"`
+	BaseRequest
 	Question  string   `json:"question" form:"question"`
 	Options   []string `json:"options" form:"options"`
 	MaxAnswer int      `json:"max_answer" form:"max_answer"`
-	Duration  *int     `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/text.go
+++ b/src/domains/send/text.go
@@ -5,4 +5,5 @@ type MessageRequest struct {
 	Message        string  `json:"message" form:"message"`
 	IsForwarded    bool    `json:"is_forwarded" form:"is_forwarded"`
 	ReplyMessageID *string `json:"reply_message_id" form:"reply_message_id"`
+	Duration       *int    `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/text.go
+++ b/src/domains/send/text.go
@@ -1,9 +1,7 @@
 package send
 
 type MessageRequest struct {
-	Phone          string  `json:"phone" form:"phone"`
+	BaseRequest
 	Message        string  `json:"message" form:"message"`
-	IsForwarded    bool    `json:"is_forwarded" form:"is_forwarded"`
 	ReplyMessageID *string `json:"reply_message_id" form:"reply_message_id"`
-	Duration       *int    `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/video.go
+++ b/src/domains/send/video.go
@@ -3,12 +3,10 @@ package send
 import "mime/multipart"
 
 type VideoRequest struct {
-	Phone       string                `json:"phone" form:"phone"`
+	BaseRequest
 	Caption     string                `json:"caption" form:"caption"`
 	Video       *multipart.FileHeader `json:"video" form:"video"`
 	ViewOnce    bool                  `json:"view_once" form:"view_once"`
 	Compress    bool                  `json:"compress"`
-	IsForwarded bool                  `json:"is_forwarded" form:"is_forwarded"`
 	VideoURL    *string               `json:"video_url" form:"video_url"`
-	Duration    *int                  `json:"duration,omitempty" form:"duration"`
 }

--- a/src/domains/send/video.go
+++ b/src/domains/send/video.go
@@ -10,4 +10,5 @@ type VideoRequest struct {
 	Compress    bool                  `json:"compress"`
 	IsForwarded bool                  `json:"is_forwarded" form:"is_forwarded"`
 	VideoURL    *string               `json:"video_url" form:"video_url"`
+	Duration    *int                  `json:"duration,omitempty" form:"duration"`
 }

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -229,6 +229,14 @@ func (service serviceSend) SendImage(ctx context.Context, request domainSend.Ima
 		}
 	}
 
+	// Set duration expiration
+	if request.Duration != nil && *request.Duration > 0 {
+		if msg.ImageMessage.ContextInfo == nil {
+			msg.ImageMessage.ContextInfo = &waE2E.ContextInfo{}
+		}
+		msg.ImageMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
+	}
+
 	caption := "🖼️ Image"
 	if request.Caption != "" {
 		caption = "🖼️ " + request.Caption
@@ -287,6 +295,13 @@ func (service serviceSend) SendFile(ctx context.Context, request domainSend.File
 			IsForwarded:     proto.Bool(true),
 			ForwardingScore: proto.Uint32(100),
 		}
+	}
+
+	if request.Duration != nil && *request.Duration > 0 {
+		if msg.DocumentMessage.ContextInfo == nil {
+			msg.DocumentMessage.ContextInfo = &waE2E.ContextInfo{}
+		}
+		msg.DocumentMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
 	}
 
 	caption := "📄 Document"
@@ -457,6 +472,13 @@ func (service serviceSend) SendVideo(ctx context.Context, request domainSend.Vid
 		}
 	}
 
+	if request.Duration != nil && *request.Duration > 0 {
+		if msg.VideoMessage.ContextInfo == nil {
+			msg.VideoMessage.ContextInfo = &waE2E.ContextInfo{}
+		}
+		msg.VideoMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
+	}
+
 	caption := "🎥 Video"
 	if request.Caption != "" {
 		caption = "🎥 " + request.Caption
@@ -493,6 +515,13 @@ func (service serviceSend) SendContact(ctx context.Context, request domainSend.C
 			IsForwarded:     proto.Bool(true),
 			ForwardingScore: proto.Uint32(100),
 		}
+	}
+
+	if request.Duration != nil && *request.Duration > 0 {
+		if msg.ContactMessage.ContextInfo == nil {
+			msg.ContactMessage.ContextInfo = &waE2E.ContextInfo{}
+		}
+		msg.ContactMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
 	}
 
 	content := "👤 " + request.ContactName
@@ -543,6 +572,13 @@ func (service serviceSend) SendLink(ctx context.Context, request domainSend.Link
 			IsForwarded:     proto.Bool(true),
 			ForwardingScore: proto.Uint32(100),
 		}
+	}
+
+	if request.Duration != nil && *request.Duration > 0 {
+		if msg.ExtendedTextMessage.ContextInfo == nil {
+			msg.ExtendedTextMessage.ContextInfo = &waE2E.ContextInfo{}
+		}
+		msg.ExtendedTextMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
 	}
 
 	// If we have a thumbnail image, upload it to WhatsApp's servers
@@ -598,6 +634,13 @@ func (service serviceSend) SendLocation(ctx context.Context, request domainSend.
 			IsForwarded:     proto.Bool(true),
 			ForwardingScore: proto.Uint32(100),
 		}
+	}
+
+	if request.Duration != nil && *request.Duration > 0 {
+		if msg.LocationMessage.ContextInfo == nil {
+			msg.LocationMessage.ContextInfo = &waE2E.ContextInfo{}
+		}
+		msg.LocationMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
 	}
 
 	content := "📍 " + request.Latitude + ", " + request.Longitude
@@ -668,6 +711,13 @@ func (service serviceSend) SendAudio(ctx context.Context, request domainSend.Aud
 		}
 	}
 
+	if request.Duration != nil && *request.Duration > 0 {
+		if msg.AudioMessage.ContextInfo == nil {
+			msg.AudioMessage.ContextInfo = &waE2E.ContextInfo{}
+		}
+		msg.AudioMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
+	}
+
 	content := "🎵 Audio"
 
 	ts, err := service.wrapSendMessage(ctx, dataWaRecipient, msg, content)
@@ -693,6 +743,13 @@ func (service serviceSend) SendPoll(ctx context.Context, request domainSend.Poll
 	content := "📊 " + request.Question
 
 	msg := service.WaCli.BuildPollCreation(request.Question, request.Options, request.MaxAnswer)
+
+	if request.Duration != nil && *request.Duration > 0 {
+		if msg.ContextInfo == nil {
+			msg.ContextInfo = &waE2E.ContextInfo{}
+		}
+		msg.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
+	}
 
 	ts, err := service.wrapSendMessage(ctx, dataWaRecipient, msg, content)
 	if err != nil {

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -73,6 +73,11 @@ func (service serviceSend) SendText(ctx context.Context, request domainSend.Mess
 		msg.ExtendedTextMessage.ContextInfo.ForwardingScore = proto.Uint32(100)
 	}
 
+	// Set disappearing message duration if provided
+	if request.Duration != nil && *request.Duration > 0 {
+		msg.ExtendedTextMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
+	}
+
 	parsedMentions := service.getMentionFromText(ctx, request.Message)
 	if len(parsedMentions) > 0 {
 		msg.ExtendedTextMessage.ContextInfo.MentionedJID = parsedMentions
@@ -91,6 +96,11 @@ func (service serviceSend) SendText(ctx context.Context, request domainSend.Mess
 						Conversation: proto.String(record.MessageContent),
 					},
 				},
+			}
+
+			// Preserve expiration if provided
+			if request.Duration != nil && *request.Duration > 0 {
+				msg.ExtendedTextMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.Duration))
 			}
 
 			if len(parsedMentions) > 0 {

--- a/src/validations/send_validation.go
+++ b/src/validations/send_validation.go
@@ -22,6 +22,11 @@ func ValidateSendMessage(ctx context.Context, request domainSend.MessageRequest)
 	if err != nil {
 		return pkgError.ValidationError(err.Error())
 	}
+
+	// Custom validation for optional Duration
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
+	}
 	return nil
 }
 

--- a/src/validations/send_validation.go
+++ b/src/validations/send_validation.go
@@ -66,6 +66,11 @@ func ValidateSendImage(ctx context.Context, request domainSend.ImageRequest) err
 		}
 	}
 
+	// Validate duration
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
+	}
+
 	return nil
 }
 
@@ -82,6 +87,10 @@ func ValidateSendFile(ctx context.Context, request domainSend.FileRequest) error
 	if request.File.Size > config.WhatsappSettingMaxFileSize { // 10MB
 		maxSizeString := humanize.Bytes(uint64(config.WhatsappSettingMaxFileSize))
 		return pkgError.ValidationError(fmt.Sprintf("max file upload is %s, please upload in cloud and send via text if your file is higher than %s", maxSizeString, maxSizeString))
+	}
+
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
 	}
 
 	return nil
@@ -132,6 +141,10 @@ func ValidateSendVideo(ctx context.Context, request domainSend.VideoRequest) err
 		}
 	}
 
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
+	}
+
 	return nil
 }
 
@@ -144,6 +157,10 @@ func ValidateSendContact(ctx context.Context, request domainSend.ContactRequest)
 
 	if err != nil {
 		return pkgError.ValidationError(err.Error())
+	}
+
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
 	}
 
 	return nil
@@ -160,6 +177,10 @@ func ValidateSendLink(ctx context.Context, request domainSend.LinkRequest) error
 		return pkgError.ValidationError(err.Error())
 	}
 
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
+	}
+
 	return nil
 }
 
@@ -172,6 +193,10 @@ func ValidateSendLocation(ctx context.Context, request domainSend.LocationReques
 
 	if err != nil {
 		return pkgError.ValidationError(err.Error())
+	}
+
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
 	}
 
 	return nil
@@ -240,6 +265,10 @@ func ValidateSendAudio(ctx context.Context, request domainSend.AudioRequest) err
 		}
 	}
 
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
+	}
+
 	return nil
 }
 
@@ -262,6 +291,10 @@ func ValidateSendPoll(ctx context.Context, request domainSend.PollRequest) error
 
 	if err != nil {
 		return pkgError.ValidationError(err.Error())
+	}
+
+	if request.Duration != nil && *request.Duration <= 0 {
+		return pkgError.ValidationError("duration must be greater than 0 second")
 	}
 
 	// validate options should be unique each other

--- a/src/views/components/SendAudio.js
+++ b/src/views/components/SendAudio.js
@@ -13,6 +13,7 @@ export default {
             selectedFileName: null,
             is_forwarded: false,
             audio_url: null,
+            duration: 0,
         }
     },
     computed: {
@@ -58,6 +59,9 @@ export default {
                 let payload = new FormData();
                 payload.append("phone", this.phone_id)
                 payload.append("is_forwarded", this.is_forwarded)
+                if (this.duration && this.duration > 0) {
+                    payload.append("duration", this.duration)
+                }
 
                 const fileInput = $("#file_audio");
                 if (fileInput.length > 0 && fileInput[0].files.length > 0) {
@@ -84,6 +88,7 @@ export default {
             this.phone = '';
             this.type = window.TYPEUSER;
             this.is_forwarded = false;
+            this.duration = 0;
             $("#file_audio").val('');
             this.selectedFileName = null;
             this.audio_url = null;
@@ -121,6 +126,10 @@ export default {
                         <input type="checkbox" aria-label="is forwarded" v-model="is_forwarded">
                         <label>Mark audio as forwarded</label>
                     </div>
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
                 <div class="field">
                     <label>Audio URL</label>

--- a/src/views/components/SendContact.js
+++ b/src/views/components/SendContact.js
@@ -12,7 +12,8 @@ export default {
             card_name: '',
             card_phone: '',
             loading: false,
-            is_forwarded: false
+            is_forwarded: false,
+            duration: 0
         }
     },
     computed: {
@@ -66,7 +67,8 @@ export default {
                     phone: this.phone_id,
                     contact_name: this.card_name,
                     contact_phone: this.card_phone,
-                    is_forwarded: this.is_forwarded
+                    is_forwarded: this.is_forwarded,
+                    ...(this.duration && this.duration > 0 ? {duration: this.duration} : {})
                 }
                 let response = await window.http.post(`/send/contact`, payload)
                 this.handleReset();
@@ -86,6 +88,7 @@ export default {
             this.card_phone = '';
             this.type = window.TYPEUSER;
             this.is_forwarded = false;
+            this.duration = 0;
         },
     },
     template: `
@@ -125,6 +128,10 @@ export default {
                         <input type="checkbox" aria-label="is forwarded" v-model="is_forwarded">
                         <label>Mark contact as forwarded</label>
                     </div>
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
             </form>
         </div>

--- a/src/views/components/SendFile.js
+++ b/src/views/components/SendFile.js
@@ -18,7 +18,8 @@ export default {
             phone: '',
             loading: false,
             selectedFileName: null,
-            is_forwarded: false
+            is_forwarded: false,
+            duration: 0
         }
     },
     computed: {
@@ -68,6 +69,9 @@ export default {
                 payload.append("caption", this.caption)
                 payload.append("phone", this.phone_id)
                 payload.append("is_forwarded", this.is_forwarded)
+                if (this.duration && this.duration > 0) {
+                    payload.append("duration", this.duration)
+                }
                 payload.append("file", $("#file_file")[0].files[0])
                 let response = await window.http.post(`/send/file`, payload)
                 this.handleReset();
@@ -87,6 +91,7 @@ export default {
             this.type = window.TYPEUSER;
             this.selectedFileName = null;
             this.is_forwarded = false;
+            this.duration = 0;
             $("#file_file").val('');
         },
         handleFileChange(event) {
@@ -129,6 +134,10 @@ export default {
                         <input type="checkbox" aria-label="is forwarded" v-model="is_forwarded">
                         <label>Mark file as forwarded</label>
                     </div>
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
                 <div class="field" style="padding-bottom: 30px">
                     <label>File</label>

--- a/src/views/components/SendImage.js
+++ b/src/views/components/SendImage.js
@@ -16,7 +16,8 @@ export default {
             selected_file: null,
             image_url: null,
             preview_url: null,
-            is_forwarded: false
+            is_forwarded: false,
+            duration: 0
         }
     },
     computed: {
@@ -76,6 +77,9 @@ export default {
                 payload.append("compress", this.compress)
                 payload.append("caption", this.caption)
                 payload.append("is_forwarded", this.is_forwarded)
+                if (this.duration && this.duration > 0) {
+                    payload.append("duration", this.duration)
+                }
                 
                 const fileInput = $("#file_image");
                 if (fileInput.length > 0 && fileInput[0].files.length > 0) {
@@ -107,6 +111,7 @@ export default {
             this.selected_file = null;
             this.image_url = null;
             this.is_forwarded = false;
+            this.duration = 0;
             $("#file_image").val('');
         },
         handleImageChange(event) {
@@ -172,6 +177,10 @@ export default {
                         <input type="checkbox" aria-label="is forwarded" v-model="is_forwarded">
                         <label>Mark image as forwarded</label>
                     </div>
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
                 <div class="field">
                     <label>Image URL</label>

--- a/src/views/components/SendLink.js
+++ b/src/views/components/SendLink.js
@@ -13,7 +13,8 @@ export default {
             caption: '',
             reply_message_id: '',
             loading: false,
-            is_forwarded: false
+            is_forwarded: false,
+            duration: 0
         }
     },
     computed: {
@@ -64,7 +65,8 @@ export default {
                     phone: this.phone_id,
                     link: this.link.trim(),
                     caption: this.caption.trim(),
-                    is_forwarded: this.is_forwarded
+                    is_forwarded: this.is_forwarded,
+                    ...(this.duration && this.duration > 0 ? {duration: this.duration} : {})
                 };
                 if (this.reply_message_id !== '') {
                     payload.reply_message_id = this.reply_message_id;
@@ -88,6 +90,7 @@ export default {
             this.caption = '';
             this.reply_message_id = '';
             this.is_forwarded = false;
+            this.duration = 0;
         },
     },
     template: `
@@ -132,6 +135,10 @@ export default {
                         <input type="checkbox" aria-label="is forwarded" v-model="is_forwarded">
                         <label>Mark link as forwarded</label>
                     </div>
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
             </form>
         </div>

--- a/src/views/components/SendLocation.js
+++ b/src/views/components/SendLocation.js
@@ -12,7 +12,8 @@ export default {
             latitude: '',
             longitude: '',
             loading: false,
-            is_forwarded: false
+            is_forwarded: false,
+            duration: 0
         }
     },
     computed: {
@@ -63,7 +64,8 @@ export default {
                     phone: this.phone_id,
                     latitude: this.latitude,
                     longitude: this.longitude,
-                    is_forwarded: this.is_forwarded
+                    is_forwarded: this.is_forwarded,
+                    ...(this.duration && this.duration > 0 ? {duration: this.duration} : {})
                 };
 
                 const response = await window.http.post(`/send/location`, payload);
@@ -84,6 +86,7 @@ export default {
             this.longitude = '';
             this.type = window.TYPEUSER;
             this.is_forwarded = false;
+            this.duration = 0;
         },
     },
     template: `
@@ -123,6 +126,10 @@ export default {
                         <input type="checkbox" aria-label="is forwarded" v-model="is_forwarded">
                         <label>Mark location as forwarded</label>
                     </div>
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
             </form>
         </div>

--- a/src/views/components/SendMessage.js
+++ b/src/views/components/SendMessage.js
@@ -12,6 +12,7 @@ export default {
             text: '',
             reply_message_id: '',
             is_forwarded: false,
+            duration: 0,
             loading: false,
         }
     },
@@ -65,6 +66,10 @@ export default {
                     payload.reply_message_id = this.reply_message_id;
                 }
 
+                if (this.duration && this.duration > 0) {
+                    payload.duration = this.duration;
+                }
+
                 const response = await window.http.post('/send/message', payload);
                 this.handleReset();
                 return response.data.message;
@@ -82,6 +87,7 @@ export default {
             this.text = '';
             this.reply_message_id = '';
             this.is_forwarded = false;
+            this.duration = 0;
         },
     },
     template: `
@@ -121,6 +127,10 @@ export default {
                         <input type="checkbox" aria-label="is forwarded" v-model="is_forwarded">
                         <label>Mark message as forwarded</label>
                     </div>
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
             </form>
         </div>

--- a/src/views/components/SendPoll.js
+++ b/src/views/components/SendPoll.js
@@ -14,6 +14,8 @@ export default {
             question: '',
             options: ['', ''],
             max_vote: 1,
+            max_answer: 1,
+            duration: 0,
         }
     },
     computed: {
@@ -63,8 +65,9 @@ export default {
                 const payload = {
                     phone: this.phone_id,
                     question: this.question,
-                    max_answer: this.max_vote,
-                    options: this.options
+                    options: this.options,
+                    max_answer: this.max_answer,
+                    ...(this.duration && this.duration > 0 ? {duration: this.duration} : {})
                 }
                 const response = await window.http.post(`/send/poll`, payload)
                 this.handleReset();
@@ -84,6 +87,8 @@ export default {
             this.question = '';
             this.options = ['', ''];
             this.max_vote = 1;
+            this.max_answer = 1;
+            this.duration = 0;
         },
         addOption() {
             this.options.push('')
@@ -139,6 +144,15 @@ export default {
                     <label>Max Vote</label>
                     <input v-model="max_vote" type="number" placeholder="Max Vote"
                            aria-label="poll max votes" min="0">
+                </div>
+                <div class="field">
+                    <label>Max Answer</label>
+                    <input v-model="max_answer" type="number" placeholder="Max Answer"
+                           aria-label="poll max answers" min="0">
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
             </form>
         </div>

--- a/src/views/components/SendVideo.js
+++ b/src/views/components/SendVideo.js
@@ -21,7 +21,8 @@ export default {
             loading: false,
             video_url: null,
             selectedFileName: null,
-            is_forwarded: false
+            is_forwarded: false,
+            duration: 0
         }
     },
     computed: {
@@ -34,6 +35,7 @@ export default {
             // If view_once is set to true, set is_forwarded to false
             if (newValue === true) {
                 this.is_forwarded = false;
+                this.duration = 0;
             }
         }
     },
@@ -93,6 +95,9 @@ export default {
                 payload.append("view_once", this.view_once)
                 payload.append("compress", this.compress)
                 payload.append("is_forwarded", this.is_forwarded)
+                if (this.duration && this.duration > 0) {
+                    payload.append("duration", this.duration)
+                }
 
                 const fileInput = $("#file_video")[0];
                 if (fileInput && fileInput.files && fileInput.files[0]) {
@@ -122,6 +127,7 @@ export default {
             this.selectedFileName = null;
             this.video_url = null;
             this.is_forwarded = false;
+            this.duration = 0;
             $("#file_video").val('');
         },
         handleFileChange(event) {
@@ -180,6 +186,10 @@ export default {
                         <input type="checkbox" aria-label="is forwarded" v-model="is_forwarded">
                         <label>Mark video as forwarded</label>
                     </div>
+                </div>
+                <div class="field">
+                    <label>Disappearing Duration (seconds)</label>
+                    <input v-model.number="duration" type="number" min="0" placeholder="0 (no expiry)" aria-label="duration"/>
                 </div>
                 <div class="field">
                     <label>Video URL</label>


### PR DESCRIPTION
## Context
This PR introduces support for WhatsApp disappearing messages across all send APIs.

Key changes include:
-   **Core Functionality**: Added an optional `duration` parameter (seconds until expiry) to all message types (Text, Image, File, Video, Audio, Contact, Link, Location, Poll).
-   **Refactoring**: Centralized common request fields (`Phone`, `Duration`, `IsForwarded`) into a new `BaseRequest` struct, which is now embedded in all send request DTOs.
-   **API & UI Exposure**: Updated `openapi.yaml` to include the `duration` parameter and modified all UI sender components to expose a "Disappearing Duration (seconds)" input field.

## Test Results
-   Verified sending various message types (Text, Image, File, Video, Audio, Contact, Link, Location, Poll) with and without a `duration` value via both API and UI.
-   Confirmed that messages sent with a valid `duration` successfully disappear on the WhatsApp client after the specified time.
-   Validated that the API and UI enforce `duration` to be a positive integer.