### PR TITLE
Add phone number to contact webhook payload

### DIFF
--- a/docs/webhook-payload.md
+++ b/docs/webhook-payload.md
@@ -851,7 +851,8 @@ When a user shares a single contact:
     "timestamp": "2025-07-13T11:10:19Z",
     "contact": {
       "displayName": "3Care",
-      "vcard": "BEGIN:VCARD\nVERSION:3.0\nN:;3Care;;;\nFN:3Care\nTEL;type=Mobile:+62 132\nEND:VCARD"
+      "vcard": "BEGIN:VCARD\nVERSION:3.0\nN:;3Care;;;\nFN:3Care\nTEL;type=Mobile:+62 132\nEND:VCARD",
+      "phone_number": "+62 132"
     }
   }
 }
@@ -874,11 +875,13 @@ When a user shares multiple contacts at once (via WhatsApp's multi-contact share
     "contacts_array": [
       {
         "displayName": "Alice",
-        "vcard": "BEGIN:VCARD\nVERSION:3.0\nN:;Alice;;;\nFN:Alice\nTEL;type=Mobile:+62 812 3456 7890\nEND:VCARD"
+        "vcard": "BEGIN:VCARD\nVERSION:3.0\nN:;Alice;;;\nFN:Alice\nTEL;type=Mobile:+62 812 3456 7890\nEND:VCARD",
+        "phone_number": "+62 812 3456 7890"
       },
       {
         "displayName": "Bob",
-        "vcard": "BEGIN:VCARD\nVERSION:3.0\nN:;Bob;;;\nFN:Bob\nTEL;type=Mobile:+62 813 9876 5432\nEND:VCARD"
+        "vcard": "BEGIN:VCARD\nVERSION:3.0\nN:;Bob;;;\nFN:Bob\nTEL;type=Mobile:+62 813 9876 5432\nEND:VCARD",
+        "phone_number": "+62 813 9876 5432"
       }
     ]
   }

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -35,6 +35,12 @@ type WebhookEvent struct {
 	Payload  map[string]any `json:"payload"`
 }
 
