### PR TITLE
Add Gowa favicon

### DIFF
--- a/src/views/index.html
+++ b/src/views/index.html
@@ -4,6 +4,7 @@
     <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="{{ .AppBasePath }}/assets/gowa.svg" type="image/svg+xml" sizes="any">
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" type="text/css"
           href="https://cdnjs.cloudflare.com/ajax/libs/fomantic-ui/2.8.8/semantic.min.css">


### PR DESCRIPTION
Add a favicon to the web client using the existing Gowa SVG asset.

What changed:
- Added a `rel="icon"` tag in the page head
- Reused the existing `src/views/assets/gowa.svg` asset

Why:
- The browser tab now shows the Gowa brand consistently with the rest of the UI

Validation:
- Ran `cd src && go test ./...`
