### PR TITLE
fix: enrich newsletter subscriber counts

### DIFF
--- a/src/usecase/user.go
+++ b/src/usecase/user.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"sync"
 	"time"
 
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
@@ -222,25 +223,51 @@ func (service serviceUser) MyListNewsletter(ctx context.Context) (response domai
 		return
 	}
 
+	// GetSubscribedNewsletters may return incomplete metadata from WhatsApp,
+	// especially subscribers_count. Enrich entries that are missing the count via
+	// GetNewsletterInfo with bounded parallelism so we don't fan out unboundedly
+	// to the WhatsApp socket, and a per-call timeout so one slow newsletter
+	// cannot stall the whole request.
+	const (
+		newsletterDetailParallelism = 5
+		newsletterDetailTimeout     = 5 * time.Second
+	)
+
+	sem := make(chan struct{}, newsletterDetailParallelism)
+	var wg sync.WaitGroup
 	for _, data := range datas {
 		if data == nil {
 			continue
 		}
-
-		// GetSubscribedNewsletters may return incomplete metadata from WhatsApp,
-		// especially subscribers_count. Fetch each newsletter detail to enrich the
-		// count while keeping the base subscribed list as the source of truth.
-		detail, detailErr := client.GetNewsletterInfo(ctx, data.ID)
-		if detailErr != nil {
-			logrus.Debugf("Could not fetch newsletter detail for %s: %v", data.ID.String(), detailErr)
-			response.Data = append(response.Data, *data)
+		// Skip the detail fetch when the base response already populated the count.
+		if data.ThreadMeta.SubscriberCount > 0 {
 			continue
 		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(d *types.NewsletterMetadata) {
+			defer wg.Done()
+			defer func() { <-sem }()
 
-		if detail != nil {
-			data.ThreadMeta.SubscriberCount = detail.ThreadMeta.SubscriberCount
+			detailCtx, cancel := context.WithTimeout(ctx, newsletterDetailTimeout)
+			defer cancel()
+
+			detail, detailErr := client.GetNewsletterInfo(detailCtx, d.ID)
+			if detailErr != nil {
+				logrus.Debugf("Could not fetch newsletter detail for %s: %v", d.ID.String(), detailErr)
+				return
+			}
+			if detail != nil {
+				d.ThreadMeta.SubscriberCount = detail.ThreadMeta.SubscriberCount
+			}
+		}(data)
+	}
+	wg.Wait()
+
+	for _, data := range datas {
+		if data == nil {
+			continue
 		}
-
 		response.Data = append(response.Data, *data)
 	}
 	return response, nil

--- a/src/usecase/user.go
+++ b/src/usecase/user.go
@@ -8,8 +8,8 @@ import (
 	"image"
 	"time"
 
-	domainUser "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/user"
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	domainUser "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/user"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
@@ -223,6 +223,24 @@ func (service serviceUser) MyListNewsletter(ctx context.Context) (response domai
 	}
 
 	for _, data := range datas {
+		if data == nil {
+			continue
+		}
+
+		// GetSubscribedNewsletters may return incomplete metadata from WhatsApp,
+		// especially subscribers_count. Fetch each newsletter detail to enrich the
+		// count while keeping the base subscribed list as the source of truth.
+		detail, detailErr := client.GetNewsletterInfo(ctx, data.ID)
+		if detailErr != nil {
+			logrus.Debugf("Could not fetch newsletter detail for %s: %v", data.ID.String(), detailErr)
+			response.Data = append(response.Data, *data)
+			continue
+		}
+
+		if detail != nil {
+			data.ThreadMeta.SubscriberCount = detail.ThreadMeta.SubscriberCount
+		}
+
 		response.Data = append(response.Data, *data)
 	}
 	return response, nil


### PR DESCRIPTION
## Summary
- enrich subscribed newsletter metadata with detail fetches so subscribers_count is populated when WhatsApp omits it from the subscribed list response
- keep the base subscribed newsletter list as source of truth
- fall back to the original newsletter metadata if a detail fetch fails

Fixes #658

## Tests
- go test ./...