### PR TITLE
fix(device): prevent orphan matching for manually created devices

### DIFF
--- a/src/infrastructure/whatsapp/device_manager.go
+++ b/src/infrastructure/whatsapp/device_manager.go
@@ -299,7 +299,10 @@ func (m *DeviceManager) LoadExistingDevices(ctx context.Context) error {
 				matchedDevice = inst
 				break
 			}
-			if inst.JID() == "" && orphanDevice == nil {
+			// Only consider auto-created devices (device_id contains @) as orphan candidates.
+			// Manual devices (UUID format, no @) should not be matched as orphans
+			// because they were explicitly created via API and are waiting for their own login.
+			if inst.JID() == "" && orphanDevice == nil && strings.Contains(inst.ID(), "@") {
 				orphanDevice = inst
 			}
 		}


### PR DESCRIPTION
## Summary

- Fixes #527 - Creating New Device Returning Same Device ID
- The orphan device matching logic in `LoadExistingDevices` incorrectly matched newly created devices (via `POST /devices` with UUID format) to JIDs from the WhatsMeow store
- Added a check to only consider auto-created devices (device_id contains `@`) as orphan candidates

## Root Cause

When a user creates Device B via `POST /devices`, it gets a UUID but no JID. On restart, `LoadExistingDevices` runs and the orphan matching logic finds Device B (empty JID) and incorrectly assigns Device A's JID to it.

## Solution

Only consider devices with `@` in their device_id as orphan candidates. Manual devices (UUID format, no `@`) are excluded since they were explicitly created via API and are waiting for their own login.

```go
// Only consider auto-created devices (device_id contains @) as orphan candidates.
if inst.JID() == "" && orphanDevice == nil && strings.Contains(inst.ID(), "@") {
    orphanDevice = inst
}
```

## Test plan

- [x] All existing tests pass
- [x] Build successful
- [ ] Manual test: Create Device A, login, create Device B, restart server - Device B should retain empty JID