### PR TITLE
feat(chatstorage): persist WhatsApp ContextInfo and expose in /chat/:jid/messages

### DIFF
--- a/src/domains/chat/chat.go
+++ b/src/domains/chat/chat.go
@@ -66,11 +66,15 @@ type MessageInfo struct {
 	Reactions []ReactionInfo `json:"reactions,omitempty"`
 	// CallMetadata is JSON when media_type is "call" (incoming call log).
 	CallMetadata string `json:"call_metadata,omitempty"`
-	Filename     string `json:"filename"`
-	URL          string `json:"url"`
-	FileLength   uint64 `json:"file_length"`
-	CreatedAt    string `json:"created_at"`
-	UpdatedAt    string `json:"updated_at"`
+	// ContextMetadata is a JSON blob of whatsmeow ContextInfo-derived fields
+	// (replied_to_id, and room to extend with mentions, forwards, etc.).
+	// Empty when the message has no meaningful context.
+	ContextMetadata string `json:"context_metadata,omitempty"`
+	Filename        string `json:"filename"`
+	URL             string `json:"url"`
+	FileLength      uint64 `json:"file_length"`
+	CreatedAt       string `json:"created_at"`
+	UpdatedAt       string `json:"updated_at"`
 }
 
 type PaginationResponse struct {

--- a/src/domains/chatstorage/chatstorage.go
+++ b/src/domains/chatstorage/chatstorage.go
@@ -32,6 +32,7 @@ type Message struct {
 	FileEncSHA256    []byte     `db:"file_enc_sha256"`
 	FileLength       uint64     `db:"file_length"`
 	ReferralMetadata string     `db:"referral_metadata"`
+	ContextMetadata  string     `db:"context_metadata"`
 	Reactions        []Reaction `db:"-"`
 	CreatedAt        time.Time  `db:"created_at"`
 	UpdatedAt        time.Time  `db:"updated_at"`

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -27,6 +27,29 @@ func NewStorageRepository(db *sql.DB) domainChatStorage.IChatStorageRepository {
 	return &SQLiteRepository{db: db}
 }
 
+// buildContextMetadata marshals whatsmeow ContextInfo-derived fields into a
+// JSON blob for the messages.context_metadata column. Returns "" when the
+// message has no meaningful context. Shape is open so future fields
+// (mentioned_jids, is_forwarded, ...) can be added without a migration.
+func buildContextMetadata(ci *waE2E.ContextInfo) string {
+	if ci == nil {
+		return ""
+	}
+	meta := map[string]any{}
+	if stanzaID := ci.GetStanzaID(); stanzaID != "" {
+		meta["replied_to_id"] = stanzaID
+	}
+	if len(meta) == 0 {
+		return ""
+	}
+	jsonBytes, err := json.Marshal(meta)
+	if err != nil {
+		logrus.WithError(err).Warn("failed to marshal context metadata")
+		return ""
+	}
+	return string(jsonBytes)
+}
+
 // StoreChat creates or updates a chat
 func (r *SQLiteRepository) StoreChat(chat *domainChatStorage.Chat) error {
 	now := time.Now()
@@ -89,7 +112,7 @@ func (r *SQLiteRepository) GetMessageByID(id string) (*domainChatStorage.Message
 	query := `
 		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
 			media_type, call_metadata, filename, url, media_key, file_sha256,
-			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
+			file_enc_sha256, file_length, referral_metadata, context_metadata, created_at, updated_at
 		FROM messages
 		WHERE id = ?
 		LIMIT 1
@@ -317,11 +340,11 @@ func (r *SQLiteRepository) StoreMessage(message *domainChatStorage.Message) erro
 	result, err := r.db.Exec(`
 		UPDATE messages SET sender = ?, content = ?, timestamp = ?, is_from_me = ?,
 			media_type = ?, call_metadata = ?, filename = ?, url = ?, media_key = ?, file_sha256 = ?,
-			file_enc_sha256 = ?, file_length = ?, referral_metadata = ?, updated_at = ?
+			file_enc_sha256 = ?, file_length = ?, referral_metadata = ?, context_metadata = ?, updated_at = ?
 		WHERE id = ? AND chat_jid = ? AND device_id = ?
 	`, message.Sender, message.Content, message.Timestamp, message.IsFromMe,
 		message.MediaType, message.CallMetadata, message.Filename, message.URL, message.MediaKey, message.FileSHA256,
-		message.FileEncSHA256, message.FileLength, message.ReferralMetadata, message.UpdatedAt,
+		message.FileEncSHA256, message.FileLength, message.ReferralMetadata, message.ContextMetadata, message.UpdatedAt,
 		message.ID, message.ChatJID, message.DeviceID)
 	if err != nil {
 		return err
@@ -333,12 +356,12 @@ func (r *SQLiteRepository) StoreMessage(message *domainChatStorage.Message) erro
 			INSERT INTO messages (
 				id, chat_jid, device_id, sender, content, timestamp, is_from_me,
 				media_type, call_metadata, filename, url, media_key, file_sha256,
-				file_enc_sha256, file_length, referral_metadata, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				file_enc_sha256, file_length, referral_metadata, context_metadata, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, message.ID, message.ChatJID, message.DeviceID, message.Sender, message.Content,
 			message.Timestamp, message.IsFromMe, message.MediaType, message.CallMetadata, message.Filename,
 			message.URL, message.MediaKey, message.FileSHA256, message.FileEncSHA256,
-			message.FileLength, message.ReferralMetadata, message.CreatedAt, message.UpdatedAt)
+			message.FileLength, message.ReferralMetadata, message.ContextMetadata, message.CreatedAt, message.UpdatedAt)
 	}
 	return err
 }
@@ -359,7 +382,7 @@ func (r *SQLiteRepository) StoreMessagesBatch(messages []*domainChatStorage.Mess
 	updateStmt, err := tx.Prepare(`
 		UPDATE messages SET sender = ?, content = ?, timestamp = ?, is_from_me = ?,
 			media_type = ?, call_metadata = ?, filename = ?, url = ?, media_key = ?, file_sha256 = ?,
-			file_enc_sha256 = ?, file_length = ?, referral_metadata = ?, updated_at = ?
+			file_enc_sha256 = ?, file_length = ?, referral_metadata = ?, context_metadata = ?, updated_at = ?
 		WHERE id = ? AND chat_jid = ? AND device_id = ?
 	`)
 	if err != nil {
@@ -371,8 +394,8 @@ func (r *SQLiteRepository) StoreMessagesBatch(messages []*domainChatStorage.Mess
 		INSERT INTO messages (
 			id, chat_jid, device_id, sender, content, timestamp, is_from_me,
 			media_type, call_metadata, filename, url, media_key, file_sha256,
-			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			file_enc_sha256, file_length, referral_metadata, context_metadata, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare insert statement: %w", err)
@@ -391,7 +414,7 @@ func (r *SQLiteRepository) StoreMessagesBatch(messages []*domainChatStorage.Mess
 		result, err := updateStmt.Exec(
 			message.Sender, message.Content, message.Timestamp, message.IsFromMe,
 			message.MediaType, message.CallMetadata, message.Filename, message.URL, message.MediaKey, message.FileSHA256,
-			message.FileEncSHA256, message.FileLength, message.ReferralMetadata, message.UpdatedAt,
+			message.FileEncSHA256, message.FileLength, message.ReferralMetadata, message.ContextMetadata, message.UpdatedAt,
 			message.ID, message.ChatJID, message.DeviceID,
 		)
 		if err != nil {
@@ -404,7 +427,7 @@ func (r *SQLiteRepository) StoreMessagesBatch(messages []*domainChatStorage.Mess
 				message.ID, message.ChatJID, message.DeviceID, message.Sender, message.Content,
 				message.Timestamp, message.IsFromMe, message.MediaType, message.CallMetadata, message.Filename,
 				message.URL, message.MediaKey, message.FileSHA256, message.FileEncSHA256,
-				message.FileLength, message.ReferralMetadata, message.CreatedAt, message.UpdatedAt,
+				message.FileLength, message.ReferralMetadata, message.ContextMetadata, message.CreatedAt, message.UpdatedAt,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to insert message %s: %w", message.ID, err)
@@ -508,7 +531,7 @@ func (r *SQLiteRepository) GetMessages(filter *domainChatStorage.MessageFilter) 
 	query := `
 		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
 			media_type, call_metadata, filename, url, media_key, file_sha256,
-			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
+			file_enc_sha256, file_length, referral_metadata, context_metadata, created_at, updated_at
 		FROM messages
 		WHERE ` + strings.Join(conditions, " AND ") + `
 		ORDER BY timestamp DESC
@@ -581,7 +604,7 @@ func (r *SQLiteRepository) SearchMessages(deviceID, chatJID, searchText string, 
 	query := `
 		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
 			media_type, call_metadata, filename, url, media_key, file_sha256,
-			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
+			file_enc_sha256, file_length, referral_metadata, context_metadata, created_at, updated_at
 		FROM messages
 		WHERE ` + strings.Join(conditions, " AND ") + `
 		ORDER BY timestamp DESC
@@ -942,7 +965,7 @@ func (r *SQLiteRepository) scanMessage(scanner interface{ Scan(...any) error }) 
 		&message.ID, &message.ChatJID, &message.DeviceID, &message.Sender, &message.Content,
 		&message.Timestamp, &message.IsFromMe, &message.MediaType, &message.CallMetadata, &message.Filename,
 		&message.URL, &message.MediaKey, &message.FileSHA256, &message.FileEncSHA256,
-		&message.FileLength, &message.ReferralMetadata, &message.CreatedAt, &message.UpdatedAt,
+		&message.FileLength, &message.ReferralMetadata, &message.ContextMetadata, &message.CreatedAt, &message.UpdatedAt,
 	)
 	return message, err
 }
@@ -1353,6 +1376,12 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 		}
 	}
 
+	// Capture whatsmeow ContextInfo (reply refs, ...) as a JSON blob so the
+	// info survives past the webhook event and shows up in /chat/:jid/messages
+	// responses. Structure is open so additional keys (mentions, forwards)
+	// can land without a new migration.
+	contextMetadata := buildContextMetadata(utils.ExtractContextInfo(evt.Message))
+
 	message := &domainChatStorage.Message{
 		ID:               evt.Info.ID,
 		ChatJID:          chatJID,
@@ -1369,6 +1398,7 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 		FileEncSHA256:    fileEncSHA256,
 		FileLength:       fileLength,
 		ReferralMetadata: referralMetadata,
+		ContextMetadata:  contextMetadata,
 	}
 
 	// Store the message
@@ -1842,22 +1872,31 @@ func (r *SQLiteRepository) StoreSentMessageWithContext(ctx context.Context, mess
 		mediaType, filename, mediaURL, mediaKey, fileSHA256, fileEncSHA256, fileLength = utils.ExtractMediaInfo(msg)
 	}
 
+	// Capture ContextInfo (reply refs, ...) from the outgoing message too so
+	// bot-authored replies show up in /chat/:jid/messages with the same shape
+	// as inbound replies. Mirrors the logic in CreateMessage.
+	var contextMetadata string
+	if msg != nil {
+		contextMetadata = buildContextMetadata(utils.ExtractContextInfo(msg))
+	}
+
 	// Store the sent message
 	message := &domainChatStorage.Message{
-		ID:            messageID,
-		ChatJID:       chatJID,
-		DeviceID:      deviceID,
-		Sender:        senderJID,
-		Content:       content,
-		Timestamp:     timestamp,
-		IsFromMe:      true,
-		MediaType:     mediaType,
-		Filename:      filename,
-		URL:           mediaURL,
-		MediaKey:      mediaKey,
-		FileSHA256:    fileSHA256,
-		FileEncSHA256: fileEncSHA256,
-		FileLength:    fileLength,
+		ID:              messageID,
+		ChatJID:         chatJID,
+		DeviceID:        deviceID,
+		Sender:          senderJID,
+		Content:         content,
+		Timestamp:       timestamp,
+		IsFromMe:        true,
+		MediaType:       mediaType,
+		Filename:        filename,
+		URL:             mediaURL,
+		MediaKey:        mediaKey,
+		FileSHA256:      fileSHA256,
+		FileEncSHA256:   fileEncSHA256,
+		FileLength:      fileLength,
+		ContextMetadata: contextMetadata,
 	}
 
 	return r.StoreMessage(message)
@@ -2103,5 +2142,10 @@ func (r *SQLiteRepository) getMigrations() []string {
 
 		// Migration 29: Fetch due Chatwoot retry jobs in stable order
 		`CREATE INDEX IF NOT EXISTS idx_chatwoot_forward_queue_due ON chatwoot_forward_queue(next_attempt_at, id)`,
+
+		// Migration 30: JSON metadata for whatsmeow ContextInfo (reply refs,
+		// mentions, forward info). Open-ended so future fields don't need a new
+		// migration — consumers JSON-parse on read.
+		`ALTER TABLE messages ADD COLUMN context_metadata TEXT DEFAULT ''`,
 	}
 }

--- a/src/usecase/chat.go
+++ b/src/usecase/chat.go
@@ -193,19 +193,20 @@ func (service serviceChat) GetChatMessages(ctx context.Context, request domainCh
 	messageInfos := make([]domainChat.MessageInfo, 0, len(messages))
 	for _, message := range messages {
 		messageInfo := domainChat.MessageInfo{
-			ID:           message.ID,
-			ChatJID:      message.ChatJID,
-			SenderJID:    message.Sender,
-			Content:      message.Content,
-			Timestamp:    message.Timestamp.Format(time.RFC3339),
-			IsFromMe:     message.IsFromMe,
-			MediaType:    message.MediaType,
-			CallMetadata: message.CallMetadata,
-			Filename:     message.Filename,
-			URL:          message.URL,
-			FileLength:   message.FileLength,
-			CreatedAt:    message.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:    message.UpdatedAt.Format(time.RFC3339),
+			ID:              message.ID,
+			ChatJID:         message.ChatJID,
+			SenderJID:       message.Sender,
+			Content:         message.Content,
+			Timestamp:       message.Timestamp.Format(time.RFC3339),
+			IsFromMe:        message.IsFromMe,
+			MediaType:       message.MediaType,
+			CallMetadata:    message.CallMetadata,
+			ContextMetadata: message.ContextMetadata,
+			Filename:        message.Filename,
+			URL:             message.URL,
+			FileLength:      message.FileLength,
+			CreatedAt:       message.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:       message.UpdatedAt.Format(time.RFC3339),
 		}
 		if len(message.Reactions) > 0 {
 			messageInfo.Reactions = make([]domainChat.ReactionInfo, 0, len(message.Reactions))


### PR DESCRIPTION
## Problem

Reply context (`whatsmeow.ContextInfo.StanzaID`) is available in real-time webhook payloads (`replied_to_id`, `quoted_body`) but is **not persisted**. Consumers that process messages asynchronously — notably anything reacting to a prior message — have no way to know that message was a reply, because `GET /chat/:jid/messages` doesn't expose that information.

Concrete scenario: a bot listens to `message.reaction` webhooks, then calls `GET /chat/:jid/messages` to resolve the reacted message. If the reacted message itself was a reply, the bot can't reconstruct that link — the field simply doesn't exist in the response.

## Approach

Add a single `context_metadata TEXT DEFAULT ''` column to the `messages` table (migration 17) storing a JSON blob derived from `ContextInfo`. Shape is open-ended so additional fields (mentions, forward info) can land later without another migration.

Pattern matches `call_metadata` (Migration 15) and `referral_metadata` (Migration 16) — both JSON blobs stored alongside the core fields.

## Current scope

Only `replied_to_id` is captured for now:

\`\`\`json
{"replied_to_id":"AC625C65EA7143E71D784176C4A90A93"}
\`\`\`

Enough to unblock reply resolution. `quoted_body`, `mentioned_jids`, `is_forwarded`, etc. can follow without schema changes.

## Changes

- **Migration 17** — \`ALTER TABLE messages ADD COLUMN context_metadata TEXT DEFAULT ''\`
- **\`domains/chatstorage.Message\`** — new \`ContextMetadata string\` field with \`db:\"context_metadata\"\` tag
- **\`infrastructure/chatstorage/sqlite_repository.go\`** — INSERT/UPDATE (both \`StoreMessage\` and \`StoreMessagesBatch\`), SELECTs, and \`scanMessage\` include the new column
- **\`CreateMessage\`** (inbound ingestion) — extracts \`ContextInfo.StanzaID\` via \`utils.ExtractContextInfo\` and marshals into the blob
- **\`CreateSentMessage\`** (outgoing bot messages) — same extraction, so bot-authored replies are also recoverable
- **\`domains/chat.MessageInfo\`** — new \`ContextMetadata string \`json:\"context_metadata,omitempty\"\`\` field
- **\`usecase/chat.go\`** — mapper copies the field through

## Response shape

For messages with context:

\`\`\`json
{
  \"id\": \"AC4BFC5C3AD9CFB3797F8E9F8D2968A0\",
  \"content\": \"got it\",
  \"context_metadata\": \"{\\\"replied_to_id\\\":\\\"AC625C65EA7143E71D784176C4A90A93\\\"}\",
  ...
}
\`\`\`

Consumers \`json.Unmarshal\` when present. Messages without context omit the field entirely (\`omitempty\`), so existing responses look unchanged.

## Webhook payloads unchanged

\`replied_to_id\` and \`quoted_body\` still show up as flat top-level fields in \`message\`-event webhook payloads (\`infrastructure/whatsapp/event_message.go\`). Existing webhook consumers are not affected.

## Backward compatibility

- Additive migration (\`ADD COLUMN ... DEFAULT ''\`).
- \`omitempty\` keeps old responses byte-identical for messages without context.
- No renames, no type changes, no behavior change for non-reply messages.

## Validation

Fresh build against \`main\` HEAD on darwin/arm64, deployed over a live instance with schema previously at version 14. Migrations 15–17 ran cleanly. Sent a WhatsApp reply; verified:

- \`chatstorage.db\` row has \`context_metadata = '{\"replied_to_id\":\"...\"}'\` on the reply, empty on the quoted message.
- \`GET /chat/:jid/messages\` response includes the \`context_metadata\` string.
- Pre-migration messages show empty \`context_metadata\` → omitted from response, no visible change.

## Related gap (separate)

\`referral_metadata\` is stored but not mapped into \`MessageInfo\` (no struct field, no mapper copy). Kept out of scope here; can follow up in a tiny separate PR if interested.