### PR TITLE
🐛 fix: detect SecretEncrypted message edits for webhook, storage and UI

### DIFF
--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -1019,7 +1019,7 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 
 	resolved, err := whatsapp.ResolveIncomingMessage(ctx, client, evt)
 	if err != nil {
-		return nil
+		return fmt.Errorf("failed to resolve incoming message %s: %w", evt.Info.ID, err)
 	}
 
 	if edit := whatsapp.ExtractMessageEdit(resolved); edit != nil {

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -1017,7 +1017,12 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 		return fmt.Errorf("failed to get existing chat: %w", err)
 	}
 
-	if editMessage := extractEditedMessage(evt.Message); editMessage != nil {
+	resolved, err := whatsapp.ResolveIncomingMessage(ctx, client, evt)
+	if err != nil {
+		return nil
+	}
+
+	if edit := whatsapp.ExtractMessageEdit(resolved); edit != nil {
 		if existingChat == nil {
 			chat := &domainChatStorage.Chat{
 				DeviceID:        deviceID,
@@ -1030,7 +1035,7 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 			}
 		}
 
-		if err := r.storeEditedMessage(ctx, evt, deviceID, chatJID, sender, editMessage); err != nil {
+		if err := r.storeEditedMessage(ctx, evt, deviceID, chatJID, sender, edit); err != nil {
 			return err
 		}
 		return nil
@@ -1104,33 +1109,28 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 	return r.StoreMessage(message)
 }
 
-func extractEditedMessage(msg *waE2E.Message) *waE2E.Message {
-	if msg == nil {
-		return nil
-	}
-	protocolMessage := msg.GetProtocolMessage()
-	if protocolMessage == nil || protocolMessage.GetType() != waE2E.ProtocolMessage_MESSAGE_EDIT {
-		return nil
-	}
-	return protocolMessage.GetEditedMessage()
-}
-
-func (r *SQLiteRepository) storeEditedMessage(ctx context.Context, evt *events.Message, deviceID, chatJID, sender string, editedMessage *waE2E.Message) error {
-	if evt == nil || editedMessage == nil {
+func (r *SQLiteRepository) storeEditedMessage(ctx context.Context, evt *events.Message, deviceID, chatJID, sender string, parsedEdit *whatsapp.MessageEdit) error {
+	if evt == nil || parsedEdit == nil || parsedEdit.Edited == nil || parsedEdit.Protocol == nil {
 		return nil
 	}
 
-	protocolMessage := evt.Message.GetProtocolMessage()
-	if protocolMessage == nil {
-		return nil
-	}
-	key := protocolMessage.GetKey()
+	key := parsedEdit.Protocol.GetKey()
 	if key == nil || key.GetID() == "" {
+		if parsedEdit.OriginalMessageID == "" {
+			return nil
+		}
+	}
+
+	originalMessageID := parsedEdit.OriginalMessageID
+	if originalMessageID == "" && key != nil {
+		originalMessageID = key.GetID()
+	}
+	if originalMessageID == "" {
 		return nil
 	}
 
-	originalMessageID := key.GetID()
-	newContent := utils.ExtractMessageTextFromProto(editedMessage)
+	editedMessage := parsedEdit.Edited
+	newContent := whatsapp.ExtractEditBody(editedMessage)
 	now := time.Now()
 
 	existingMessage, err := r.getMessageByDeviceAndChatIDAndMessageID(deviceID, chatJID, originalMessageID)
@@ -1166,7 +1166,7 @@ func (r *SQLiteRepository) storeEditedMessage(ctx context.Context, evt *events.M
 		previousContent = currentMessage.Content
 	}
 
-	edit := &domainChatStorage.MessageEdit{
+	editRecord := &domainChatStorage.MessageEdit{
 		OriginalMessageID: originalMessageID,
 		EditEventID:       evt.Info.ID,
 		ChatJID:           chatJID,
@@ -1206,7 +1206,7 @@ func (r *SQLiteRepository) storeEditedMessage(ctx context.Context, evt *events.M
 		}
 	}
 
-	if err := r.storeMessageEditExec(tx, edit); err != nil {
+	if err := r.storeMessageEditExec(tx, editRecord); err != nil {
 		return fmt.Errorf("failed to store edit history for %s: %w", originalMessageID, err)
 	}
 

--- a/src/infrastructure/chatstorage/sqlite_repository_edit_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_edit_test.go
@@ -171,7 +171,8 @@ func (suite *SQLiteRepositoryEditTestSuite) TestCreateMessageSecretEncryptedEdit
 	}
 
 	err := suite.repo.CreateMessage(suite.ctx, encryptedEdit)
-	require.NoError(suite.T(), err)
+	require.Error(suite.T(), err)
+	assert.ErrorIs(suite.T(), err, whatsapp.ErrSecretEditDecrypt)
 
 	got, err := suite.repo.GetMessageByID("MSG-SEC-ORIG")
 	require.NoError(suite.T(), err)

--- a/src/infrastructure/chatstorage/sqlite_repository_edit_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_edit_test.go
@@ -136,6 +136,53 @@ func (suite *SQLiteRepositoryEditTestSuite) TestCreateMessageStoresEditHistoryAn
 	}
 }
 
+func (suite *SQLiteRepositoryEditTestSuite) TestCreateMessageSecretEncryptedEditWithoutClientDoesNotInsertNewRow() {
+	original := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     types.NewJID("123", types.DefaultUserServer),
+				Sender:   types.NewJID("123", types.DefaultUserServer),
+				IsFromMe: true,
+			},
+			ID:        "MSG-SEC-ORIG",
+			Timestamp: time.Now(),
+		},
+		Message: &waE2E.Message{
+			Conversation: editProtoString("before"),
+		},
+	}
+	require.NoError(suite.T(), suite.repo.CreateMessage(suite.ctx, original))
+
+	encryptedEdit := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     types.NewJID("123", types.DefaultUserServer),
+				Sender:   types.NewJID("123", types.DefaultUserServer),
+				IsFromMe: true,
+			},
+			ID:        "MSG-SEC-EDIT",
+			Timestamp: time.Now(),
+		},
+		Message: &waE2E.Message{
+			SecretEncryptedMessage: &waE2E.SecretEncryptedMessage{
+				SecretEncType: waE2E.SecretEncryptedMessage_MESSAGE_EDIT.Enum(),
+			},
+		},
+	}
+
+	err := suite.repo.CreateMessage(suite.ctx, encryptedEdit)
+	require.NoError(suite.T(), err)
+
+	got, err := suite.repo.GetMessageByID("MSG-SEC-ORIG")
+	require.NoError(suite.T(), err)
+	require.NotNil(suite.T(), got)
+	assert.Equal(suite.T(), "before", got.Content)
+
+	editRow, err := suite.repo.GetMessageByID("MSG-SEC-EDIT")
+	require.NoError(suite.T(), err)
+	assert.Nil(suite.T(), editRow)
+}
+
 func TestSQLiteRepositoryEditTestSuite(t *testing.T) {
 	suite.Run(t, new(SQLiteRepositoryEditTestSuite))
 }

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -92,8 +92,6 @@ func createWebhookEvent(ctx context.Context, client *whatsmeow.Client, evt *even
 func buildEventPayload(ctx context.Context, client *whatsmeow.Client, evt *events.Message) (string, map[string]any, error) {
 	payload := make(map[string]any)
 
-	msg := utils.UnwrapMessage(evt.Message)
-
 	// Common fields for all message types
 	payload["id"] = evt.Info.ID
 	payload["timestamp"] = evt.Info.Timestamp.Format(time.RFC3339)
@@ -107,19 +105,9 @@ func buildEventPayload(ctx context.Context, client *whatsmeow.Client, evt *event
 		payload["from_name"] = pushname
 	}
 
-	// Modern WhatsApp clients (LID-migrated accounts on recent app builds) wrap
-	// message edits in a SecretEncryptedMessage with encType=MESSAGE_EDIT instead
-	// of sending them as a plain ProtocolMessage{MESSAGE_EDIT}. Decrypt those
-	// here using whatsmeow's existing helper, then fall through to the standard
-	// MESSAGE_EDIT extraction path using the decrypted inner Message.
-	if sem := msg.GetSecretEncryptedMessage(); sem != nil &&
-		sem.GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT &&
-		client != nil {
-		if decrypted, err := client.DecryptSecretEncryptedMessage(ctx, evt); err != nil {
-			logrus.Warnf("Failed to decrypt SecretEncryptedMessage(MESSAGE_EDIT) for %s: %v", evt.Info.ID, err)
-		} else if decrypted != nil {
-			msg = utils.UnwrapMessage(decrypted)
-		}
+	msg, err := ResolveIncomingMessage(ctx, client, evt)
+	if err != nil {
+		return "", nil, err
 	}
 
 	// Check for protocol messages (revoke, edit)
@@ -138,14 +126,12 @@ func buildEventPayload(ctx context.Context, client *whatsmeow.Client, evt *event
 			return EventTypeMessageRevoked, payload, nil
 
 		case "MESSAGE_EDIT":
-			if key := protocolMessage.GetKey(); key != nil {
-				payload["original_message_id"] = key.GetID()
-			}
-			if editedMessage := protocolMessage.GetEditedMessage(); editedMessage != nil {
-				if editedText := editedMessage.GetExtendedTextMessage(); editedText != nil {
-					payload["body"] = editedText.GetText()
-				} else if editedConv := editedMessage.GetConversation(); editedConv != "" {
-					payload["body"] = editedConv
+			if edit := ExtractMessageEdit(msg); edit != nil {
+				if edit.OriginalMessageID != "" {
+					payload["original_message_id"] = edit.OriginalMessageID
+				}
+				if body := ExtractEditBody(edit.Edited); body != "" {
+					payload["body"] = body
 				}
 			}
 			return EventTypeMessageEdited, payload, nil

--- a/src/infrastructure/whatsapp/event_message_handler.go
+++ b/src/infrastructure/whatsapp/event_message_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/ui/websocket"
 	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/types"
@@ -37,6 +38,8 @@ func handleMessage(ctx context.Context, evt *events.Message, chatStorageRepo dom
 	if err := chatStorageRepo.CreateMessage(ctx, evt); err != nil {
 		// Log storage errors to avoid silent failures that could lead to data loss
 		log.Errorf("Failed to store incoming message %s: %v", evt.Info.ID, err)
+	} else {
+		broadcastMessageEditedIfApplicable(ctx, evt, client)
 	}
 
 	// Handle image message if present
@@ -109,28 +112,68 @@ func handleAutoMarkRead(ctx context.Context, evt *events.Message, client *whatsm
 }
 
 func handleWebhookForward(ctx context.Context, evt *events.Message, client *whatsmeow.Client) {
-	// Skip webhook for protocol messages that are internal sync messages
-	if protocolMessage := evt.Message.GetProtocolMessage(); protocolMessage != nil {
-		protocolType := protocolMessage.GetType().String()
-		// Only allow REVOKE and MESSAGE_EDIT through - skip all other protocol messages
-		// (HISTORY_SYNC_NOTIFICATION, APP_STATE_SYNC_KEY_SHARE, EPHEMERAL_SYNC_RESPONSE, etc.)
-		switch protocolType {
-		case "REVOKE", "MESSAGE_EDIT":
-			// These are meaningful user actions, allow webhook
-		default:
-			log.Debugf("Skipping webhook for protocol message type: %s", protocolType)
-			return
+	// Skip webhook for protocol messages that are internal sync messages.
+	// SecretEncrypted MESSAGE_EDIT has no top-level ProtocolMessage; always allow those through.
+	if !IsSecretEncryptedEdit(evt.Message) {
+		if protocolMessage := evt.Message.GetProtocolMessage(); protocolMessage != nil {
+			protocolType := protocolMessage.GetType().String()
+			switch protocolType {
+			case "REVOKE", "MESSAGE_EDIT":
+				// meaningful user actions
+			default:
+				log.Debugf("Skipping webhook for protocol message type: %s", protocolType)
+				return
+			}
 		}
 	}
 
 	if (len(config.WhatsappWebhook) > 0 || config.ChatwootEnabled) &&
 		!strings.Contains(evt.Info.SourceString(), "broadcast") {
-		go func(e *events.Message, c *whatsmeow.Client) {
-			webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		go func(parentCtx context.Context, e *events.Message, c *whatsmeow.Client) {
+			webhookCtx, cancel := context.WithTimeout(parentCtx, 30*time.Second)
 			defer cancel()
 			if err := forwardMessageToWebhook(webhookCtx, c, e); err != nil {
 				logrus.Error("Failed forward to webhook: ", err)
 			}
-		}(evt, client)
+		}(ctx, evt, client)
+	}
+}
+
+func broadcastMessageEditedIfApplicable(ctx context.Context, evt *events.Message, client *whatsmeow.Client) {
+	if evt == nil || evt.Message == nil || client == nil {
+		return
+	}
+
+	resolved, err := ResolveIncomingMessage(ctx, client, evt)
+	if err != nil {
+		return
+	}
+	edit := ExtractMessageEdit(resolved)
+	if edit == nil || edit.OriginalMessageID == "" {
+		return
+	}
+
+	deviceID := ""
+	if inst, ok := DeviceFromContext(ctx); ok && inst != nil {
+		deviceID = inst.JID()
+		if deviceID == "" {
+			deviceID = inst.ID()
+		}
+	}
+	if deviceID == "" && client.Store != nil && client.Store.ID != nil {
+		deviceID = client.Store.ID.ToNonAD().String()
+	}
+
+	chatJID := NormalizeJIDFromLID(ctx, evt.Info.Chat, client).ToNonAD().String()
+
+	websocket.Broadcast <- websocket.BroadcastMessage{
+		Code: "MESSAGE_EDITED",
+		Result: map[string]any{
+			"device_id":           deviceID,
+			"chat_jid":            chatJID,
+			"original_message_id": edit.OriginalMessageID,
+			"new_content":         ExtractEditBody(edit.Edited),
+			"edit_event_id":       evt.Info.ID,
+		},
 	}
 }

--- a/src/infrastructure/whatsapp/message_edit.go
+++ b/src/infrastructure/whatsapp/message_edit.go
@@ -1,0 +1,95 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// ErrSecretEditDecrypt is returned when a SecretEncryptedMessage(MESSAGE_EDIT) cannot be decrypted.
+var ErrSecretEditDecrypt = errors.New("failed to decrypt secret encrypted message edit")
+
+// MessageEdit holds a parsed MESSAGE_EDIT protocol payload from a resolved (possibly decrypted) message.
+type MessageEdit struct {
+	Protocol          *waE2E.ProtocolMessage
+	Edited            *waE2E.Message
+	OriginalMessageID string
+}
+
+// IsSecretEncryptedEdit reports whether msg (after unwrap) is a SecretEncryptedMessage with MESSAGE_EDIT.
+func IsSecretEncryptedEdit(msg *waE2E.Message) bool {
+	if msg == nil {
+		return false
+	}
+	unwrapped := utils.UnwrapMessage(msg)
+	sem := unwrapped.GetSecretEncryptedMessage()
+	return sem != nil && sem.GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT
+}
+
+// ResolveIncomingMessage unwraps evt.Message and decrypts SecretEncryptedMessage(MESSAGE_EDIT) when present.
+func ResolveIncomingMessage(ctx context.Context, client *whatsmeow.Client, evt *events.Message) (*waE2E.Message, error) {
+	if evt == nil || evt.Message == nil {
+		return nil, nil
+	}
+
+	msg := utils.UnwrapMessage(evt.Message)
+
+	sem := msg.GetSecretEncryptedMessage()
+	if sem == nil || sem.GetSecretEncType() != waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
+		return msg, nil
+	}
+
+	if client == nil {
+		logrus.Errorf("SecretEncryptedMessage(MESSAGE_EDIT) for %s requires a connected client", evt.Info.ID)
+		return nil, fmt.Errorf("%w: no client", ErrSecretEditDecrypt)
+	}
+
+	decrypted, err := client.DecryptSecretEncryptedMessage(ctx, evt)
+	if err != nil {
+		logrus.Errorf("Failed to decrypt SecretEncryptedMessage(MESSAGE_EDIT) for %s: %v", evt.Info.ID, err)
+		return nil, fmt.Errorf("%w: %v", ErrSecretEditDecrypt, err)
+	}
+	if decrypted == nil {
+		logrus.Errorf("DecryptSecretEncryptedMessage returned nil for %s", evt.Info.ID)
+		return nil, fmt.Errorf("%w: nil decrypted message", ErrSecretEditDecrypt)
+	}
+
+	return utils.UnwrapMessage(decrypted), nil
+}
+
+// ExtractMessageEdit returns edit metadata when msg contains ProtocolMessage MESSAGE_EDIT.
+func ExtractMessageEdit(msg *waE2E.Message) *MessageEdit {
+	if msg == nil {
+		return nil
+	}
+	protocolMessage := msg.GetProtocolMessage()
+	if protocolMessage == nil || protocolMessage.GetType() != waE2E.ProtocolMessage_MESSAGE_EDIT {
+		return nil
+	}
+	editedMessage := protocolMessage.GetEditedMessage()
+	if editedMessage == nil {
+		return nil
+	}
+
+	originalMessageID := ""
+	if key := protocolMessage.GetKey(); key != nil {
+		originalMessageID = key.GetID()
+	}
+
+	return &MessageEdit{
+		Protocol:          protocolMessage,
+		Edited:            editedMessage,
+		OriginalMessageID: originalMessageID,
+	}
+}
+
+// ExtractEditBody returns the new text content from an edited message proto.
+func ExtractEditBody(edited *waE2E.Message) string {
+	return utils.ExtractMessageTextFromProto(edited)
+}

--- a/src/infrastructure/whatsapp/message_edit_test.go
+++ b/src/infrastructure/whatsapp/message_edit_test.go
@@ -1,0 +1,117 @@
+package whatsapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func TestIsSecretEncryptedEdit(t *testing.T) {
+	assert.False(t, IsSecretEncryptedEdit(nil))
+	assert.False(t, IsSecretEncryptedEdit(&waE2E.Message{
+		Conversation: protoString("hello"),
+	}))
+
+	assert.True(t, IsSecretEncryptedEdit(&waE2E.Message{
+		SecretEncryptedMessage: &waE2E.SecretEncryptedMessage{
+			SecretEncType: waE2E.SecretEncryptedMessage_MESSAGE_EDIT.Enum(),
+		},
+	}))
+}
+
+func TestExtractMessageEdit(t *testing.T) {
+	assert.Nil(t, ExtractMessageEdit(nil))
+	assert.Nil(t, ExtractMessageEdit(&waE2E.Message{Conversation: protoString("x")}))
+
+	edit := ExtractMessageEdit(&waE2E.Message{
+		ProtocolMessage: &waE2E.ProtocolMessage{
+			Type: waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+			Key: &waCommon.MessageKey{
+				ID: protoString("ORIG-1"),
+			},
+			EditedMessage: &waE2E.Message{
+				Conversation: protoString("updated text"),
+			},
+		},
+	})
+	require.NotNil(t, edit)
+	assert.Equal(t, "ORIG-1", edit.OriginalMessageID)
+	assert.Equal(t, "updated text", ExtractEditBody(edit.Edited))
+}
+
+func TestResolveIncomingMessagePlainEdit(t *testing.T) {
+	evt := &events.Message{
+		Info: types.MessageInfo{ID: "EVT-1"},
+		Message: &waE2E.Message{
+			ProtocolMessage: &waE2E.ProtocolMessage{
+				Type: waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+				Key:  &waCommon.MessageKey{ID: protoString("ORIG-2")},
+				EditedMessage: &waE2E.Message{
+					ExtendedTextMessage: &waE2E.ExtendedTextMessage{
+						Text: protoString("extended update"),
+					},
+				},
+			},
+		},
+	}
+
+	resolved, err := ResolveIncomingMessage(context.Background(), nil, evt)
+	require.NoError(t, err)
+	edit := ExtractMessageEdit(resolved)
+	require.NotNil(t, edit)
+	assert.Equal(t, "extended update", ExtractEditBody(edit.Edited))
+}
+
+func TestResolveIncomingMessageSecretEditNoClient(t *testing.T) {
+	evt := &events.Message{
+		Info: types.MessageInfo{ID: "EVT-SEC"},
+		Message: &waE2E.Message{
+			SecretEncryptedMessage: &waE2E.SecretEncryptedMessage{
+				SecretEncType: waE2E.SecretEncryptedMessage_MESSAGE_EDIT.Enum(),
+			},
+		},
+	}
+
+	_, err := ResolveIncomingMessage(context.Background(), nil, evt)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSecretEditDecrypt)
+}
+
+func TestBuildEventPayloadMessageEdited(t *testing.T) {
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     types.NewJID("123", types.DefaultUserServer),
+				Sender:   types.NewJID("456", types.DefaultUserServer),
+				IsFromMe: false,
+			},
+			ID:        "EDIT-EVT",
+			PushName:  "Alice",
+			Timestamp: time.Date(2026, time.May, 29, 4, 58, 11, 0, time.UTC),
+		},
+		Message: &waE2E.Message{
+			ProtocolMessage: &waE2E.ProtocolMessage{
+				Type: waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+				Key: &waCommon.MessageKey{
+					ID: protoString("ORIG-MSG"),
+				},
+				EditedMessage: &waE2E.Message{
+					Conversation: protoString("new body text"),
+				},
+			},
+		},
+	}
+
+	eventType, payload, err := buildEventPayload(context.Background(), nil, evt)
+	require.NoError(t, err)
+	assert.Equal(t, EventTypeMessageEdited, eventType)
+	assert.Equal(t, "ORIG-MSG", payload["original_message_id"])
+	assert.Equal(t, "new body text", payload["body"])
+}

--- a/src/pkg/utils/whatsapp.go
+++ b/src/pkg/utils/whatsapp.go
@@ -729,8 +729,10 @@ func BuildEventMessage(evt *events.Message) (message EvtMessage) {
 		message.Text = extendedMessage.GetText()
 	} else if protocolMessage := msg.GetProtocolMessage(); protocolMessage != nil {
 		if editedMessage := protocolMessage.GetEditedMessage(); editedMessage != nil {
-			if extendedText := editedMessage.GetExtendedTextMessage(); extendedText != nil {
+			if extendedText := editedMessage.GetExtendedTextMessage(); extendedText != nil && extendedText.GetText() != "" {
 				message.Text = extendedText.GetText()
+			} else if conv := editedMessage.GetConversation(); conv != "" {
+				message.Text = conv
 			}
 			if ci := ExtractContextInfo(editedMessage); ci != nil {
 				message.RepliedId = ci.GetStanzaID()

--- a/src/views/components/ChatMessages.js
+++ b/src/views/components/ChatMessages.js
@@ -161,6 +161,26 @@ export default {
       if (message.media_type) return `[${message.media_type.toUpperCase()}]`;
       return "[No content]";
     },
+    applyMessageEdit(result) {
+      if (!result || !result.original_message_id) {
+        return;
+      }
+      const chatJid = result.chat_jid || "";
+      if (chatJid && this.formattedJid && chatJid !== this.formattedJid) {
+        return;
+      }
+      const message = this.messages.find(
+        (m) => m.id === result.original_message_id
+      );
+      if (!message) {
+        return;
+      }
+      const newContent = result.new_content ?? "";
+      message.content = newContent;
+      if ("text" in message) {
+        message.text = newContent;
+      }
+    },
     getMediaDisplay(message) {
       if (!message.media_type || !message.url || !message.id) {
         return null;

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -409,6 +409,11 @@
                             }
                             break;
                         }
+                        case 'MESSAGE_EDITED':
+                            if (window.ChatMessagesComponent?.applyMessageEdit) {
+                                window.ChatMessagesComponent.applyMessageEdit(message.result);
+                            }
+                            break;
                         default:
                             console.log(message)
                     }


### PR DESCRIPTION
- Add message_edit helpers to decrypt SecretEncryptedMessage(MESSAGE_EDIT) and parse MESSAGE_EDIT protocol payloads
- Route webhook buildEventPayload through ResolveIncomingMessage so edits emit message.edited with body instead of message
- Propagate device context into webhook goroutine for reliable LID/decrypt handling
- Update CreateMessage/storeEditedMessage to resolve encrypted edits before persisting to messages and message_edits
- Broadcast MESSAGE_EDITED over websocket and refresh ChatMessages in the embedded UI
- Add Conversation fallback in BuildEventMessage for edited text extraction
- Add unit tests for edit helpers, webhook payload, and secret-encrypted edit without client

# PR Title

## Context

It resolve: https://github.com/aldinokemal/go-whatsapp-web-multidevice/issues/700

## Test Results
<!--
- Attach the screenshot of the result or something
-->
- what you have done to test it

It resolve: https://github.com/aldinokemal/go-whatsapp-web-multidevice/issues/700
