### PR TITLE
Fix whatsapp web multidevice issue

### DIFF
--- a/src/views/components/ChatList.js
+++ b/src/views/components/ChatList.js
@@ -26,11 +26,7 @@ export default {
     },
     methods: {
         openModal() {
-            $('#modalChatList').modal({
-                onApprove: function () {
-                    return false;
-                }
-            }).modal('show');
+            $('#modalChatList').modal('show');
             this.loadChats();
         },
         async loadChats() {


### PR DESCRIPTION
## PR Title
Fix: Chat List modal close button not working (#418)

## Context
- Resolves issue #418 by enabling the "Close" button on the Chat List modal. The `onApprove: () => false` callback was removed, which previously prevented the modal from closing.

## Test Results
- Opened the Chat List modal and confirmed the "Close" button now successfully closes the modal.
- Verified that clicking "View Messages" on a chat still correctly closes the Chat List and opens the Chat Messages view.
- Confirmed the "X" close icon functionality remains unchanged.
- No regressions or broken changes were observed in other modal interactions.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1249a96-8c43-430d-8a9f-a6b047ed342a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1249a96-8c43-430d-8a9f-a6b047ed342a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

