### PR TITLE
fix(chatwoot): forward WhatsApp reactions to Chatwoot

### DIFF
--- a/src/infrastructure/whatsapp/chatwoot_forward_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_forward_test.go
@@ -1,6 +1,10 @@
 package whatsapp
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+)
 
 func TestChatwootMessageTypeFromPayload(t *testing.T) {
 	tests := []struct {
@@ -63,6 +67,39 @@ func TestShouldForwardEventToChatwoot(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsEventWhitelistedForChatwoot(t *testing.T) {
+	originalEvents := config.WhatsappWebhookEvents
+	defer func() { config.WhatsappWebhookEvents = originalEvents }()
+
+	t.Run("empty whitelist allows all", func(t *testing.T) {
+		config.WhatsappWebhookEvents = nil
+		if !isEventWhitelistedForChatwoot("message.reaction") {
+			t.Fatal("expected message.reaction to be allowed when whitelist is empty")
+		}
+	})
+
+	t.Run("explicit reaction whitelist allowed", func(t *testing.T) {
+		config.WhatsappWebhookEvents = []string{"message.reaction"}
+		if !isEventWhitelistedForChatwoot("message.reaction") {
+			t.Fatal("expected message.reaction to be allowed when explicitly whitelisted")
+		}
+	})
+
+	t.Run("message whitelist also allows reactions for chatwoot", func(t *testing.T) {
+		config.WhatsappWebhookEvents = []string{"message"}
+		if !isEventWhitelistedForChatwoot("message.reaction") {
+			t.Fatal("expected message.reaction to be allowed for Chatwoot when message is whitelisted")
+		}
+	})
+
+	t.Run("unrelated whitelist blocks reaction", func(t *testing.T) {
+		config.WhatsappWebhookEvents = []string{"message.ack"}
+		if isEventWhitelistedForChatwoot("message.reaction") {
+			t.Fatal("expected message.reaction to be blocked for Chatwoot when not covered by whitelist")
+		}
+	})
 }
 
 func TestBuildReactionChatwootContent(t *testing.T) {

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -72,17 +72,22 @@ func getContactMutex(phone string) *sync.Mutex {
 // It only returns an error when all webhook deliveries fail. Partial failures are logged and suppressed so
 // successful targets still receive the event.
 func forwardPayloadToConfiguredWebhooks(ctx context.Context, payload map[string]any, eventName string) error {
-	// Check if event is whitelisted (if whitelist is configured)
-	if len(config.WhatsappWebhookEvents) > 0 {
-		if !isEventWhitelisted(eventName) {
-			logrus.Debugf("Skipping event %s - not in webhook events whitelist", eventName)
-			return nil
-		}
+	webhookAllowed := len(config.WhatsappWebhookEvents) == 0 || isEventWhitelisted(eventName)
+	chatwootAllowed := config.ChatwootEnabled && shouldForwardEventToChatwoot(eventName) && isEventWhitelistedForChatwoot(eventName)
+
+	if !webhookAllowed && !chatwootAllowed {
+		logrus.Debugf("Skipping event %s - not allowed for webhooks or Chatwoot", eventName)
+		return nil
 	}
 
-	err := forwardToWebhooks(ctx, payload, eventName)
+	var err error
+	if webhookAllowed {
+		err = forwardToWebhooks(ctx, payload, eventName)
+	} else {
+		logrus.Debugf("Skipping event %s for configured webhooks, but allowing Chatwoot", eventName)
+	}
 
-	if shouldForwardEventToChatwoot(eventName) && config.ChatwootEnabled {
+	if chatwootAllowed {
 		go forwardToChatwoot(ctx, payload, eventName)
 	}
 
@@ -222,6 +227,16 @@ func shouldForwardEventToChatwoot(eventName string) bool {
 	default:
 		return false
 	}
+}
+
+func isEventWhitelistedForChatwoot(eventName string) bool {
+	if len(config.WhatsappWebhookEvents) == 0 {
+		return true
+	}
+	if isEventWhitelisted(eventName) {
+		return true
+	}
+	return eventName == "message.reaction" && isEventWhitelisted("message")
 }
 
 func buildReactionChatwootContent(data map[string]interface{}, isGroup bool, fromName string) string {


### PR DESCRIPTION
## Summary
- forward `message.reaction` events into the Chatwoot sync path
- render reactions as readable Chatwoot messages using sender and reacted message id when available
- add unit tests for event gating and reaction content generation

## Root cause
Issue #576 happens because WhatsApp reactions are emitted as `message.reaction`, but Chatwoot forwarding was only triggered for `message`. As a result, reactions never reached Chatwoot even though the bridge already parsed them.

## Testing
- `cd src && go test ./infrastructure/whatsapp/... ./ui/rest/... ./infrastructure/chatwoot/... ./usecase/...`

Closes #576
