### PR TITLE
fix(device.go): Fix DeviceMiddleware to allow if APP_BASE_PATH is change

### DIFF
--- a/src/ui/rest/middleware/device.go
+++ b/src/ui/rest/middleware/device.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/gofiber/fiber/v2"
@@ -16,7 +17,8 @@ const DeviceIDHeader = "X-Device-Id"
 func DeviceMiddleware(dm *whatsapp.DeviceManager) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		// Allow non-device-scoped public endpoints (e.g., landing page) to pass through.
-		if path := strings.TrimSpace(c.Path()); path == "/" || path == "" {
+		path := strings.TrimSpace(c.Path())
+		if path == "/" || path == "" || path == config.AppBasePath || path == config.AppBasePath+"/" {
 			return c.Next()
 		}
 


### PR DESCRIPTION
## Context

- Currently, if we set `APP_BASE_PATH`, it will be blocked by `DeviceMiddleware`. This PR is to fix this issue

## Test Results
In .env `APP_BASE_PATH=/wa-messages`

Before
<img width="854" height="117" alt="Screenshot 2026-01-05 at 09 46 54" src="https://github.com/user-attachments/assets/0bbdf61e-0e3a-4c8a-b325-a1d1431233a1" />

After
<img width="1165" height="235" alt="Screenshot 2026-01-05 at 09 49 14" src="https://github.com/user-attachments/assets/18217b74-1ff3-4b8e-894c-304ba55e515a" />
