### PR TITLE
fix: harden webhook forwarding against partial failures

### DIFF
--- a/src/infrastructure/whatsapp/event_delete.go
+++ b/src/infrastructure/whatsapp/event_delete.go
@@ -4,28 +4,18 @@ import (
 	"context"
 	"time"
 
-	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
-	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow/types/events"
 )
 
 // forwardDeleteToWebhook sends a delete event to webhook
 func forwardDeleteToWebhook(ctx context.Context, evt *events.DeleteForMe, message *domainChatStorage.Message) error {
-	logrus.Infof("Forwarding delete event to %d configured webhook(s)", len(config.WhatsappWebhook))
 	payload, err := createDeletePayload(ctx, evt, message)
 	if err != nil {
 		return err
 	}
 
-	for _, url := range config.WhatsappWebhook {
-		if err = submitWebhook(ctx, payload, url); err != nil {
-			return err
-		}
-	}
-
-	logrus.Info("Delete event forwarded to webhook")
-	return nil
+	return forwardPayloadToConfiguredWebhooks(ctx, payload, "delete event")
 }
 
 // createDeletePayload creates a webhook payload for delete events

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -18,20 +18,12 @@ import (
 
 // forwardMessageToWebhook is a helper function to forward message event to webhook url
 func forwardMessageToWebhook(ctx context.Context, evt *events.Message) error {
-	logrus.Infof("Forwarding message event to %d configured webhook(s)", len(config.WhatsappWebhook))
 	payload, err := createMessagePayload(ctx, evt)
 	if err != nil {
 		return err
 	}
 
-	for _, url := range config.WhatsappWebhook {
-		if err = submitWebhook(ctx, payload, url); err != nil {
-			return err
-		}
-	}
-
-	logrus.Info("Message event forwarded to webhook")
-	return nil
+	return forwardPayloadToConfiguredWebhooks(ctx, payload, "message event")
 }
 
 func createMessagePayload(ctx context.Context, evt *events.Message) (map[string]any, error) {

--- a/src/infrastructure/whatsapp/event_receipt.go
+++ b/src/infrastructure/whatsapp/event_receipt.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
-	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 )
@@ -70,15 +68,6 @@ func createReceiptPayload(evt *events.Receipt) map[string]any {
 
 // forwardReceiptToWebhook forwards message acknowledgement events to the configured webhook URLs
 func forwardReceiptToWebhook(ctx context.Context, evt *events.Receipt) error {
-	logrus.Infof("Forwarding message ack event to %d configured webhook(s)", len(config.WhatsappWebhook))
 	payload := createReceiptPayload(evt)
-
-	for _, url := range config.WhatsappWebhook {
-		if err := submitWebhook(ctx, payload, url); err != nil {
-			return err
-		}
-	}
-
-	logrus.Info("Message ack event forwarded to webhook")
-	return nil
+	return forwardPayloadToConfiguredWebhooks(ctx, payload, "message ack event")
 }

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -1,0 +1,51 @@
+package whatsapp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
+	"github.com/sirupsen/logrus"
+)
+
+var submitWebhookFn = submitWebhook
+
+// forwardPayloadToConfiguredWebhooks attempts to deliver the provided payload to every configured webhook URL.
+// It only returns an error when all webhook deliveries fail. Partial failures are logged and suppressed so
+// successful targets still receive the event.
+func forwardPayloadToConfiguredWebhooks(ctx context.Context, payload map[string]any, eventName string) error {
+	total := len(config.WhatsappWebhook)
+	logrus.Infof("Forwarding %s to %d configured webhook(s)", eventName, total)
+
+	if total == 0 {
+		logrus.Infof("No webhook configured for %s; skipping dispatch", eventName)
+		return nil
+	}
+
+	var (
+		failed    []string
+		successes int
+	)
+	for _, url := range config.WhatsappWebhook {
+		if err := submitWebhookFn(ctx, payload, url); err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %v", url, err))
+			logrus.Warnf("Failed forwarding %s to %s: %v", eventName, url, err)
+			continue
+		}
+		successes++
+	}
+
+	if len(failed) == total {
+		return pkgError.WebhookError(fmt.Sprintf("all webhook URLs failed for %s: %s", eventName, strings.Join(failed, "; ")))
+	}
+
+	if len(failed) > 0 {
+		logrus.Warnf("Some webhook URLs failed for %s (succeeded: %d/%d): %s", eventName, successes, total, strings.Join(failed, "; "))
+	} else {
+		logrus.Infof("%s forwarded to all webhook(s)", eventName)
+	}
+
+	return nil
+}

--- a/src/infrastructure/whatsapp/webhook_forward_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_test.go
@@ -1,0 +1,77 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+)
+
+func TestForwardPayloadToConfiguredWebhooks_NoWebhooksConfigured(t *testing.T) {
+	ctx := context.Background()
+	payload := map[string]any{"foo": "bar"}
+
+	originalWebhooks := config.WhatsappWebhook
+	config.WhatsappWebhook = nil
+	defer func() { config.WhatsappWebhook = originalWebhooks }()
+
+	originalSubmit := submitWebhookFn
+	submitWebhookFn = func(context.Context, map[string]any, string) error {
+		t.Fatal("submitWebhookFn should not be invoked when no webhooks are configured")
+		return nil
+	}
+	defer func() { submitWebhookFn = originalSubmit }()
+
+	if err := forwardPayloadToConfiguredWebhooks(ctx, payload, "test"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestForwardPayloadToConfiguredWebhooks_PartialFailure(t *testing.T) {
+	ctx := context.Background()
+	payload := map[string]any{"foo": "bar"}
+
+	originalWebhooks := config.WhatsappWebhook
+	config.WhatsappWebhook = []string{"https://success", "https://fail", "https://success2"}
+	defer func() { config.WhatsappWebhook = originalWebhooks }()
+
+	originalSubmit := submitWebhookFn
+	var attempts []string
+	submitWebhookFn = func(_ context.Context, _ map[string]any, url string) error {
+		attempts = append(attempts, url)
+		if strings.Contains(url, "fail") {
+			return errors.New("boom")
+		}
+		return nil
+	}
+	defer func() { submitWebhookFn = originalSubmit }()
+
+	if err := forwardPayloadToConfiguredWebhooks(ctx, payload, "test"); err != nil {
+		t.Fatalf("expected partial failure to return nil, got %v", err)
+	}
+
+	if len(attempts) != 3 {
+		t.Fatalf("expected 3 attempts, got %d", len(attempts))
+	}
+}
+
+func TestForwardPayloadToConfiguredWebhooks_AllFail(t *testing.T) {
+	ctx := context.Background()
+	payload := map[string]any{"foo": "bar"}
+
+	originalWebhooks := config.WhatsappWebhook
+	config.WhatsappWebhook = []string{"https://fail1", "https://fail2"}
+	defer func() { config.WhatsappWebhook = originalWebhooks }()
+
+	originalSubmit := submitWebhookFn
+	submitWebhookFn = func(_ context.Context, _ map[string]any, url string) error {
+		return errors.New("failure for " + url)
+	}
+	defer func() { submitWebhookFn = originalSubmit }()
+
+	if err := forwardPayloadToConfiguredWebhooks(ctx, payload, "test"); err == nil {
+		t.Fatalf("expected error when all webhooks fail")
+	}
+}


### PR DESCRIPTION
## Summary
- allow the webhook forwarder to use an overridable submitter so behavior can be exercised in tests
- add unit tests covering empty, partial failure, and all-failure webhook dispatch scenarios
- tidy the delete event helper imports after switching to the shared forwarder

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ea4a6cc98c8328841ea3d8434d0ff0