### PR TITLE
docs: fix join group typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -394,7 +394,7 @@ You can fork or edit this source code !
 | My Group             | ![My Group](./gallery/group-list.png)                         |
 | Group Info From Link | ![Group Info From Link](./gallery/group-info-from-link.png)   |
 | Create Group         | ![Create Group](./gallery/group-create.png)                   |
-| Join Group with LInk | ![Join Group with Link](./gallery/group-join-link.png)        |
+| Join Group with Link | ![Join Group with Link](./gallery/group-join-link.png)        |
 | Manage Participant   | ![Manage Participant](./gallery/group-manage-participant.png) |
 | My Newsletter        | ![My Newsletter](./gallery/newsletter-list.png)               |
 | My Contacts          | ![My Contacts](./gallery/contact-list.png)                    |


### PR DESCRIPTION
## Summary
- fix typo in gallery table entry

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68957e32e6508328a44ec61ca222fc5b