### PR TITLE
feat: add on-demand media download API and auto-download UI

### DIFF
--- a/src/domains/message/interfaces.go
+++ b/src/domains/message/interfaces.go
@@ -16,6 +16,7 @@ type IMessageActions interface {
 type IMessageManagement interface {
 	DeleteMessage(ctx context.Context, request DeleteRequest) (err error)
 	StarMessage(ctx context.Context, request StarRequest) (err error)
+	DownloadMedia(ctx context.Context, request DownloadMediaRequest) (response DownloadMediaResponse, err error)
 }
 
 // IMessageUsecase combines all message interfaces

--- a/src/domains/message/message.go
+++ b/src/domains/message/message.go
@@ -37,3 +37,17 @@ type StarRequest struct {
 	Phone     string `json:"phone" form:"phone"`
 	IsStarred bool   `json:"is_starred"`
 }
+
+type DownloadMediaRequest struct {
+	MessageID string `json:"message_id" uri:"message_id"`
+	Phone     string `json:"phone" form:"phone"`
+}
+
+type DownloadMediaResponse struct {
+	MessageID string `json:"message_id"`
+	Status    string `json:"status"`
+	MediaType string `json:"media_type"`
+	Filename  string `json:"filename"`
+	FilePath  string `json:"file_path"`
+	FileSize  int64  `json:"file_size"`
+}

--- a/src/pkg/utils/environment.go
+++ b/src/pkg/utils/environment.go
@@ -17,19 +17,19 @@ func IsLocal() bool {
 }
 
 func Env[T any](key string, defValue ...T) T {
-        if env := viper.Get(key); env != nil {
-                // Ensure type safety for retrieved environment variables
-                if value, ok := env.(T); ok {
-                        return value
-                }
-        }
+	if env := viper.Get(key); env != nil {
+		// Ensure type safety for retrieved environment variables
+		if value, ok := env.(T); ok {
+			return value
+		}
+	}
 
-        if len(defValue) > 0 {
-                return defValue[0]
-        }
+	if len(defValue) > 0 {
+		return defValue[0]
+	}
 
-        var zero T
-        return zero
+	var zero T
+	return zero
 }
 
 // MustHaveEnv ensure the ENV is exists, otherwise will crashing the app

--- a/src/ui/rest/message.go
+++ b/src/ui/rest/message.go
@@ -21,6 +21,7 @@ func InitRestMessage(app fiber.Router, service domainMessage.IMessageUsecase) Me
 	app.Post("/message/:message_id/read", rest.MarkAsRead)
 	app.Post("/message/:message_id/star", rest.StarMessage)
 	app.Post("/message/:message_id/unstar", rest.UnstarMessage)
+	app.Get("/message/:message_id/download", rest.DownloadMedia)
 	return rest
 }
 
@@ -155,5 +156,23 @@ func (controller *Message) UnstarMessage(c *fiber.Ctx) error {
 		Code:    "SUCCESS",
 		Message: "Unstarred message successfully",
 		Results: nil,
+	})
+}
+
+func (controller *Message) DownloadMedia(c *fiber.Ctx) error {
+	var request domainMessage.DownloadMediaRequest
+
+	request.MessageID = c.Params("message_id")
+	request.Phone = c.Query("phone")
+	utils.SanitizePhone(&request.Phone)
+
+	response, err := controller.Service.DownloadMedia(c.UserContext(), request)
+	utils.PanicIfNeeded(err)
+
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: response.Status,
+		Results: response,
 	})
 }

--- a/src/validations/message_validation.go
+++ b/src/validations/message_validation.go
@@ -89,3 +89,16 @@ func ValidateStarMessage(ctx context.Context, request domainMessage.StarRequest)
 
 	return nil
 }
+
+func ValidateDownloadMedia(ctx context.Context, request domainMessage.DownloadMediaRequest) error {
+	err := validation.ValidateStructWithContext(ctx, &request,
+		validation.Field(&request.Phone, validation.Required),
+		validation.Field(&request.MessageID, validation.Required),
+	)
+
+	if err != nil {
+		return pkgError.ValidationError(err.Error())
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Download Media & Update UI List Chat

## Context
- Add DownloadMedia API endpoint (GET /message/:id/download)
- Implement media download with organized storage by chat/date
- Support all media types: image, video, audio, document, sticker
- Add auto-download functionality to ChatMessages UI component
- Display actual media content instead of "Media Available" labels
- Include loading states, error handling, and retry functionality
- Implement concurrency control for batch downloads (max 3 concurrent)

## Test Results
<img width="927" height="780" alt="image" src="https://github.com/user-attachments/assets/70e1b154-cf30-45a6-8a6e-3fcd8f888dbb" />

<img width="1250" height="775" alt="image" src="https://github.com/user-attachments/assets/337c94f8-ba47-4254-80c9-6cf89eb50c68" />

## Issue Link
https://github.com/aldinokemal/go-whatsapp-web-multidevice/issues/396

