### PR TITLE
Expose referral metadata in chat message API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4233,6 +4233,10 @@ components:
           type: string
           example: '{"call_id":"ABC","auto_rejected":false}'
           description: JSON string with call details when media_type is `call`. Omitted when not applicable (matches Go json omitempty).
+        referral_metadata:
+          type: string
+          example: '{"ctwa_clid":"clid_123","source_app":"whatsapp"}'
+          description: JSON string with Meta Ads referral/attribution details when the message originated from a Click-to-WhatsApp ad. Omitted when not applicable (matches Go json omitempty).
         filename:
           type: string
           example: 'photo.jpg'

--- a/src/domains/chat/chat.go
+++ b/src/domains/chat/chat.go
@@ -64,12 +64,13 @@ type MessageInfo struct {
 	IsFromMe  bool   `json:"is_from_me"`
 	MediaType string `json:"media_type"`
 	// CallMetadata is JSON when media_type is "call" (incoming call log).
-	CallMetadata string `json:"call_metadata,omitempty"`
-	Filename     string `json:"filename"`
-	URL          string `json:"url"`
-	FileLength   uint64 `json:"file_length"`
-	CreatedAt    string `json:"created_at"`
-	UpdatedAt    string `json:"updated_at"`
+	CallMetadata     string `json:"call_metadata,omitempty"`
+	ReferralMetadata  string `json:"referral_metadata,omitempty"`
+	Filename          string `json:"filename"`
+	URL               string `json:"url"`
+	FileLength        uint64 `json:"file_length"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
 }
 
 type PaginationResponse struct {

--- a/src/usecase/chat.go
+++ b/src/usecase/chat.go
@@ -165,19 +165,20 @@ func (service serviceChat) GetChatMessages(ctx context.Context, request domainCh
 	messageInfos := make([]domainChat.MessageInfo, 0, len(messages))
 	for _, message := range messages {
 		messageInfo := domainChat.MessageInfo{
-			ID:           message.ID,
-			ChatJID:      message.ChatJID,
-			SenderJID:    message.Sender,
-			Content:      message.Content,
-			Timestamp:    message.Timestamp.Format(time.RFC3339),
-			IsFromMe:     message.IsFromMe,
-			MediaType:    message.MediaType,
-			CallMetadata: message.CallMetadata,
-			Filename:     message.Filename,
-			URL:          message.URL,
-			FileLength:   message.FileLength,
-			CreatedAt:    message.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:    message.UpdatedAt.Format(time.RFC3339),
+			ID:               message.ID,
+			ChatJID:          message.ChatJID,
+			SenderJID:        message.Sender,
+			Content:          message.Content,
+			Timestamp:        message.Timestamp.Format(time.RFC3339),
+			IsFromMe:         message.IsFromMe,
+			MediaType:        message.MediaType,
+			CallMetadata:     message.CallMetadata,
+			ReferralMetadata: message.ReferralMetadata,
+			Filename:         message.Filename,
+			URL:              message.URL,
+			FileLength:       message.FileLength,
+			CreatedAt:        message.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:        message.UpdatedAt.Format(time.RFC3339),
 		}
 		messageInfos = append(messageInfos, messageInfo)
 	}


### PR DESCRIPTION
## Summary
- Add `referral_metadata` to the chat message API payload
- Map the stored referral JSON into `GetChatMessages` responses
- Document the new field in the OpenAPI schema

## Verification
- `go test ./usecase ./domains/chat` *(not run here because `go` is unavailable in this environment)*