### PR TITLE
chore: reorganize .gitignore and add statics/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,41 @@
-*.db
-tmp
-.idea
-.DS_Store
-history-*.json
+# Binaries
+bin/
 main
 main.exe
-*.jpe
-src/pkged.go
-storages
-.env
-bin
-.playwright-mcp
-.cursor/mcp.json
-.factory
-.vscode/settings.json
-src/whatsapp
-.worktrees/
 src/gowa
+
+# Build artifacts
+src/pkged.go
+
+# Database
+*.db
+storages/
+
+# Environment
+.env
+
+# Runtime media & QR codes
+statics/
+
+# History files
+history-*.json
+
+# Media conversions
+*.jpe
+
+# IDE & editor
+.idea/
+.vscode/settings.json
+.factory/
+.cursor/mcp.json
+.playwright-mcp/
+
+# OS files
+.DS_Store
+tmp/
+
+# Worktrees
+.worktrees/
+
+# whatsmeow store (legacy path)
+src/whatsapp/


### PR DESCRIPTION
## Context

- Reorganized `.gitignore` entries into logical categories (Binaries, Build, Database, Environment, Runtime, IDE, OS, etc.) for better readability and maintainability
- Added `statics/` to `.gitignore` — this directory contains runtime media and QR codes that should not be tracked in version control

## Test Results

- Verified `.gitignore` syntax is correct and all existing entries are preserved
- Confirmed `statics/` directory exists at project root and contains runtime-generated files (`media/`, `qrcode/`, `senditems/`)