### PR TITLE
Fix inconsistent sender JID storage

### DIFF
--- a/src/infrastructure/chatstorage/whatsapp_integration.go
+++ b/src/infrastructure/chatstorage/whatsapp_integration.go
@@ -52,7 +52,8 @@ func (s *Storage) CreateMessage(ctx context.Context, evt *events.Message) error 
 
 	// Extract chat and sender information
 	chatJID := evt.Info.Chat.String()
-	sender := evt.Info.Sender.User
+	// Store the full sender JID (user@server) to ensure consistency between received and sent messages
+	sender := evt.Info.Sender.String()
 
 	// Get appropriate chat name using pushname if available
 	chatName := s.GetChatNameWithPushName(evt.Info.Chat, chatJID, evt.Info.Sender.User, evt.Info.PushName)

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -117,10 +117,17 @@ func (service serviceSend) SendText(ctx context.Context, request domainSend.Mess
 	if request.ReplyMessageID != nil && *request.ReplyMessageID != "" {
 		message, err := service.chatStorageRepo.FindMessageByID(*request.ReplyMessageID)
 		if err == nil && message != nil { // Only set reply context if we found the message
+			// Ensure we use a full JID (user@server) for the Participant field
+			participantJID := message.Sender
+			if !strings.Contains(participantJID, "@") {
+				// Default to WhatsApp user server when the server part is missing
+				participantJID = participantJID + "@s.whatsapp.net"
+			}
+
 			// Build base ContextInfo with reply details
 			ctxInfo := &waE2E.ContextInfo{
 				StanzaID:    request.ReplyMessageID,
-				Participant: proto.String(message.Sender),
+				Participant: proto.String(participantJID),
 				QuotedMessage: &waE2E.Message{
 					Conversation: proto.String(message.Content),
 				},


### PR DESCRIPTION
# Fix: Inconsistent Sender JID in `chatstorage.Message` breaks replies

## Context

- Addresses a bug where `chatstorage.Message` stored sender JIDs inconsistently (user-only for received messages, full JID for sent messages).
- This caused reply functionality to fail, particularly in group chats, as the `Participant` field in the reply context required a full JID.
- The fix ensures the full sender JID is always stored and correctly used when constructing reply contexts, appending `@s.whatsapp.net` as a default if the server part is missing.

## Test Results
- `go build ./...`
- `go test ./...`
- Verified reply functionality works correctly in both 1-to-1 and group chats.