### PR TITLE
fix: API-sent messages missing from chat message list (#683)

### DIFF
--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -1286,7 +1286,7 @@ func (r *SQLiteRepository) StoreSentMessageWithContext(ctx context.Context, mess
 		deviceID = client.Store.ID.ToNonAD().String()
 	}
 	if deviceID == "" {
-		return fmt.Errorf("device_id required: missing device in context")
+		return fmt.Errorf("device_id required: missing device in context: %w", domainChatStorage.ErrMissingDeviceContext)
 	}
 
 	// Normalize recipient JID (convert @lid to @s.whatsapp.net)

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -1285,6 +1285,9 @@ func (r *SQLiteRepository) StoreSentMessageWithContext(ctx context.Context, mess
 	if deviceID == "" && client != nil && client.Store != nil && client.Store.ID != nil {
 		deviceID = client.Store.ID.ToNonAD().String()
 	}
+	if deviceID == "" {
+		return fmt.Errorf("device_id required: missing device in context")
+	}
 
 	// Normalize recipient JID (convert @lid to @s.whatsapp.net)
 	normalizedJID := whatsapp.NormalizeJIDFromLID(ctx, jid, client)

--- a/src/infrastructure/chatstorage/sqlite_repository_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_test.go
@@ -3,6 +3,7 @@ package chatstorage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -177,6 +178,9 @@ func TestStoreSentMessageWithContextRequiresDeviceInContext(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected error when storing sent message without device context")
+	}
+	if !errors.Is(err, domainChatStorage.ErrMissingDeviceContext) {
+		t.Fatalf("expected missing device context error, got %v", err)
 	}
 }
 

--- a/src/infrastructure/chatstorage/sqlite_repository_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_test.go
@@ -1,6 +1,7 @@
 package chatstorage
 
 import (
+	"context"
 	"database/sql"
 	"path/filepath"
 	"testing"
@@ -156,6 +157,26 @@ func TestSQLiteRepositoryDeletesReactionsWithMessagesAndDevices(t *testing.T) {
 	}
 	if got := countMessageReactions(t, repo); got != 0 {
 		t.Fatalf("expected device cleanup to delete reactions, got %d", got)
+	}
+}
+
+func TestStoreSentMessageWithContextRequiresDeviceInContext(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "6289605618749@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+	now := time.Date(2026, time.May, 22, 10, 0, 0, 0, time.UTC)
+
+	err := repo.StoreSentMessageWithContext(
+		context.Background(),
+		"msg-sent-1",
+		deviceID,
+		chatJID,
+		"hello from api",
+		now,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error when storing sent message without device context")
 	}
 }
 

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -112,6 +112,9 @@ func (r *deviceChatStorage) DeleteMessageByDevice(deviceID, id, chatJID string) 
 }
 
 func (r *deviceChatStorage) StoreSentMessageWithContext(ctx context.Context, messageID string, senderJID string, recipientJID string, content string, timestamp time.Time, msg *waE2E.Message) error {
+	if _, ok := DeviceFromContext(ctx); !ok && r.deviceID != "" {
+		ctx = ContextWithDevice(ctx, NewDeviceInstance(r.deviceID, nil, nil))
+	}
 	return r.base.StoreSentMessageWithContext(ctx, messageID, senderJID, recipientJID, content, timestamp, msg)
 }
 

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -63,10 +63,10 @@ func (service serviceSend) wrapSendMessage(ctx context.Context, client *whatsmeo
 		senderJID = client.Store.ID.String()
 	}
 
-	// Store message asynchronously with timeout
-	// Use a goroutine to avoid blocking the send operation
+	// Store message asynchronously with timeout.
+	// Preserve device context (for device_id scoping) but detach from request cancellation.
 	go func() {
-		storeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		storeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
 		defer cancel()
 
 		if err := service.chatStorageRepo.StoreSentMessageWithContext(storeCtx, ts.ID, senderJID, recipient.String(), content, ts.Timestamp, msg); err != nil {

--- a/src/usecase/send_test.go
+++ b/src/usecase/send_test.go
@@ -1,6 +1,28 @@
 package usecase
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
+)
+
+func TestWithoutCancelPreservesDeviceContext(t *testing.T) {
+	deviceID := "6289605618749@s.whatsapp.net"
+	ctx := whatsapp.ContextWithDevice(context.Background(), whatsapp.NewDeviceInstance(deviceID, nil, nil))
+
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	storeCtx := context.WithoutCancel(cancelledCtx)
+	inst, ok := whatsapp.DeviceFromContext(storeCtx)
+	if !ok || inst == nil {
+		t.Fatal("expected device instance to remain in detached context")
+	}
+	if got := inst.ID(); got != deviceID {
+		t.Fatalf("expected device id %q, got %q", deviceID, got)
+	}
+}
 
 func TestResolveDocumentMIME(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #683

## Problem

Messages sent via `POST /send/message` were delivered on WhatsApp but often did not appear in the UI or `GET /chat/:chat_jid/messages` response (`total_messages=0`).

## Root cause

`wrapSendMessage` stores sent messages asynchronously using `context.Background()`, which drops the device instance attached by `ContextWithDevice`. Without device context, `StoreSentMessageWithContext` could not resolve `device_id`, so rows were stored with an empty `device_id` while queries use the logged-in JID from context — a device scoping mismatch.

Reporter logs (`chat with JID ... not found`, intermittent `total_messages=0`) match this behavior.

## Fix

- Use `context.WithoutCancel(ctx)` in the async storage goroutine so device context survives after the HTTP request completes without inheriting request cancellation.
- Return an explicit error from `StoreSentMessageWithContext` when `device_id` cannot be resolved (surfaces failures in logs instead of silent bad data).
- Inject device scope in `deviceChatStorage.StoreSentMessageWithContext` when context lacks a device (defense in depth for event-path callers).

## Testing

- `go test ./...`
- Added `TestStoreSentMessageWithContextRequiresDeviceInContext` and `TestWithoutCancelPreservesDeviceContext`

## Note for existing deployments

Messages previously stored with empty `device_id` will not appear until re-sent or re-synced via history. A one-off DB migration could backfill `device_id` if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab76e9ce-ed67-4c68-bd99-7973b6baf89a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab76e9ce-ed67-4c68-bd99-7973b6baf89a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

