### PR TITLE
Fix webhook event filtering and refactor webhook broadcasting

### DIFF
--- a/src/infrastructure/whatsapp/event_delete.go
+++ b/src/infrastructure/whatsapp/event_delete.go
@@ -16,7 +16,7 @@ func forwardDeleteToWebhook(ctx context.Context, evt *events.DeleteForMe, messag
 		return err
 	}
 
-	return forwardPayloadToConfiguredWebhooks(ctx, payload, "delete event")
+	return BroadcastWebhookEvent(ctx, "message.delete", payload)
 }
 
 // createDeletePayload creates a webhook payload for delete events

--- a/src/infrastructure/whatsapp/event_group.go
+++ b/src/infrastructure/whatsapp/event_group.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
-	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
@@ -57,8 +55,6 @@ func jidsToStrings(ctx context.Context, jids []types.JID, client *whatsmeow.Clie
 
 // forwardGroupInfoToWebhook forwards group information events to the configured webhook URLs
 func forwardGroupInfoToWebhook(ctx context.Context, evt *events.GroupInfo, deviceID string, client *whatsmeow.Client) error {
-	logrus.Infof("Forwarding group info event to %d configured webhook(s)", len(config.WhatsappWebhook))
-
 	// Send separate webhook events for each action type
 	actions := []struct {
 		actionType string
@@ -70,34 +66,19 @@ func forwardGroupInfoToWebhook(ctx context.Context, evt *events.GroupInfo, devic
 		{"demote", evt.Demote},
 	}
 
+	var errors []string
+
 	for _, action := range actions {
 		if len(action.jids) > 0 {
 			payload := createGroupInfoPayload(ctx, evt, action.actionType, action.jids, deviceID, client)
-
-			// Collect errors from all webhook URLs instead of failing fast
-			var errors []error
-			for _, url := range config.WhatsappWebhook {
-				if err := submitWebhook(ctx, payload, url); err != nil {
-					errors = append(errors, fmt.Errorf("webhook %s failed: %w", url, err))
-				}
+			if err := BroadcastWebhookEvent(ctx, "group.participants", payload); err != nil {
+				errors = append(errors, fmt.Sprintf("failed to forward %s: %v", action.actionType, err))
 			}
-
-			// If all webhooks failed, return combined error
-			if len(errors) == len(config.WhatsappWebhook) && len(errors) > 0 {
-				var errMessages []string
-				for _, err := range errors {
-					errMessages = append(errMessages, err.Error())
-				}
-				return fmt.Errorf("all webhook URLs failed: %s", strings.Join(errMessages, "; "))
-			}
-
-			// Log partial failures
-			if len(errors) > 0 {
-				logrus.Warnf("Some webhook URLs failed for group %s event: %v", action.actionType, errors)
-			}
-
-			logrus.Infof("Group %s event forwarded to webhook: %d users %s", action.actionType, len(action.jids), action.actionType)
 		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("some group events failed to forward: %s", strings.Join(errors, "; "))
 	}
 
 	return nil

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -45,7 +45,7 @@ func forwardMessageToWebhook(ctx context.Context, client *whatsmeow.Client, evt 
 		"payload":   webhookEvent.Payload,
 	}
 
-	return forwardPayloadToConfiguredWebhooks(ctx, payload, "message event")
+	return BroadcastWebhookEvent(ctx, webhookEvent.Event, payload)
 }
 
 func createWebhookEvent(ctx context.Context, client *whatsmeow.Client, evt *events.Message) (*WebhookEvent, error) {

--- a/src/infrastructure/whatsapp/event_receipt.go
+++ b/src/infrastructure/whatsapp/event_receipt.go
@@ -95,5 +95,5 @@ func forwardReceiptToWebhook(ctx context.Context, evt *events.Receipt, deviceID 
 	}
 
 	payload := createReceiptPayload(ctx, evt, deviceID, client)
-	return forwardPayloadToConfiguredWebhooks(ctx, payload, "message ack event")
+	return BroadcastWebhookEvent(ctx, "message.ack", payload)
 }


### PR DESCRIPTION

This PR fixes a critical bug where the `WHATSAPP_WEBHOOK_EVENTS` configuration was not working correctly. The application was failing to filter events properly because the internal event names passed to the whitelist checker did not match the expected configuration keys (e.g., passing "message event" instead of "message"). Consequently, valid events were being filtered out when a whitelist was active.

**Key Changes:**
- **Fix Event Naming**: Updated all event handlers (`message`, `receipt`, `delete`) to use standard event keys (e.g., `message`, `message.ack`, `message.delete`) that match the configuration expectations.
- **Fix Group Event Filtering**: Updated the group participant event handler to respect the `WHATSAPP_WEBHOOK_EVENTS` whitelist (previously it bypassed the check entirely).
- **Refactor Webhook Broadcasting**:
  - Centralized webhook logic into a clean `BroadcastWebhookEvent` helper in `src/infrastructure/whatsapp/webhook_forward.go`.
  - Decomposed complex logic into smaller, testable functions (`shouldForwardEvent`, `dispatchToWebhooks`, `handleBroadcastResults`).