### PR TITLE
feat: add original message ID and timestamp to message edit events

### DIFF
--- a/docs/webhook-payload.md
+++ b/docs/webhook-payload.md
@@ -511,6 +511,10 @@ Triggered when users are demoted from admin.
   "action": "message_edited",
   "chat_id": "6289XXXXXXXXX",
   "edited_text": "hhhiawww",
+  "original_message_id": "D6271D8223A05B4DA6AE9FE3CD632543",
+  "original_from_me": false,
+  "original_chat": "6289XXXXXXXXX@s.whatsapp.net",
+  "edit_timestamp": "2025-07-13T11:14:19Z",
   "from": "6289XXXXXXXXX@s.whatsapp.net",
   "message": {
     "text": "hhhiawww",
@@ -523,6 +527,12 @@ Triggered when users are demoted from admin.
   "timestamp": "2025-07-13T11:14:19Z"
 }
 ```
+
+**New Fields Explained:**
+- `original_message_id`: The ID of the message that was edited (use this to track which message was modified)
+- `original_from_me`: Boolean indicating if the original message was sent by you
+- `original_chat`: The chat JID where the original message was sent
+- `edit_timestamp`: When the edit occurred (may differ from the original timestamp)
 
 ## Special Flags
 

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -119,6 +119,19 @@ func createMessagePayload(ctx context.Context, evt *events.Message) (map[string]
 			}
 		case "MESSAGE_EDIT":
 			body["action"] = "message_edited"
+			// Extract original message ID that was edited
+			if key := protocolMessage.GetKey(); key != nil {
+				body["original_message_id"] = key.GetID()
+				body["original_from_me"] = key.GetFromMe()
+				if key.GetRemoteJID() != "" {
+					body["original_chat"] = key.GetRemoteJID()
+				}
+			}
+			// Extract edit timestamp
+			if timestamp := protocolMessage.GetTimestampMS(); timestamp > 0 {
+				body["edit_timestamp"] = time.UnixMilli(timestamp).Format(time.RFC3339)
+			}
+			// Extract new edited content
 			if editedMessage := protocolMessage.GetEditedMessage(); editedMessage != nil {
 				if editedText := editedMessage.GetExtendedTextMessage(); editedText != nil {
 					body["edited_text"] = editedText.GetText()


### PR DESCRIPTION
Previously, when a message was edited, the webhook payload only included the new edited text but not the original message ID. This made it impossible to track which message was modified, as the payload contained a new event ID instead of referencing the original message.

This change extracts the original message metadata from the protocol message using GetKey(), similar to how message revokes are handled.

Changes:
- Add original_message_id field to track which message was edited
- Add original_from_me to indicate message ownership
- Add original_chat to include the chat JID
- Add edit_timestamp to capture when the edit occurred
- Update webhook payload documentation with new fields

The webhook payload now properly links edit events to their original messages, enabling applications to maintain accurate message history and display edits correctly.


# PR Title

## Context

- Explain briefly the changes about

## Test Results
<!--
- Attach the screenshot of the result or something
-->
- what you have done to test it
