### PR TITLE
fix: make Env type-safe

### DIFF
--- a/src/pkg/utils/environment.go
+++ b/src/pkg/utils/environment.go
@@ -17,11 +17,19 @@ func IsLocal() bool {
 }
 
 func Env[T any](key string, defValue ...T) T {
-	env := viper.Get(key)
-	if env == nil && len(defValue) > 0 {
-		return defValue[0]
-	}
-	return env.(T)
+        if env := viper.Get(key); env != nil {
+                // Ensure type safety for retrieved environment variables
+                if value, ok := env.(T); ok {
+                        return value
+                }
+        }
+
+        if len(defValue) > 0 {
+                return defValue[0]
+        }
+
+        var zero T
+        return zero
 }
 
 // MustHaveEnv ensure the ENV is exists, otherwise will crashing the app

--- a/src/pkg/utils/environment_test.go
+++ b/src/pkg/utils/environment_test.go
@@ -77,6 +77,16 @@ func (suite *EnvironmentTestSuite) TestEnv() {
 	viper.Set("TEST_BOOL", true)
 	boolResult := utils.Env[bool]("TEST_BOOL")
 	assert.Equal(suite.T(), true, boolResult)
+
+	// Test missing key without default returns zero value
+	var zeroInt int
+	zeroVal := utils.Env[int]("MISSING_INT")
+	assert.Equal(suite.T(), zeroInt, zeroVal)
+
+	// Test type mismatch returns provided default value
+	viper.Set("STRING_VALUE", "abc")
+	defaultInt := utils.Env[int]("STRING_VALUE", 10)
+	assert.Equal(suite.T(), 10, defaultInt)
 }
 
 func (suite *EnvironmentTestSuite) TestMustHaveEnv() {


### PR DESCRIPTION
## Summary
- avoid panicking when environment variable is missing or wrong type
- add tests for zero value and type mismatch scenarios
- streamline Env default fallback handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68957d39c8b08328aff7c4bd6bda4da8