### PR TITLE
🚀 Add Support for Subpath Deployment

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -3,6 +3,7 @@ APP_PORT=3000
 APP_DEBUG=false
 APP_OS=Chrome
 APP_BASIC_AUTH=user1:pass1,user2:pass2
+APP_BASE_PATH=
 
 # Database Settings
 DB_URI="file:storages/whatsapp.db?_foreign_keys=on"

--- a/src/cmd/rest.go
+++ b/src/cmd/rest.go
@@ -43,13 +43,13 @@ func restServer(_ *cobra.Command, _ []string) {
 		Network:   "tcp",
 	})
 
-	app.Static("/statics", "./statics")
-	app.Use("/components", filesystem.New(filesystem.Config{
+	app.Static(config.AppBasePath+"/statics", "./statics")
+	app.Use(config.AppBasePath+"/components", filesystem.New(filesystem.Config{
 		Root:       http.FS(EmbedViews),
 		PathPrefix: "views/components",
 		Browse:     true,
 	}))
-	app.Use("/assets", filesystem.New(filesystem.Config{
+	app.Use(config.AppBasePath+"/assets", filesystem.New(filesystem.Config{
 		Root:       http.FS(EmbedViews),
 		PathPrefix: "views/assets",
 		Browse:     true,
@@ -80,26 +80,33 @@ func restServer(_ *cobra.Command, _ []string) {
 		}))
 	}
 
-	// Rest
-	rest.InitRestApp(app, appUsecase)
-	rest.InitRestChat(app, chatUsecase)
-	rest.InitRestSend(app, sendUsecase)
-	rest.InitRestUser(app, userUsecase)
-	rest.InitRestMessage(app, messageUsecase)
-	rest.InitRestGroup(app, groupUsecase)
-	rest.InitRestNewsletter(app, newsletterUsecase)
+	// Create base path group or use app directly
+	var apiGroup fiber.Router = app
+	if config.AppBasePath != "" {
+		apiGroup = app.Group(config.AppBasePath)
+	}
 
-	app.Get("/", func(c *fiber.Ctx) error {
+	// Rest
+	rest.InitRestApp(apiGroup, appUsecase)
+	rest.InitRestChat(apiGroup, chatUsecase)
+	rest.InitRestSend(apiGroup, sendUsecase)
+	rest.InitRestUser(apiGroup, userUsecase)
+	rest.InitRestMessage(apiGroup, messageUsecase)
+	rest.InitRestGroup(apiGroup, groupUsecase)
+	rest.InitRestNewsletter(apiGroup, newsletterUsecase)
+
+	apiGroup.Get("/", func(c *fiber.Ctx) error {
 		return c.Render("views/index", fiber.Map{
 			"AppHost":        fmt.Sprintf("%s://%s", c.Protocol(), c.Hostname()),
 			"AppVersion":     config.AppVersion,
+			"AppBasePath":    config.AppBasePath,
 			"BasicAuthToken": c.UserContext().Value(middleware.AuthorizationValue("BASIC_AUTH")),
 			"MaxFileSize":    humanize.Bytes(uint64(config.WhatsappSettingMaxFileSize)),
 			"MaxVideoSize":   humanize.Bytes(uint64(config.WhatsappSettingMaxVideoSize)),
 		})
 	})
 
-	websocket.RegisterRoutes(app, appUsecase)
+	websocket.RegisterRoutes(apiGroup, appUsecase)
 	go websocket.RunHub()
 
 	// Set auto reconnect to whatsapp server after booting

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -91,6 +91,9 @@ func initEnvConfig() {
 		credential := strings.Split(envBasicAuth, ",")
 		config.AppBasicAuthCredential = credential
 	}
+	if envBasePath := viper.GetString("app_base_path"); envBasePath != "" {
+		config.AppBasePath = envBasePath
+	}
 
 	// Database settings
 	if envDBURI := viper.GetString("db_uri"); envDBURI != "" {
@@ -145,6 +148,12 @@ func initFlags() {
 		"basic-auth", "b",
 		config.AppBasicAuthCredential,
 		"basic auth credential | -b=yourUsername:yourPassword",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&config.AppBasePath,
+		"base-path", "",
+		config.AppBasePath,
+		`base path for subpath deployment --base-path <string> | example: --base-path="/gowa"`,
 	)
 
 	// Database flags

--- a/src/config/settings.go
+++ b/src/config/settings.go
@@ -11,6 +11,7 @@ var (
 	AppOs                  = "AldinoKemal"
 	AppPlatform            = waCompanionReg.DeviceProps_PlatformType(1)
 	AppBasicAuthCredential []string
+	AppBasePath            = ""
 
 	McpPort = "8080"
 	McpHost = "localhost"

--- a/src/ui/rest/app.go
+++ b/src/ui/rest/app.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"fmt"
 
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	domainApp "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/app"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
@@ -13,7 +14,7 @@ type App struct {
 	Service domainApp.IAppUsecase
 }
 
-func InitRestApp(app *fiber.App, service domainApp.IAppUsecase) App {
+func InitRestApp(app fiber.Router, service domainApp.IAppUsecase) App {
 	rest := App{Service: service}
 	app.Get("/app/login", rest.Login)
 	app.Get("/app/login-with-code", rest.LoginWithCode)
@@ -34,7 +35,7 @@ func (handler *App) Login(c *fiber.Ctx) error {
 		Code:    "SUCCESS",
 		Message: "Login success",
 		Results: map[string]any{
-			"qr_link":     fmt.Sprintf("%s://%s/%s", c.Protocol(), c.Hostname(), response.ImagePath),
+			"qr_link":     fmt.Sprintf("%s://%s%s/%s", c.Protocol(), c.Hostname(), config.AppBasePath, response.ImagePath),
 			"qr_duration": response.Duration,
 		},
 	})

--- a/src/ui/rest/chat.go
+++ b/src/ui/rest/chat.go
@@ -10,7 +10,7 @@ type Chat struct {
 	Service domainChat.IChatUsecase
 }
 
-func InitRestChat(app *fiber.App, service domainChat.IChatUsecase) Chat {
+func InitRestChat(app fiber.Router, service domainChat.IChatUsecase) Chat {
 	rest := Chat{Service: service}
 
 	// Chat endpoints

--- a/src/ui/rest/group.go
+++ b/src/ui/rest/group.go
@@ -15,7 +15,7 @@ type Group struct {
 	Service domainGroup.IGroupUsecase
 }
 
-func InitRestGroup(app *fiber.App, service domainGroup.IGroupUsecase) Group {
+func InitRestGroup(app fiber.Router, service domainGroup.IGroupUsecase) Group {
 	rest := Group{Service: service}
 	app.Post("/group", rest.CreateGroup)
 	app.Post("/group/join-with-link", rest.JoinGroupWithLink)

--- a/src/ui/rest/message.go
+++ b/src/ui/rest/message.go
@@ -10,7 +10,7 @@ type Message struct {
 	Service domainMessage.IMessageUsecase
 }
 
-func InitRestMessage(app *fiber.App, service domainMessage.IMessageUsecase) Message {
+func InitRestMessage(app fiber.Router, service domainMessage.IMessageUsecase) Message {
 	rest := Message{Service: service}
 
 	// Message action endpoints

--- a/src/ui/rest/newsletter.go
+++ b/src/ui/rest/newsletter.go
@@ -10,7 +10,7 @@ type Newsletter struct {
 	Service domainNewsletter.INewsletterUsecase
 }
 
-func InitRestNewsletter(app *fiber.App, service domainNewsletter.INewsletterUsecase) Newsletter {
+func InitRestNewsletter(app fiber.Router, service domainNewsletter.INewsletterUsecase) Newsletter {
 	rest := Newsletter{Service: service}
 	app.Post("/newsletter/unfollow", rest.Unfollow)
 	return rest

--- a/src/ui/rest/send.go
+++ b/src/ui/rest/send.go
@@ -10,7 +10,7 @@ type Send struct {
 	Service domainSend.ISendUsecase
 }
 
-func InitRestSend(app *fiber.App, service domainSend.ISendUsecase) Send {
+func InitRestSend(app fiber.Router, service domainSend.ISendUsecase) Send {
 	rest := Send{Service: service}
 	app.Post("/send/message", rest.SendText)
 	app.Post("/send/image", rest.SendImage)

--- a/src/ui/rest/user.go
+++ b/src/ui/rest/user.go
@@ -10,7 +10,7 @@ type User struct {
 	Service domainUser.IUserUsecase
 }
 
-func InitRestUser(app *fiber.App, service domainUser.IUserUsecase) User {
+func InitRestUser(app fiber.Router, service domainUser.IUserUsecase) User {
 	rest := User{Service: service}
 	app.Get("/user/info", rest.UserInfo)
 	app.Get("/user/avatar", rest.UserAvatar)

--- a/src/ui/websocket/websocket.go
+++ b/src/ui/websocket/websocket.go
@@ -77,7 +77,7 @@ func RunHub() {
 	}
 }
 
-func RegisterRoutes(app *fiber.App, service domainApp.IAppUsecase) {
+func RegisterRoutes(app fiber.Router, service domainApp.IAppUsecase) {
 	app.Use("/ws", func(c *fiber.Ctx) error {
 		if websocket.IsWebSocketUpgrade(c) {
 			return c.Next()

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css"
           href="https://cdnjs.cloudflare.com/ajax/libs/fomantic-ui/2.8.8/semantic.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.11.4/css/dataTables.semanticui.min.css">
-    <link rel="stylesheet" href="assets/app.css">
+    <link rel="stylesheet" href="{{ .AppBasePath }}/assets/app.css">
     <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
     <script src="https://cdn.datatables.net/1.11.4/js/jquery.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/1.11.4/js/dataTables.semanticui.min.js"></script>
@@ -21,7 +21,7 @@
 <body>
 <div id="splash-screen">
     <!-- Clean squircle logo without background wrapper -->
-    <img src="assets/gowa.svg" alt="GoWA Logo" class="splash-icon" id="main-logo">
+    <img src="{{ .AppBasePath }}/assets/gowa.svg" alt="GoWA Logo" class="splash-icon" id="main-logo">
     
     <h2 class="splash-title">WhatsApp API</h2>
     <div class="ui active large inline loader splash-spinner"></div>
@@ -31,7 +31,7 @@
     <div class="main-header">
         <h1 class="ui header center aligned">
             <div class="title-container">
-                <img src="assets/gowa.svg" alt="GoWA Logo">
+                <img src="{{ .AppBasePath }}/assets/gowa.svg" alt="GoWA Logo">
                 
                 <span>WhatsApp API</span>
                 
@@ -174,56 +174,56 @@
 
 
     window.http = axios.create({
-        baseURL: `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}`
+        baseURL: `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}{{ .AppBasePath }}`
     });
     {{ if isEnableBasicAuth .BasicAuthToken }}
     window.http.defaults.headers.common['Authorization'] = "{{ .BasicAuthToken }}";
     {{ end }}
 </script>
 <script type="module">
-    import AppLogin from "./components/AppLogin.js";
-    import AppLoginWithCode from "./components/AppLoginWithCode.js";
-    import AppLogout from "./components/AppLogout.js";
-    import AppReconnect from "./components/AppReconnect.js";
-    import SendMessage from "./components/SendMessage.js";
-    import SendImage from "./components/SendImage.js";
-    import SendFile from "./components/SendFile.js";
-    import SendVideo from "./components/SendVideo.js";
-    import SendLink from "./components/SendLink.js";
-    import SendContact from "./components/SendContact.js";
-    import SendLocation from "./components/SendLocation.js";
-    import SendAudio from "./components/SendAudio.js";
-    import SendPoll from "./components/SendPoll.js";
-    import SendPresence from "./components/SendPresence.js";
-    import SendChatPresence from "./components/SendChatPresence.js";
-    import MessageDelete from "./components/MessageDelete.js";
-    import MessageUpdate from "./components/MessageUpdate.js";
-    import MessageReact from "./components/MessageReact.js";
-    import MessageRevoke from "./components/MessageRevoke.js";
-    import MessageRead from "./components/MessageRead.js";
-    import GroupList from "./components/GroupList.js";
-    import GroupCreate from "./components/GroupCreate.js";
-    import GroupJoinWithLink from "./components/GroupJoinWithLink.js";
-    import GroupInfoFromLink from "./components/GroupInfoFromLink.js";
-    import GroupAddParticipants from "./components/GroupManageParticipants.js";
-    import GroupSetPhoto from "./components/GroupSetPhoto.js";
-    import GroupSetName from "./components/GroupSetName.js";
-    import GroupSetLocked from "./components/GroupSetLocked.js";
-    import GroupSetAnnounce from "./components/GroupSetAnnounce.js";
-    import GroupSetTopic from "./components/GroupSetTopic.js";
-    import GroupInfo from "./components/GroupInfo.js";
-    import NewsletterList from "./components/NewsletterList.js";
-    import AccountAvatar from "./components/AccountAvatar.js";
-    import AccountChangeAvatar from "./components/AccountChangeAvatar.js";
-    import AccountChangePushName from "./components/AccountChangePushName.js";
-    import AccountUserInfo from "./components/AccountUserInfo.js";
-    import AccountPrivacy from "./components/AccountPrivacy.js";
-    import AccountContact from "./components/AccountContact.js";
-    import AccountUserCheck from "./components/AccountUserCheck.js";
-    import AccountBusinessProfile from "./components/AccountBusinessProfile.js";
-    import ChatPinManager from "./components/ChatPinManager.js";
-    import ChatList from "./components/ChatList.js";
-    import ChatMessages from "./components/ChatMessages.js";
+    import AppLogin from "{{ .AppBasePath }}/components/AppLogin.js";
+    import AppLoginWithCode from "{{ .AppBasePath }}/components/AppLoginWithCode.js";
+    import AppLogout from "{{ .AppBasePath }}/components/AppLogout.js";
+    import AppReconnect from "{{ .AppBasePath }}/components/AppReconnect.js";
+    import SendMessage from "{{ .AppBasePath }}/components/SendMessage.js";
+    import SendImage from "{{ .AppBasePath }}/components/SendImage.js";
+    import SendFile from "{{ .AppBasePath }}/components/SendFile.js";
+    import SendVideo from "{{ .AppBasePath }}/components/SendVideo.js";
+    import SendLink from "{{ .AppBasePath }}/components/SendLink.js";
+    import SendContact from "{{ .AppBasePath }}/components/SendContact.js";
+    import SendLocation from "{{ .AppBasePath }}/components/SendLocation.js";
+    import SendAudio from "{{ .AppBasePath }}/components/SendAudio.js";
+    import SendPoll from "{{ .AppBasePath }}/components/SendPoll.js";
+    import SendPresence from "{{ .AppBasePath }}/components/SendPresence.js";
+    import SendChatPresence from "{{ .AppBasePath }}/components/SendChatPresence.js";
+    import MessageDelete from "{{ .AppBasePath }}/components/MessageDelete.js";
+    import MessageUpdate from "{{ .AppBasePath }}/components/MessageUpdate.js";
+    import MessageReact from "{{ .AppBasePath }}/components/MessageReact.js";
+    import MessageRevoke from "{{ .AppBasePath }}/components/MessageRevoke.js";
+    import MessageRead from "{{ .AppBasePath }}/components/MessageRead.js";
+    import GroupList from "{{ .AppBasePath }}/components/GroupList.js";
+    import GroupCreate from "{{ .AppBasePath }}/components/GroupCreate.js";
+    import GroupJoinWithLink from "{{ .AppBasePath }}/components/GroupJoinWithLink.js";
+    import GroupInfoFromLink from "{{ .AppBasePath }}/components/GroupInfoFromLink.js";
+    import GroupAddParticipants from "{{ .AppBasePath }}/components/GroupManageParticipants.js";
+    import GroupSetPhoto from "{{ .AppBasePath }}/components/GroupSetPhoto.js";
+    import GroupSetName from "{{ .AppBasePath }}/components/GroupSetName.js";
+    import GroupSetLocked from "{{ .AppBasePath }}/components/GroupSetLocked.js";
+    import GroupSetAnnounce from "{{ .AppBasePath }}/components/GroupSetAnnounce.js";
+    import GroupSetTopic from "{{ .AppBasePath }}/components/GroupSetTopic.js";
+    import GroupInfo from "{{ .AppBasePath }}/components/GroupInfo.js";
+    import NewsletterList from "{{ .AppBasePath }}/components/NewsletterList.js";
+    import AccountAvatar from "{{ .AppBasePath }}/components/AccountAvatar.js";
+    import AccountChangeAvatar from "{{ .AppBasePath }}/components/AccountChangeAvatar.js";
+    import AccountChangePushName from "{{ .AppBasePath }}/components/AccountChangePushName.js";
+    import AccountUserInfo from "{{ .AppBasePath }}/components/AccountUserInfo.js";
+    import AccountPrivacy from "{{ .AppBasePath }}/components/AccountPrivacy.js";
+    import AccountContact from "{{ .AppBasePath }}/components/AccountContact.js";
+    import AccountUserCheck from "{{ .AppBasePath }}/components/AccountUserCheck.js";
+    import AccountBusinessProfile from "{{ .AppBasePath }}/components/AccountBusinessProfile.js";
+    import ChatPinManager from "{{ .AppBasePath }}/components/ChatPinManager.js";
+    import ChatList from "{{ .AppBasePath }}/components/ChatList.js";
+    import ChatMessages from "{{ .AppBasePath }}/components/ChatMessages.js";
 
     const showErrorInfo = (message) => {
         $('body').toast({
@@ -246,13 +246,9 @@
 
     const constructWebSocketURL = () => {
         const protocol = location.protocol === 'https:' ? 'wss://' : 'ws://';
-        const path = location.pathname
-            // Remove trailing slash
-            .replace(/\/+$/, '')
-            // Remove double slashes
-            .replace(/\/+/g, '/');
+        const basePath = '{{ .AppBasePath }}';
         
-        return `${protocol}${location.host}${path}/ws`;
+        return `${protocol}${location.host}${basePath}/ws`;
     };
 
     Vue.createApp({


### PR DESCRIPTION
## Summary

This PR implements support for subpath deployment (e.g., `/gowa`) to resolve issue #371. The application can now be deployed behind reverse proxies with path prefixes while maintaining full backward compatibility.

## 📝 Problem

Previously, the application assumed it was always served from the root path (`/`), causing issues when deployed behind reverse proxies like Traefik + NGINX with subpath routing. API requests and static assets would fail with 404 errors when the app wasn't hosted at the root.

**Example Issue:**
- Domain: `https://monitor.example.com/gowa/`
- API requests sent to `/app/login` instead of `/gowa/app/login`
- Static assets requested at `/assets/app.css` instead of `/gowa/assets/app.css`

## 🛠️ Solution

### Backend Changes

1. **Configuration Support**
   - Added `APP_BASE_PATH` environment variable to `.env.example`
   - Added `AppBasePath` configuration variable in `config/settings.go`
   - Added CLI flag `--base-path` support in `cmd/root.go`
   - Added environment variable loading for `app_base_path`

2. **Route Updates**
   - Modified `cmd/rest.go` to use base path grouping for all API routes
   - Updated static file serving paths (`/statics`, `/components`, `/assets`)
   - Fixed QR code link generation in `ui/rest/app.go` to include base path
   - Updated all REST route handlers to accept `fiber.Router` interface
   - Modified WebSocket routes to support base path

### Frontend Changes

3. **Asset Path Fixes**
   - Updated axios baseURL configuration to include base path from template
   - Fixed all CSS and SVG asset references to use `{{ .AppBasePath }}`
   - Updated all 43 JavaScript component imports to use base path
   - Fixed WebSocket URL construction to handle subpath deployment

## 🔧 Configuration

### Environment Variable
```bash
# For root deployment (default)
APP_BASE_PATH=

# For subpath deployment
APP_BASE_PATH=/gowa
```

### CLI Flag
```bash
# For subpath deployment
./whatsapp rest --base-path="/gowa"
```

## ✅ Testing

- ✅ Root deployment works (backward compatibility maintained)
- ✅ Subpath deployment works with `/gowa` prefix
- ✅ All static assets load correctly with base path
- ✅ API endpoints work with base path prefix
- ✅ WebSocket connections work with base path
- ✅ QR code links include correct base path

## 📋 Files Changed

**Backend:**
- `src/.env.example` - Added APP_BASE_PATH documentation
- `src/config/settings.go` - Added AppBasePath variable
- `src/cmd/root.go` - Added environment loading and CLI flag
- `src/cmd/rest.go` - Updated route grouping and static paths
- `src/ui/rest/*.go` - Updated function signatures to use fiber.Router
- `src/ui/websocket/websocket.go` - Updated to support base path

**Frontend:**
- `src/views/index.html` - Updated all asset paths and component imports

## 🎯 Impact

- ✅ **Backward Compatible**: Works at root path by default
- ✅ **Reverse Proxy Ready**: Supports any subpath deployment
- ✅ **Environment Flexible**: Configurable via env var or CLI flag
- ✅ **Production Ready**: Tested with real deployment scenario

## 🔗 Closes

Fixes #371