### PR TITLE
fix: allow empty emoji in reaction request for unreacting

### DIFF
--- a/src/validations/message_validation.go
+++ b/src/validations/message_validation.go
@@ -53,7 +53,7 @@ func ValidateReactMessage(ctx context.Context, request domainMessage.ReactionReq
 	err := validation.ValidateStructWithContext(ctx, &request,
 		validation.Field(&request.Phone, validation.Required),
 		validation.Field(&request.MessageID, validation.Required),
-		validation.Field(&request.Emoji, validation.Required),
+		validation.Field(&request.Emoji),
 	)
 
 	if err != nil {

--- a/src/validations/message_validation_test.go
+++ b/src/validations/message_validation_test.go
@@ -122,13 +122,13 @@ func TestValidateReactMessage(t *testing.T) {
 			err: pkgError.ValidationError("message_id: cannot be blank."),
 		},
 		{
-			name: "should error with empty emoji",
+			name: "should success with empty emoji (unreact)",
 			args: args{request: domainMessage.ReactionRequest{
 				Phone:     "6281234567890@s.whatsapp.net",
 				MessageID: "3EB0789ABC123456",
 				Emoji:     "",
 			}},
-			err: pkgError.ValidationError("emoji: cannot be blank."),
+			err: nil,
 		},
 		{
 			name: "should error with all empty fields",
@@ -137,7 +137,7 @@ func TestValidateReactMessage(t *testing.T) {
 				MessageID: "",
 				Emoji:     "",
 			}},
-			err: pkgError.ValidationError("emoji: cannot be blank; message_id: cannot be blank; phone: cannot be blank."),
+			err: pkgError.ValidationError("message_id: cannot be blank; phone: cannot be blank."),
 		},
 	}
 
@@ -150,7 +150,6 @@ func TestValidateReactMessage(t *testing.T) {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "phone: cannot be blank")
 				assert.Contains(t, err.Error(), "message_id: cannot be blank")
-				assert.Contains(t, err.Error(), "emoji: cannot be blank")
 			} else {
 				assert.Equal(t, tt.err, err)
 			}


### PR DESCRIPTION
## Summary

WhatsApp protocol removes a reaction by sending a `ReactionMessage` with empty `Text` (see whatsmeow's `RemoveReactionText = ""`). The validation on the `/message/{id}/reaction` endpoint currently rejects empty emoji via `validation.Required`, making it impossible to remove reactions via the API.

This PR removes `validation.Required` from the `Emoji` field in `ValidateReactMessage` so that an empty string passes validation and reaches the WhatsApp proto layer correctly.

## Changes

- `src/validations/message_validation.go`: Remove `validation.Required` from `Emoji` field
- `src/validations/message_validation_test.go`: Update tests — empty emoji now succeeds (unreact), adjust "all empty fields" expected error

## Tests

All 7 tests pass (`go test ./validations/ -run TestValidateReactMessage -v`):

- `should_success_with_valid_phone,_message_id_and_emoji` — PASS
- `should_success_with_heart_emoji` — PASS
- `should_success_with_simple_emoji` — PASS
- `should_error_with_empty_phone` — PASS
- `should_error_with_empty_message_id` — PASS
- `should_success_with_empty_emoji_(unreact)` — PASS (new)
- `should_error_with_all_empty_fields` — PASS (updated)

## How to test

1. Send a reaction: `POST /message/{id}/reaction` with `{"phone": "...", "emoji": "👍"}` — works as before
2. Remove a reaction: `POST /message/{id}/reaction` with `{"phone": "...", "emoji": ""}` — now removes the reaction instead of returning 400