### PR TITLE
Add error handling for message storage

### DIFF
--- a/src/infrastructure/whatsapp/init.go
+++ b/src/infrastructure/whatsapp/init.go
@@ -393,7 +393,10 @@ func handleMessage(ctx context.Context, evt *events.Message, chatStorageRepo *ch
 		evt.Message,
 	)
 
-	chatStorageRepo.CreateMessage(ctx, evt)
+	if err := chatStorageRepo.CreateMessage(ctx, evt); err != nil {
+		// Log storage errors to avoid silent failures that could lead to data loss
+		log.Errorf("Failed to store incoming message %s: %v", evt.Info.ID, err)
+	}
 
 	// Handle image message if present
 	handleImageMessage(ctx, evt)


### PR DESCRIPTION
# Add error handling for `chatStorageRepo.CreateMessage`

## Context

- Previously, the `chatStorageRepo.CreateMessage` call in `handleMessage` silently ignored errors, potentially leading to data loss without notification.
- This PR adds error logging to ensure any failures during message storage are reported.

## Test Results
- Verified that `chatStorageRepo.CreateMessage` is now wrapped in an error check and logs any encountered errors using `log.Errorf`.