### PR TITLE
feat: basic auth from db & hot reload

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,21 @@
+services:
+  whatsapp_go:
+    build:
+      context: .
+      dockerfile: ./docker/golang.dev.Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./src:/app/src
+      - go_cache:/root/go
+    env_file:
+      - src/.env
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
+
+volumes:
+  go_cache:

--- a/docker/golang.dev.Dockerfile
+++ b/docker/golang.dev.Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.25-alpine3.23
+RUN apk update && apk add --no-cache gcc musl-dev gcompat ffmpeg libwebp-tools tzdata
+ENV TZ=UTC
+ENV CGO_ENABLED=1
+WORKDIR /app
+RUN go install github.com/air-verse/air@latest
+WORKDIR /app/src
+CMD ["air", "-c", ".air.toml"]

--- a/src/.air.toml
+++ b/src/.air.toml
@@ -2,4 +2,23 @@ root = '.'
 tmp_dir = "tmp"
 
 [build]
-exclude_dir = ["statics", "storages"]
+cmd = "go build -o ./tmp/main ."
+bin = "./tmp/main"
+full_bin = "./tmp/main rest"
+include_ext = ["go", "tpl", "tmpl", "html"]
+exclude_dir = ["tmp", "statics", "storages", "vendor"]
+delay = 1000
+kill_delay = "0.5s"
+rerun = false
+
+[log]
+time = true
+
+[color]
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+clean_on_exit = true

--- a/src/.env.example
+++ b/src/.env.example
@@ -4,6 +4,7 @@ APP_HOST=0.0.0.0
 APP_DEBUG=false
 APP_OS=Chrome
 APP_BASIC_AUTH=user1:pass1,user2:pass2
+APP_BASIC_AUTH_DB_URI=postgres://user:password@host.docker.internal:5432/dbname
 APP_BASE_PATH=
 APP_TRUSTED_PROXIES=0.0.0.0/0
 

--- a/src/config/settings.go
+++ b/src/config/settings.go
@@ -13,6 +13,7 @@ var (
 	AppPlatform            = waCompanionReg.DeviceProps_PlatformType(1)
 	AppBasicAuthCredential []string
 	AppBasePath            = ""
+	AppBasicAuthDBURI      = ""
 	AppTrustedProxies      []string // Trusted proxy IP ranges (e.g., "0.0.0.0/0" for all, or specific CIDRs)
 
 	McpPort = "8080"


### PR DESCRIPTION
This pull request introduces support for dynamically loading basic authentication credentials from a Postgres database, along with improvements to the development environment using Docker and Air. The main changes include new configuration options, logic for loading credentials from the database, and updates to development tooling.

**Dynamic Basic Auth Credentials:**

* Added support for specifying a Postgres DB URI (`APP_BASIC_AUTH_DB_URI`) to fetch basic auth accounts dynamically, including a new environment variable, config field, flag, and logic to connect, query, and populate credentials from the `res_users` table. Handles SSL fallback if needed. [[1]](diffhunk://#diff-37d244a68001b3a8ce7d98f05894470bb8e6fb387402adc29351d41570e3e1e6R7) [[2]](diffhunk://#diff-4bbb6a3320f9473c5728698a2340462822b843a30624e875bf90e72324a8434eR16) [[3]](diffhunk://#diff-27b7e7ca994735ab05cd957631bb724f0145e54090994a56f13b47f6d07b7b30R100-R102) [[4]](diffhunk://#diff-27b7e7ca994735ab05cd957631bb724f0145e54090994a56f13b47f6d07b7b30R215-R220) [[5]](diffhunk://#diff-27b7e7ca994735ab05cd957631bb724f0145e54090994a56f13b47f6d07b7b30R398-R447)

**Development Environment Improvements:**

* Added `docker-compose.dev.yml` and a new `docker/golang.dev.Dockerfile` to streamline local development with Go, including hot reload support via Air and persistent Go cache. [[1]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1R1-R21) [[2]](diffhunk://#diff-90c1e2bfbd226bd35cada742f9976196b1d0abfbc87d330e25622bba852b4492R1-R8)
* Updated `.air.toml` configuration for improved build and reload behavior, including new build commands, colorized logs, and cleaner temp directory handling.# PR Title

