### PR TITLE
Handle chat storage initialization failure

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -196,7 +196,8 @@ func initApp() {
 
 	chatStorageRepo, err = chatstorage.NewStorage(chatstorage.DefaultConfig())
 	if err != nil {
-		logrus.Errorln(err)
+		// Terminate the application if chat storage fails to initialize to avoid nil pointer panics later.
+		logrus.Fatalf("failed to initialize chat storage: %v", err)
 	}
 
 	whatsappDB = whatsapp.InitWaDB(ctx)


### PR DESCRIPTION
# Fix: Terminate on Chat Storage Initialization Failure

## Context

- Previously, if `chatstorage.NewStorage()` failed during application initialization, the error was only logged, and `chatStorageRepo` remained `nil`.
- This caused nil pointer panics when `chatStorageRepo` was subsequently accessed.
- The application now terminates immediately if chat storage initialization fails, preventing downstream panics.

## Test Results
- Verified that the application now exits immediately with a fatal error if `chatstorage.NewStorage()` returns an error during initialization.