+type webhookContactPayload struct {
+	DisplayName string `json:"displayName"`
+	VCard       string `json:"vcard"`
+	PhoneNumber string `json:"phone_number,omitempty"`
+}
+
 // forwardMessageToWebhook is a helper function to forward message event to webhook url
 func forwardMessageToWebhook(ctx context.Context, client *whatsmeow.Client, evt *events.Message) error {
 	webhookEvent, err := createWebhookEvent(ctx, client, evt)
@@ -344,11 +350,11 @@ func buildAutoDownloadPayload(extracted utils.ExtractedMedia) any {
 
 func buildOtherMessageTypes(msg *waE2E.Message, payload map[string]any) {
 	if contactMessage := msg.GetContactMessage(); contactMessage != nil {
-		payload["contact"] = contactMessage
+		payload["contact"] = buildWebhookContactPayload(contactMessage)
 	}
 
 	if contactsArrayMessage := msg.GetContactsArrayMessage(); contactsArrayMessage != nil {
-		payload["contacts_array"] = contactsArrayMessage.GetContacts()
+		payload["contacts_array"] = buildWebhookContactsArrayPayload(contactsArrayMessage.GetContacts())
 	}
 
 	if listMessage := msg.GetListMessage(); listMessage != nil {
@@ -366,4 +372,28 @@ func buildOtherMessageTypes(msg *waE2E.Message, payload map[string]any) {
 	if orderMessage := msg.GetOrderMessage(); orderMessage != nil {
 		payload["order"] = orderMessage
 	}
+}
+
+func buildWebhookContactPayload(contact *waE2E.ContactMessage) webhookContactPayload {
+	if contact == nil {
+		return webhookContactPayload{}
+	}
+
+	vcard := contact.GetVcard()
+	return webhookContactPayload{
+		DisplayName: contact.GetDisplayName(),
+		VCard:       vcard,
+		PhoneNumber: extractPhoneFromVCard(vcard),
+	}
+}
+
+func buildWebhookContactsArrayPayload(contacts []*waE2E.ContactMessage) []webhookContactPayload {
+	result := make([]webhookContactPayload, 0, len(contacts))
+	for _, contact := range contacts {
+		if contact == nil {
+			continue
+		}
+		result = append(result, buildWebhookContactPayload(contact))
+	}
+	return result
 }

--- a/src/infrastructure/whatsapp/event_message_test.go
+++ b/src/infrastructure/whatsapp/event_message_test.go
@@ -225,3 +225,92 @@ func TestBuildEventPayloadDocumentWithCaption(t *testing.T) {
 		t.Fatalf("expected body='Important document', got %v", body)
 	}
 }
+
+func TestBuildEventPayloadContactIncludesPhoneNumber(t *testing.T) {
+	name := "Alice"
+	vcard := "BEGIN:VCARD\nVERSION:3.0\nN:;Alice;;;\nFN:Alice\nTEL;type=Mobile:+62 812 3456 7890\nEND:VCARD"
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     types.NewJID("123", types.DefaultUserServer),
+				Sender:   types.NewJID("456", types.DefaultUserServer),
+				IsFromMe: false,
+			},
+			ID:        "MSG204",
+			Timestamp: time.Date(2026, time.February, 8, 10, 0, 0, 0, time.UTC),
+		},
+		Message: &waE2E.Message{
+			ContactMessage: &waE2E.ContactMessage{
+				DisplayName: &name,
+				Vcard:       &vcard,
+			},
+		},
+	}
+
+	_, payload, err := buildEventPayload(context.Background(), nil, evt)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	contact, ok := payload["contact"].(webhookContactPayload)
+	if !ok {
+		t.Fatalf("expected contact payload to be webhookContactPayload, got %T", payload["contact"])
+	}
+	if contact.DisplayName != "Alice" {
+		t.Fatalf("expected display name Alice, got %q", contact.DisplayName)
+	}
+	if contact.PhoneNumber != "+62 812 3456 7890" {
+		t.Fatalf("expected phone number from vCard, got %q", contact.PhoneNumber)
+	}
+}
+
+func TestBuildEventPayloadContactsArrayIncludesPhoneNumbers(t *testing.T) {
+	nameOne := "Alice"
+	vcardOne := "BEGIN:VCARD\nVERSION:3.0\nN:;Alice;;;\nFN:Alice\nTEL;type=Mobile:+62 812 3456 7890\nEND:VCARD"
+	nameTwo := "Bob"
+	vcardTwo := "BEGIN:VCARD\nVERSION:3.0\nN:;Bob;;;\nFN:Bob\nTEL;type=Mobile:+62 813 9876 5432\nEND:VCARD"
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     types.NewJID("123", types.DefaultUserServer),
+				Sender:   types.NewJID("456", types.DefaultUserServer),
+				IsFromMe: false,
+			},
+			ID:        "MSG205",
+			Timestamp: time.Date(2026, time.February, 8, 10, 0, 0, 0, time.UTC),
+		},
+		Message: &waE2E.Message{
+			ContactsArrayMessage: &waE2E.ContactsArrayMessage{
+				Contacts: []*waE2E.ContactMessage{
+					{
+						DisplayName: &nameOne,
+						Vcard:       &vcardOne,
+					},
+					{
+						DisplayName: &nameTwo,
+						Vcard:       &vcardTwo,
+					},
+				},
+			},
+		},
+	}
+
+	_, payload, err := buildEventPayload(context.Background(), nil, evt)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	contacts, ok := payload["contacts_array"].([]webhookContactPayload)
+	if !ok {
+		t.Fatalf("expected contacts_array to be []webhookContactPayload, got %T", payload["contacts_array"])
+	}
+	if len(contacts) != 2 {
+		t.Fatalf("expected 2 contacts, got %d", len(contacts))
+	}
+	if contacts[0].PhoneNumber != "+62 812 3456 7890" {
+		t.Fatalf("expected first phone number, got %q", contacts[0].PhoneNumber)
+	}
+	if contacts[1].PhoneNumber != "+62 813 9876 5432" {
+		t.Fatalf("expected second phone number, got %q", contacts[1].PhoneNumber)
+	}
+}

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -272,12 +272,7 @@ func chatwootMessageTypeFromPayload(data map[string]interface{}) string {
 
 func extractStructuredMessageContent(data map[string]interface{}) string {
 	if contact, ok := data["contact"]; ok && contact != nil {
-		if cm, ok := contact.(interface {
-			GetDisplayName() string
-			GetVcard() string
-		}); ok {
-			name := cm.GetDisplayName()
-			phone := extractPhoneFromVCard(cm.GetVcard())
+		if name, phone, ok := extractContactDetails(contact); ok {
 			switch {
 			case name != "" && phone != "":
 				return fmt.Sprintf("Contact: %s (%s)", name, phone)
@@ -288,6 +283,38 @@ func extractStructuredMessageContent(data map[string]interface{}) string {
 			}
 		}
 		return "Contact shared"
+	}
+
+	if contactsArray, ok := data["contacts_array"]; ok && contactsArray != nil {
+		switch contacts := contactsArray.(type) {
+		case []webhookContactPayload:
+			return structuredContactsArraySummary(contacts)
+		case []*webhookContactPayload:
+			normalized := make([]webhookContactPayload, 0, len(contacts))
+			for _, contact := range contacts {
+				if contact != nil {
+					normalized = append(normalized, *contact)
+				}
+			}
+			return structuredContactsArraySummary(normalized)
+		case []interface{}:
+			if len(contacts) == 0 {
+				return "Contacts shared"
+			}
+			if name, phone, ok := extractContactDetails(contacts[0]); ok {
+				switch {
+				case name != "" && phone != "":
+					return fmt.Sprintf("Contacts: %s (%s)", name, phone)
+				case name != "":
+					return "Contacts: " + name
+				case phone != "":
+					return "Contacts: " + phone
+				}
+			}
+			return "Contacts shared"
+		default:
+			return "Contacts shared"
+		}
 	}
 
 	if location, ok := data["location"]; ok && location != nil {
@@ -336,6 +363,60 @@ func extractStructuredMessageContent(data map[string]interface{}) string {
 	}
 
 	return ""
+}
+
+func extractContactDetails(contact interface{}) (name string, phone string, ok bool) {
+	switch c := contact.(type) {
+	case webhookContactPayload:
+		return c.DisplayName, c.PhoneNumber, true
+	case *webhookContactPayload:
+		if c == nil {
+			return "", "", false
+		}
+		return c.DisplayName, c.PhoneNumber, true
+	case map[string]any:
+		if v, ok := c["displayName"].(string); ok {
+			name = v
+		} else if v, ok := c["display_name"].(string); ok {
+			name = v
+		}
+		if v, ok := c["phone_number"].(string); ok {
+			phone = v
+		}
+		if phone == "" {
+			if v, ok := c["vcard"].(string); ok {
+				phone = extractPhoneFromVCard(v)
+			}
+		}
+		return name, phone, name != "" || phone != ""
+	case interface {
+		GetDisplayName() string
+		GetVcard() string
+	}:
+		name = c.GetDisplayName()
+		phone = extractPhoneFromVCard(c.GetVcard())
+		return name, phone, true
+	default:
+		return "", "", false
+	}
+}
+
+func structuredContactsArraySummary(contacts []webhookContactPayload) string {
+	if len(contacts) == 0 {
+		return "Contacts shared"
+	}
+
+	first := contacts[0]
+	switch {
+	case first.DisplayName != "" && first.PhoneNumber != "":
+		return fmt.Sprintf("Contacts: %s (%s)", first.DisplayName, first.PhoneNumber)
+	case first.DisplayName != "":
+		return "Contacts: " + first.DisplayName
+	case first.PhoneNumber != "":
+		return "Contacts: " + first.PhoneNumber
+	default:
+		return "Contacts shared"
+	}
 }
 
 func extractPhoneFromVCard(vcard string) string {

--- a/src/infrastructure/whatsapp/webhook_forward_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_test.go
@@ -194,3 +194,39 @@ func TestForwardPayloadToConfiguredWebhooks_WhitelistCaseInsensitive(t *testing.
 		t.Fatalf("expected 2 calls (case-insensitive match), got %d", called)
 	}
 }
+
+func TestExtractStructuredMessageContentWithContactPayload(t *testing.T) {
+	payload := map[string]any{
+		"contact": webhookContactPayload{
+			DisplayName: "Alice",
+			PhoneNumber: "+62 812 3456 7890",
+		},
+	}
+
+	got := extractStructuredMessageContent(payload)
+	want := "Contact: Alice (+62 812 3456 7890)"
+	if got != want {
+		t.Fatalf("extractStructuredMessageContent() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractStructuredMessageContentWithContactsArrayPayload(t *testing.T) {
+	payload := map[string]any{
+		"contacts_array": []webhookContactPayload{
+			{
+				DisplayName: "Alice",
+				PhoneNumber: "+62 812 3456 7890",
+			},
+			{
+				DisplayName: "Bob",
+				PhoneNumber: "+62 813 9876 5432",
+			},
+		},
+	}
+
+	got := extractStructuredMessageContent(payload)
+	want := "Contacts: Alice (+62 812 3456 7890)"
+	if got != want {
+		t.Fatalf("extractStructuredMessageContent() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #653

This PR enriches contact webhook payloads with a structured `phone_number` field for both single contacts and multi-contact shares. It keeps the original `vcard` field intact for backward compatibility and updates the Chatwoot forwarding path to understand the structured payload as well.