### PR TITLE
feat: allow group-admin bots to revoke other members' messages

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1491,6 +1491,12 @@ paths:
       tags:
         - message
       summary: Revoke Message
+      description: |
+        Revoke (delete for everyone) a message. Revokes the bot's own message by default.
+        If the target message was sent by another user and is present in chat storage,
+        the original sender is resolved automatically so a group-admin bot can revoke
+        other members' messages (anti-spam use case). The WhatsApp server rejects the
+        request if the bot is not a group admin.
       parameters:
         - $ref: '#/components/parameters/DeviceIdHeader'
         - in: path

--- a/src/usecase/message.go
+++ b/src/usecase/message.go
@@ -134,7 +134,28 @@ func (service serviceMessage) RevokeMessage(ctx context.Context, request domainM
 		return response, err
 	}
 
-	ts, err := client.SendMessage(ctx, dataWaRecipient, client.BuildRevoke(dataWaRecipient, types.EmptyJID, request.MessageID))
+	// Resolve the original sender so group admins can revoke other members'
+	// messages. BuildRevoke treats types.EmptyJID as "message was from me";
+	// any other JID is admin-revoke and requires the bot to be group admin.
+	// WhatsApp message IDs are globally unique, so a cross-device lookup
+	// via GetMessageByID yields the same sender regardless of which device
+	// owns the row.
+	senderJID := types.EmptyJID
+	message, lookupErr := service.chatStorageRepo.GetMessageByID(request.MessageID)
+	if lookupErr != nil {
+		logrus.Warnf("Failed to lookup message %s for revoke: %v, assuming self-revoke", request.MessageID, lookupErr)
+	} else if message != nil && !message.IsFromMe && message.Sender != "" {
+		parsed, parseErr := utils.ParseJID(message.Sender)
+		if parseErr != nil {
+			logrus.Warnf("Failed to parse sender JID '%s' for revoke: %v", message.Sender, parseErr)
+		} else {
+			// Stored senders can still be @lid; whatsmeow's Revoke needs
+			// the phone-number form or it rejects the request at the wire.
+			senderJID = whatsapp.NormalizeJIDFromLID(ctx, parsed, client)
+		}
+	}
+
+	ts, err := client.SendMessage(ctx, dataWaRecipient, client.BuildRevoke(dataWaRecipient, senderJID, request.MessageID))
 	if err != nil {
 		return response, err
 	}

--- a/src/views/components/MessageRevoke.js
+++ b/src/views/components/MessageRevoke.js
@@ -77,7 +77,7 @@ export default {
             <a class="ui red right ribbon label">Message</a>
             <div class="header">Revoke Message</div>
             <div class="description">
-                 any message in private or group chat
+                 Revoke your own message, or any member's message in a group where you are admin
             </div>
         </div>
     </div>
@@ -94,7 +94,7 @@ export default {
                 
                 <div class="field">
                     <label> Message ID</label>
-                    <input v-model="message_id" type="text" placeholder="Please enter your message id"
+                    <input v-model="message_id" type="text" placeholder="Please enter the message id to revoke"
                            aria-label="message id">
                 </div>
             </form>


### PR DESCRIPTION
## Context

Implements [discussion #638](https://github.com/aldinokemal/go-whatsapp-web-multidevice/discussions/638) — allow the bot to revoke messages from other users in a group when the bot is a group admin (anti-spam use case).

Previously `RevokeMessage` always passed `types.EmptyJID` to `BuildRevoke`, which tells whatsmeow "the message was mine" — so only self-revoke worked. Now the usecase resolves the original sender via `chatStorageRepo.GetMessageByID`, normalizes any `@lid` to the phone-number form, and passes that JID to `BuildRevoke`. This produces an admin-revoke when the sender is another user. If the message is not found in local storage, it falls back to the previous self-revoke behavior.

### Changes
- `src/usecase/message.go` — sender lookup + LID normalization before `BuildRevoke`
- `docs/openapi.yaml` — updated `POST /message/{message_id}/revoke` description
- `src/views/components/MessageRevoke.js` — card description and input placeholder clarified for admin-revoke

### Prerequisites (to actually revoke someone else's message)
1. **Bot must be group admin** — WhatsApp rejects admin-revoke from non-admins at the wire level.
2. **Target message must exist in local chat storage** — the usecase looks up the original sender by message id. If storage is disabled, or the bot was offline when the message arrived, the lookup returns nothing and we fall back to self-revoke (a no-op for other users' messages).
3. **WhatsApp revoke time window** — WhatsApp only allows revoking within its allowed window (currently ~2 days).
4. **Groups only** — in private chats, you can still only revoke your own messages.

Self-revoke of your own messages keeps working regardless of the above.

## Test Results

- `cd src && go vet ./...` — passes, no warnings
- Manual test plan:
  - [ ] Bot as group admin revokes a spam message from another member → message disappears for everyone
  - [ ] Bot as non-admin tries to revoke another member's message → WhatsApp rejects (error surfaced to caller)
  - [ ] Bot revokes its own message in a private chat → still works (self-revoke path)
  - [ ] Bot revokes a message id not present in chat storage → falls back to self-revoke without crashing
  - [ ] Sender stored as `@lid` → normalized to phone JID before `BuildRevoke`