### PR TITLE
fix: allow link preview thumbnail upload without explicit dimensions (#627)

### DIFF
--- a/src/pkg/utils/general.go
+++ b/src/pkg/utils/general.go
@@ -255,15 +255,8 @@ func GetMetaDataFromURL(urlStr string) (meta Metadata, err error) {
 								width := uint32(bounds.Max.X - bounds.Min.X)
 								height := uint32(bounds.Max.Y - bounds.Min.Y)
 
-								// Check if image is square (1:1 ratio)
-								if width == height && width <= 200 {
-									// For small square images, leave width and height as nil
-									meta.Width = nil
-									meta.Height = nil
-								} else {
-									meta.Width = &width
-									meta.Height = &height
-								}
+								meta.Width = &width
+								meta.Height = &height
 
 								logrus.Debugf("Image dimensions: %dx%d", width, height)
 							}

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -1003,7 +1003,7 @@ func (service serviceSend) SendLink(ctx context.Context, request domainSend.Link
 	}
 
 	// If we have a thumbnail image, upload it to WhatsApp's servers
-	if len(metadata.ImageThumb) > 0 && metadata.Height != nil && metadata.Width != nil {
+	if len(metadata.ImageThumb) > 0 {
 		uploadedThumb, err := service.uploadMedia(ctx, client, whatsmeow.MediaLinkThumbnail, metadata.ImageThumb, dataWaRecipient)
 		if err == nil {
 			// Update the message with the uploaded thumbnail information
@@ -1011,8 +1011,12 @@ func (service serviceSend) SendLink(ctx context.Context, request domainSend.Link
 			msg.ExtendedTextMessage.ThumbnailSHA256 = uploadedThumb.FileSHA256
 			msg.ExtendedTextMessage.ThumbnailEncSHA256 = uploadedThumb.FileEncSHA256
 			msg.ExtendedTextMessage.MediaKey = uploadedThumb.MediaKey
-			msg.ExtendedTextMessage.ThumbnailHeight = metadata.Height
-			msg.ExtendedTextMessage.ThumbnailWidth = metadata.Width
+			if metadata.Height != nil {
+				msg.ExtendedTextMessage.ThumbnailHeight = metadata.Height
+			}
+			if metadata.Width != nil {
+				msg.ExtendedTextMessage.ThumbnailWidth = metadata.Width
+			}
 		} else {
 			logrus.Warnf("Failed to upload thumbnail: %v, continue without uploaded thumbnail", err)
 		}


### PR DESCRIPTION
## Context

- The `/send/link` endpoint failed to generate link preview thumbnails for URLs where image dimensions couldn't be determined (e.g., Instagram posts), as reported in #627
- Root cause: the thumbnail upload in `src/usecase/send.go` was gated on `ImageThumb + Height + Width` all being non-nil. Two code paths caused dimensions to be nil while valid image data existed:
  1. **Image decode failure** (unsupported format) — dimensions never populated
  2. **Small square images ≤200px** — a special-case in `src/pkg/utils/general.go` intentionally nil'd dimensions
- Fix: relaxed the upload condition to only require valid image data (`len(ImageThumb) > 0`), with dimensions set conditionally when available
- Removed the small square image special-case that was nil'ing dimensions unnecessarily
- WhatsApp can render thumbnails without explicit dimension hints, so the strict check was unnecessary

Fixes #627

## Test Results

- `go build ./...` passes
- All existing unit tests pass (`go test ./pkg/utils/ -v` — all PASS)
- Manual test needed: send link with Instagram URL via `/send/link` endpoint and verify preview thumbnail appears