### PR TITLE
Fix: assign the client returned by InitWaCLI to whatsappCli. (#467)

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -256,7 +256,7 @@ func initApp() {
 		keysDB = whatsapp.InitWaDB(ctx, config.DBKeysURI)
 	}
 
-	whatsapp.InitWaCLI(ctx, whatsappDB, keysDB, chatStorageRepo)
+	whatsappCli = whatsapp.InitWaCLI(ctx, whatsappDB, keysDB, chatStorageRepo)
 
 	// Usecase
 	appUsecase = usecase.NewAppService(chatStorageRepo)


### PR DESCRIPTION
# Fix: assign the client returned by InitWaCLI to whatsappCli. (#467)
## Context

- Every 5 minutes it checks if the client is connected; if not, it tries to reconnect... but the pointer it was receiving was nil because the global variable had been declared but not initialized, thus causing a panic.
