### PR TITLE
feat(send): support quoted media replies

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -901,6 +901,10 @@ paths:
                   type: string
                   example: selamat malam
                   description: Caption to send
+                reply_message_id:
+                  type: string
+                  example: 3EB089B9D6ADD58153C561
+                  description: Message ID that you want reply
                 view_once:
                   type: boolean
                   example: false
@@ -970,6 +974,10 @@ paths:
                   type: string
                   example: https://example.com/audio.mp3
                   description: Audio URL to send
+                reply_message_id:
+                  type: string
+                  example: 3EB089B9D6ADD58153C561
+                  description: Message ID that you want reply
                 is_forwarded:
                   type: boolean
                   example: false
@@ -1019,6 +1027,10 @@ paths:
                   type: string
                   example: selamat malam
                   description: Caption to send
+                reply_message_id:
+                  type: string
+                  example: 3EB089B9D6ADD58153C561
+                  description: Message ID that you want reply
                 file:
                   type: string
                   format: binary
@@ -1126,6 +1138,10 @@ paths:
                   type: string
                   example: ini contoh caption video
                   description: Caption to send
+                reply_message_id:
+                  type: string
+                  example: 3EB089B9D6ADD58153C561
+                  description: Message ID that you want reply
                 view_once:
                   type: boolean
                   example: false

--- a/src/domains/chatstorage/interfaces.go
+++ b/src/domains/chatstorage/interfaces.go
@@ -26,7 +26,8 @@ type IChatStorageRepository interface {
 	StoreMessage(message *Message) error
 	StoreMessageEdit(edit *MessageEdit) error
 	StoreMessagesBatch(messages []*Message) error
-	GetMessageByID(id string) (*Message, error) // New method for efficient ID-only search
+	GetMessageByID(id string) (*Message, error)                    // New method for efficient ID-only search
+	GetMessageByIDAndDevice(deviceID, id string) (*Message, error) // Device-scoped ID lookup for device-isolated flows
 	GetMessageEdits(originalMessageID, deviceID string) ([]*MessageEdit, error)
 	GetMessages(filter *MessageFilter) ([]*Message, error)
 	SearchMessages(deviceID, chatJID, searchText string, limit int) ([]*Message, error) // Database-level search with device isolation

--- a/src/domains/send/audio.go
+++ b/src/domains/send/audio.go
@@ -4,7 +4,8 @@ import "mime/multipart"
 
 type AudioRequest struct {
 	BaseRequest
-	Audio    *multipart.FileHeader `json:"audio" form:"audio"`
-	AudioURL *string               `json:"audio_url" form:"audio_url"`
-	PTT      bool                  `json:"ptt" form:"ptt"`
+	Audio          *multipart.FileHeader `json:"audio" form:"audio"`
+	AudioURL       *string               `json:"audio_url" form:"audio_url"`
+	ReplyMessageID *string               `json:"reply_message_id" form:"reply_message_id"`
+	PTT            bool                  `json:"ptt" form:"ptt"`
 }

--- a/src/domains/send/file.go
+++ b/src/domains/send/file.go
@@ -4,7 +4,8 @@ import "mime/multipart"
 
 type FileRequest struct {
 	BaseRequest
-	File    *multipart.FileHeader `json:"file" form:"file"`
-	FileURL *string               `json:"file_url" form:"file_url"`
-	Caption string                `json:"caption" form:"caption"`
+	File           *multipart.FileHeader `json:"file" form:"file"`
+	FileURL        *string               `json:"file_url" form:"file_url"`
+	Caption        string                `json:"caption" form:"caption"`
+	ReplyMessageID *string               `json:"reply_message_id" form:"reply_message_id"`
 }

--- a/src/domains/send/image.go
+++ b/src/domains/send/image.go
@@ -4,9 +4,10 @@ import "mime/multipart"
 
 type ImageRequest struct {
 	BaseRequest
-	Caption  string                `json:"caption" form:"caption"`
-	Image    *multipart.FileHeader `json:"image" form:"image"`
-	ImageURL *string               `json:"image_url" form:"image_url"`
-	ViewOnce bool                  `json:"view_once" form:"view_once"`
-	Compress bool                  `json:"compress"`
+	Caption        string                `json:"caption" form:"caption"`
+	ReplyMessageID *string               `json:"reply_message_id" form:"reply_message_id"`
+	Image          *multipart.FileHeader `json:"image" form:"image"`
+	ImageURL       *string               `json:"image_url" form:"image_url"`
+	ViewOnce       bool                  `json:"view_once" form:"view_once"`
+	Compress       bool                  `json:"compress"`
 }

--- a/src/domains/send/video.go
+++ b/src/domains/send/video.go
@@ -4,10 +4,11 @@ import "mime/multipart"
 
 type VideoRequest struct {
 	BaseRequest
-	Caption     string                `json:"caption" form:"caption"`
-	Video       *multipart.FileHeader `json:"video" form:"video"`
-	ViewOnce    bool                  `json:"view_once" form:"view_once"`
-	Compress    bool                  `json:"compress"`
-	GifPlayback bool                  `json:"gif_playback" form:"gif_playback"`
-	VideoURL    *string               `json:"video_url" form:"video_url"`
+	Caption        string                `json:"caption" form:"caption"`
+	ReplyMessageID *string               `json:"reply_message_id" form:"reply_message_id"`
+	Video          *multipart.FileHeader `json:"video" form:"video"`
+	ViewOnce       bool                  `json:"view_once" form:"view_once"`
+	Compress       bool                  `json:"compress"`
+	GifPlayback    bool                  `json:"gif_playback" form:"gif_playback"`
+	VideoURL       *string               `json:"video_url" form:"video_url"`
 }

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -103,6 +103,26 @@ func (r *SQLiteRepository) GetMessageByID(id string) (*domainChatStorage.Message
 	return message, err
 }
 
+// GetMessageByIDAndDevice retrieves a message by its ID scoped to a specific device,
+// so a message ID belonging to another device cannot be read from device-isolated flows.
+func (r *SQLiteRepository) GetMessageByIDAndDevice(deviceID, id string) (*domainChatStorage.Message, error) {
+	query := `
+		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
+			media_type, call_metadata, filename, url, media_key, file_sha256,
+			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
+		FROM messages
+		WHERE id = ? AND device_id = ?
+		LIMIT 1
+	`
+
+	message, err := r.scanMessage(r.db.QueryRow(query, id, deviceID))
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+
+	return message, err
+}
+
 // GetMessageEdits returns the edit history for a specific message.
 func (r *SQLiteRepository) GetMessageEdits(originalMessageID, deviceID string) ([]*domainChatStorage.MessageEdit, error) {
 	query := `

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -95,6 +95,14 @@ func (r *deviceChatStorage) GetMessageByID(id string) (*domainChatStorage.Messag
 	return r.base.GetMessageByID(id)
 }
 
+func (r *deviceChatStorage) GetMessageByIDAndDevice(deviceID, id string) (*domainChatStorage.Message, error) {
+	targetDeviceID := deviceID
+	if targetDeviceID == "" {
+		targetDeviceID = r.deviceID
+	}
+	return r.base.GetMessageByIDAndDevice(targetDeviceID, id)
+}
+
 func (r *deviceChatStorage) GetMessageEdits(originalMessageID, deviceID string) ([]*domainChatStorage.MessageEdit, error) {
 	targetDeviceID := deviceID
 	if targetDeviceID == "" {

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -84,6 +84,32 @@ func (service serviceSend) wrapSendMessage(ctx context.Context, client *whatsmeo
 	return ts, nil
 }
 
+func (service serviceSend) mergeReplyContext(contextInfo *waE2E.ContextInfo, replyMessageID *string) *waE2E.ContextInfo {
+	if replyMessageID == nil || *replyMessageID == "" {
+		return contextInfo
+	}
+
+	message, err := service.chatStorageRepo.GetMessageByID(*replyMessageID)
+	if err != nil {
+		logrus.Warnf("Error retrieving reply message ID %s: %v, continuing without reply context", *replyMessageID, err)
+		return contextInfo
+	}
+	if message == nil {
+		logrus.Warnf("Reply message ID %s not found in storage, continuing without reply context", *replyMessageID)
+		return contextInfo
+	}
+
+	if contextInfo == nil {
+		contextInfo = &waE2E.ContextInfo{}
+	}
+	contextInfo.StanzaID = replyMessageID
+	contextInfo.Participant = proto.String(message.Sender)
+	contextInfo.QuotedMessage = &waE2E.Message{
+		Conversation: proto.String(message.Content),
+	}
+	return contextInfo
+}
+
 func normalizeSendError(err error) error {
 	if err == nil {
 		return nil
@@ -146,53 +172,7 @@ func (service serviceSend) SendText(ctx context.Context, request domainSend.Mess
 		msg.ExtendedTextMessage.ContextInfo.MentionedJID = parsedMentions
 	}
 
-	// Reply message
-	if request.ReplyMessageID != nil && *request.ReplyMessageID != "" {
-		message, err := service.chatStorageRepo.GetMessageByID(*request.ReplyMessageID)
-		if err != nil {
-			logrus.Warnf("Error retrieving reply message ID %s: %v, continuing without reply context", *request.ReplyMessageID, err)
-		} else if message != nil { // Only set reply context if we found the message
-			// Ensure we use a full JID (user@server) for the Participant field
-			// Use the sender JID from storage as-is. Modern storage should already provide
-			// fully-qualified JIDs (e.g., user@s.whatsapp.net or group@g.us). Avoid mutating
-			// the JID here to prevent corrupting valid group or special JIDs.
-			participantJID := message.Sender
-
-			// Build base ContextInfo with reply details
-			ctxInfo := &waE2E.ContextInfo{
-				StanzaID:    request.ReplyMessageID,
-				Participant: proto.String(participantJID),
-				QuotedMessage: &waE2E.Message{
-					Conversation: proto.String(message.Content),
-				},
-			}
-
-			// Preserve forwarding flag if set
-			if request.BaseRequest.IsForwarded {
-				ctxInfo.IsForwarded = proto.Bool(true)
-				ctxInfo.ForwardingScore = proto.Uint32(100)
-			}
-
-			// Preserve disappearing message duration if provided
-			if request.BaseRequest.Duration != nil && *request.BaseRequest.Duration > 0 {
-				ctxInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
-			} else {
-				ctxInfo.Expiration = proto.Uint32(service.getDefaultEphemeralExpiration(participantJID))
-			}
-
-			// Preserve mentions
-			if len(parsedMentions) > 0 {
-				ctxInfo.MentionedJID = parsedMentions
-			}
-
-			msg.ExtendedTextMessage = &waE2E.ExtendedTextMessage{
-				Text:        proto.String(request.Message),
-				ContextInfo: ctxInfo,
-			}
-		} else {
-			logrus.Warnf("Reply message ID %s not found in storage, continuing without reply context", *request.ReplyMessageID)
-		}
-	}
+	msg.ExtendedTextMessage.ContextInfo = service.mergeReplyContext(msg.ExtendedTextMessage.ContextInfo, request.ReplyMessageID)
 
 	ts, err := service.wrapSendMessage(ctx, client, dataWaRecipient, msg, request.Message)
 	if err != nil {
@@ -351,6 +331,7 @@ func (service serviceSend) SendImage(ctx context.Context, request domainSend.Ima
 		}
 		msg.ImageMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
 	}
+	msg.ImageMessage.ContextInfo = service.mergeReplyContext(msg.ImageMessage.ContextInfo, request.ReplyMessageID)
 
 	caption := "🖼️ Image"
 	if request.Caption != "" {
@@ -442,6 +423,7 @@ func (service serviceSend) SendFile(ctx context.Context, request domainSend.File
 		}
 		msg.DocumentMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
 	}
+	msg.DocumentMessage.ContextInfo = service.mergeReplyContext(msg.DocumentMessage.ContextInfo, request.ReplyMessageID)
 
 	caption := "📄 Document"
 	if fileName != "" {
@@ -901,6 +883,7 @@ func (service serviceSend) SendVideo(ctx context.Context, request domainSend.Vid
 		}
 		msg.VideoMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
 	}
+	msg.VideoMessage.ContextInfo = service.mergeReplyContext(msg.VideoMessage.ContextInfo, request.ReplyMessageID)
 
 	caption := "🎥 Video"
 	if request.Caption != "" {
@@ -1301,6 +1284,7 @@ func (service serviceSend) SendAudio(ctx context.Context, request domainSend.Aud
 		}
 		msg.AudioMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
 	}
+	msg.AudioMessage.ContextInfo = service.mergeReplyContext(msg.AudioMessage.ContextInfo, request.ReplyMessageID)
 
 	content := "🎵 Audio"
 

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -84,12 +84,14 @@ func (service serviceSend) wrapSendMessage(ctx context.Context, client *whatsmeo
 	return ts, nil
 }
 
-func (service serviceSend) mergeReplyContext(contextInfo *waE2E.ContextInfo, replyMessageID *string) *waE2E.ContextInfo {
+func (service serviceSend) mergeReplyContext(ctx context.Context, contextInfo *waE2E.ContextInfo, replyMessageID *string) *waE2E.ContextInfo {
 	if replyMessageID == nil || *replyMessageID == "" {
 		return contextInfo
 	}
 
-	message, err := service.chatStorageRepo.GetMessageByID(*replyMessageID)
+	// Scope the reply lookup to the active device so a message ID from another
+	// device cannot be bound as quote context (see usecase AGENTS.md).
+	message, err := service.chatStorageRepo.GetMessageByIDAndDevice(deviceIDFromContext(ctx), *replyMessageID)
 	if err != nil {
 		logrus.Warnf("Error retrieving reply message ID %s: %v, continuing without reply context", *replyMessageID, err)
 		return contextInfo
@@ -172,7 +174,7 @@ func (service serviceSend) SendText(ctx context.Context, request domainSend.Mess
 		msg.ExtendedTextMessage.ContextInfo.MentionedJID = parsedMentions
 	}
 
-	msg.ExtendedTextMessage.ContextInfo = service.mergeReplyContext(msg.ExtendedTextMessage.ContextInfo, request.ReplyMessageID)
+	msg.ExtendedTextMessage.ContextInfo = service.mergeReplyContext(ctx, msg.ExtendedTextMessage.ContextInfo, request.ReplyMessageID)
 
 	ts, err := service.wrapSendMessage(ctx, client, dataWaRecipient, msg, request.Message)
 	if err != nil {
@@ -331,7 +333,7 @@ func (service serviceSend) SendImage(ctx context.Context, request domainSend.Ima
 		}
 		msg.ImageMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
 	}
-	msg.ImageMessage.ContextInfo = service.mergeReplyContext(msg.ImageMessage.ContextInfo, request.ReplyMessageID)
+	msg.ImageMessage.ContextInfo = service.mergeReplyContext(ctx, msg.ImageMessage.ContextInfo, request.ReplyMessageID)
 
 	caption := "🖼️ Image"
 	if request.Caption != "" {
@@ -423,7 +425,7 @@ func (service serviceSend) SendFile(ctx context.Context, request domainSend.File
 		}
 		msg.DocumentMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
 	}
-	msg.DocumentMessage.ContextInfo = service.mergeReplyContext(msg.DocumentMessage.ContextInfo, request.ReplyMessageID)
+	msg.DocumentMessage.ContextInfo = service.mergeReplyContext(ctx, msg.DocumentMessage.ContextInfo, request.ReplyMessageID)
 
 	caption := "📄 Document"
 	if fileName != "" {
@@ -883,7 +885,7 @@ func (service serviceSend) SendVideo(ctx context.Context, request domainSend.Vid
 		}
 		msg.VideoMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
 	}
-	msg.VideoMessage.ContextInfo = service.mergeReplyContext(msg.VideoMessage.ContextInfo, request.ReplyMessageID)
+	msg.VideoMessage.ContextInfo = service.mergeReplyContext(ctx, msg.VideoMessage.ContextInfo, request.ReplyMessageID)
 
 	caption := "🎥 Video"
 	if request.Caption != "" {
@@ -1284,7 +1286,7 @@ func (service serviceSend) SendAudio(ctx context.Context, request domainSend.Aud
 		}
 		msg.AudioMessage.ContextInfo.Expiration = proto.Uint32(uint32(*request.BaseRequest.Duration))
 	}
-	msg.AudioMessage.ContextInfo = service.mergeReplyContext(msg.AudioMessage.ContextInfo, request.ReplyMessageID)
+	msg.AudioMessage.ContextInfo = service.mergeReplyContext(ctx, msg.AudioMessage.ContextInfo, request.ReplyMessageID)
 
 	content := "🎵 Audio"
 

--- a/src/usecase/send_test.go
+++ b/src/usecase/send_test.go
@@ -16,12 +16,14 @@ import (
 
 type replyMessageRepo struct {
 	domainChatStorage.IChatStorageRepository
-	message *domainChatStorage.Message
-	err     error
-	gotID   string
+	message     *domainChatStorage.Message
+	err         error
+	gotID       string
+	gotDeviceID string
 }
 
-func (r *replyMessageRepo) GetMessageByID(id string) (*domainChatStorage.Message, error) {
+func (r *replyMessageRepo) GetMessageByIDAndDevice(deviceID, id string) (*domainChatStorage.Message, error) {
+	r.gotDeviceID = deviceID
 	r.gotID = id
 	return r.message, r.err
 }
@@ -110,13 +112,18 @@ func TestMergeReplyContextAddsQuoteFields(t *testing.T) {
 	service := serviceSend{chatStorageRepo: repo}
 	contextInfo := &waE2E.ContextInfo{}
 
-	got := service.mergeReplyContext(contextInfo, &replyID)
+	deviceID := "6289605618749@s.whatsapp.net"
+	ctx := whatsapp.ContextWithDevice(context.Background(), whatsapp.NewDeviceInstance(deviceID, nil, nil))
+	got := service.mergeReplyContext(ctx, contextInfo, &replyID)
 
 	if got != contextInfo {
 		t.Fatal("expected existing context info to be reused")
 	}
 	if repo.gotID != replyID {
 		t.Fatalf("expected lookup for reply ID %q, got %q", replyID, repo.gotID)
+	}
+	if repo.gotDeviceID != deviceID {
+		t.Fatalf("expected device-scoped lookup for %q, got %q", deviceID, repo.gotDeviceID)
 	}
 	if got.GetStanzaID() != replyID {
 		t.Fatalf("expected stanza ID %q, got %q", replyID, got.GetStanzaID())
@@ -145,7 +152,7 @@ func TestMergeReplyContextPreservesExistingContext(t *testing.T) {
 		MentionedJID:    []string{"628999999999@s.whatsapp.net"},
 	}
 
-	got := service.mergeReplyContext(contextInfo, &replyID)
+	got := service.mergeReplyContext(context.Background(), contextInfo, &replyID)
 
 	if !got.GetIsForwarded() {
 		t.Fatal("expected forwarded flag to be preserved")
@@ -199,7 +206,7 @@ func TestMergeReplyContextLeavesExistingContextWhenReplyUnavailable(t *testing.T
 				err:     tt.err,
 			}}
 
-			got := service.mergeReplyContext(contextInfo, tt.replyID)
+			got := service.mergeReplyContext(context.Background(), contextInfo, tt.replyID)
 
 			if got != contextInfo {
 				t.Fatal("expected existing context info to be reused")

--- a/src/usecase/send_test.go
+++ b/src/usecase/send_test.go
@@ -6,10 +6,25 @@ import (
 	"net/http"
 	"testing"
 
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
 )
+
+type replyMessageRepo struct {
+	domainChatStorage.IChatStorageRepository
+	message *domainChatStorage.Message
+	err     error
+	gotID   string
+}
+
+func (r *replyMessageRepo) GetMessageByID(id string) (*domainChatStorage.Message, error) {
+	r.gotID = id
+	return r.message, r.err
+}
 
 func TestWithoutCancelPreservesDeviceContext(t *testing.T) {
 	deviceID := "6289605618749@s.whatsapp.net"
@@ -81,5 +96,123 @@ func TestNormalizeSendErrorMapsReachoutTimelock(t *testing.T) {
 	}
 	if got := genericErr.Error(); got != string(pkgError.ErrWaReachoutTimelock) {
 		t.Fatalf("unexpected error message: %q", got)
+	}
+}
+
+func TestMergeReplyContextAddsQuoteFields(t *testing.T) {
+	replyID := "3EB089B9D6ADD58153C561"
+	repo := &replyMessageRepo{
+		message: &domainChatStorage.Message{
+			Sender:  "628123456789@s.whatsapp.net",
+			Content: "quoted message body",
+		},
+	}
+	service := serviceSend{chatStorageRepo: repo}
+	contextInfo := &waE2E.ContextInfo{}
+
+	got := service.mergeReplyContext(contextInfo, &replyID)
+
+	if got != contextInfo {
+		t.Fatal("expected existing context info to be reused")
+	}
+	if repo.gotID != replyID {
+		t.Fatalf("expected lookup for reply ID %q, got %q", replyID, repo.gotID)
+	}
+	if got.GetStanzaID() != replyID {
+		t.Fatalf("expected stanza ID %q, got %q", replyID, got.GetStanzaID())
+	}
+	if got.GetParticipant() != "628123456789@s.whatsapp.net" {
+		t.Fatalf("unexpected participant: %q", got.GetParticipant())
+	}
+	if got.GetQuotedMessage().GetConversation() != "quoted message body" {
+		t.Fatalf("unexpected quoted body: %q", got.GetQuotedMessage().GetConversation())
+	}
+}
+
+func TestMergeReplyContextPreservesExistingContext(t *testing.T) {
+	replyID := "3EB089B9D6ADD58153C561"
+	repo := &replyMessageRepo{
+		message: &domainChatStorage.Message{
+			Sender:  "628123456789@s.whatsapp.net",
+			Content: "quoted message body",
+		},
+	}
+	service := serviceSend{chatStorageRepo: repo}
+	contextInfo := &waE2E.ContextInfo{
+		IsForwarded:     proto.Bool(true),
+		ForwardingScore: proto.Uint32(100),
+		Expiration:      proto.Uint32(3600),
+		MentionedJID:    []string{"628999999999@s.whatsapp.net"},
+	}
+
+	got := service.mergeReplyContext(contextInfo, &replyID)
+
+	if !got.GetIsForwarded() {
+		t.Fatal("expected forwarded flag to be preserved")
+	}
+	if got.GetForwardingScore() != 100 {
+		t.Fatalf("expected forwarding score 100, got %d", got.GetForwardingScore())
+	}
+	if got.GetExpiration() != 3600 {
+		t.Fatalf("expected expiration 3600, got %d", got.GetExpiration())
+	}
+	if len(got.GetMentionedJID()) != 1 || got.GetMentionedJID()[0] != "628999999999@s.whatsapp.net" {
+		t.Fatalf("expected mentioned JIDs to be preserved, got %#v", got.GetMentionedJID())
+	}
+	if got.GetQuotedMessage().GetConversation() != "quoted message body" {
+		t.Fatalf("unexpected quoted body: %q", got.GetQuotedMessage().GetConversation())
+	}
+}
+
+func TestMergeReplyContextLeavesExistingContextWhenReplyUnavailable(t *testing.T) {
+	replyID := "3EB089B9D6ADD58153C561"
+
+	tests := []struct {
+		name    string
+		replyID *string
+		message *domainChatStorage.Message
+		err     error
+	}{
+		{
+			name: "nil reply ID",
+		},
+		{
+			name:    "empty reply ID",
+			replyID: proto.String(""),
+		},
+		{
+			name:    "message not found",
+			replyID: &replyID,
+		},
+		{
+			name:    "lookup error",
+			replyID: &replyID,
+			err:     errors.New("storage unavailable"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contextInfo := &waE2E.ContextInfo{Expiration: proto.Uint32(3600)}
+			service := serviceSend{chatStorageRepo: &replyMessageRepo{
+				message: tt.message,
+				err:     tt.err,
+			}}
+
+			got := service.mergeReplyContext(contextInfo, tt.replyID)
+
+			if got != contextInfo {
+				t.Fatal("expected existing context info to be reused")
+			}
+			if got.GetExpiration() != 3600 {
+				t.Fatalf("expected expiration to remain 3600, got %d", got.GetExpiration())
+			}
+			if got.GetStanzaID() != "" {
+				t.Fatalf("expected no stanza ID, got %q", got.GetStanzaID())
+			}
+			if got.GetQuotedMessage() != nil {
+				t.Fatalf("expected no quoted message, got %#v", got.GetQuotedMessage())
+			}
+		})
 	}
 }

--- a/src/validations/send_validation_test.go
+++ b/src/validations/send_validation_test.go
@@ -66,6 +66,7 @@ func TestValidateSendImage(t *testing.T) {
 		Size:     100,
 		Header:   map[string][]string{"Content-Type": {"image/png"}},
 	}
+	replyMessageID := "3EB089B9D6ADD58153C561"
 
 	type args struct {
 		request domainSend.ImageRequest
@@ -81,8 +82,9 @@ func TestValidateSendImage(t *testing.T) {
 				BaseRequest: domainSend.BaseRequest{
 					Phone: "1728937129312@s.whatsapp.net",
 				},
-				Caption: "Hello this is testing",
-				Image:   image,
+				Caption:        "Hello this is testing",
+				ReplyMessageID: &replyMessageID,
+				Image:          image,
 			}},
 			err: nil,
 		},
@@ -136,6 +138,7 @@ func TestValidateSendFile(t *testing.T) {
 		Size:     100,
 		Header:   map[string][]string{"Content-Type": {"image/png"}},
 	}
+	replyMessageID := "3EB089B9D6ADD58153C561"
 
 	type args struct {
 		request domainSend.FileRequest
@@ -151,7 +154,8 @@ func TestValidateSendFile(t *testing.T) {
 				BaseRequest: domainSend.BaseRequest{
 					Phone: "1728937129312@s.whatsapp.net",
 				},
-				File: file,
+				File:           file,
+				ReplyMessageID: &replyMessageID,
 			}},
 			err: nil,
 		},
@@ -191,6 +195,7 @@ func TestValidateSendVideo(t *testing.T) {
 		Size:     100,
 		Header:   map[string][]string{"Content-Type": {"video/mp4"}},
 	}
+	replyMessageID := "3EB089B9D6ADD58153C561"
 
 	type args struct {
 		request domainSend.VideoRequest
@@ -206,10 +211,11 @@ func TestValidateSendVideo(t *testing.T) {
 				BaseRequest: domainSend.BaseRequest{
 					Phone: "1728937129312@s.whatsapp.net",
 				},
-				Caption:  "simple caption",
-				Video:    file,
-				ViewOnce: false,
-				Compress: false,
+				Caption:        "simple caption",
+				ReplyMessageID: &replyMessageID,
+				Video:          file,
+				ViewOnce:       false,
+				Compress:       false,
 			}},
 			err: nil,
 		},
@@ -633,6 +639,7 @@ func TestValidateSendAudio(t *testing.T) {
 		Size:     100,
 		Header:   map[string][]string{"Content-Type": {"audio/mp3"}},
 	}
+	replyMessageID := "3EB089B9D6ADD58153C561"
 
 	type args struct {
 		request domainSend.AudioRequest
@@ -648,7 +655,8 @@ func TestValidateSendAudio(t *testing.T) {
 				BaseRequest: domainSend.BaseRequest{
 					Phone: "1728937129312@s.whatsapp.net",
 				},
-				Audio: audio,
+				Audio:          audio,
+				ReplyMessageID: &replyMessageID,
 			}},
 			err: nil,
 		},

--- a/src/views/components/SendAudio.js
+++ b/src/views/components/SendAudio.js
@@ -12,6 +12,7 @@ export default {
             loading: false,
             selectedFileName: null,
             is_forwarded: false,
+            reply_message_id: '',
             audio_url: null,
             duration: 0,
             ptt: false,
@@ -29,6 +30,9 @@ export default {
                     return false;
                 }
             }).modal('show');
+        },
+        isShowAttributes() {
+            return this.type !== window.TYPESTATUS;
         },
         isValidForm() {
             if (this.type !== window.TYPEUSER && !this.phone.trim()) {
@@ -61,6 +65,9 @@ export default {
                 payload.append("phone", this.phone_id)
                 payload.append("is_forwarded", this.is_forwarded)
                 payload.append("ptt", this.ptt)
+                if (this.reply_message_id !== '') {
+                    payload.append("reply_message_id", this.reply_message_id)
+                }
                 if (this.duration && this.duration > 0) {
                     payload.append("duration", this.duration)
                 }
@@ -90,6 +97,7 @@ export default {
             this.phone = '';
             this.type = window.TYPEUSER;
             this.is_forwarded = false;
+            this.reply_message_id = '';
             this.duration = 0;
             this.ptt = false;
             $("#file_audio").val('');
@@ -123,6 +131,12 @@ export default {
         <div class="content">
             <form class="ui form">
                 <FormRecipient v-model:type="type" v-model:phone="phone"/>
+                <div class="field" v-if="isShowAttributes()">
+                    <label>Reply Message ID</label>
+                    <input v-model="reply_message_id" type="text"
+                           placeholder="Optional: 57D29F74B7FC62F57D8AC2C840279B5B/3EB0288F008D32FCD0A424"
+                           aria-label="reply_message_id">
+                </div>
                 <div class="field">
                     <label>Is Forwarded</label>
                     <div class="ui toggle checkbox">

--- a/src/views/components/SendAudio.js
+++ b/src/views/components/SendAudio.js
@@ -65,8 +65,9 @@ export default {
                 payload.append("phone", this.phone_id)
                 payload.append("is_forwarded", this.is_forwarded)
                 payload.append("ptt", this.ptt)
-                if (this.reply_message_id !== '') {
-                    payload.append("reply_message_id", this.reply_message_id)
+                const replyMessageID = this.reply_message_id.trim()
+                if (this.isShowAttributes() && replyMessageID !== '') {
+                    payload.append("reply_message_id", replyMessageID)
                 }
                 if (this.duration && this.duration > 0) {
                     payload.append("duration", this.duration)

--- a/src/views/components/SendFile.js
+++ b/src/views/components/SendFile.js
@@ -14,6 +14,7 @@ export default {
     data() {
         return {
             caption: '',
+            reply_message_id: '',
             type: window.TYPEUSER,
             phone: '',
             loading: false,
@@ -69,6 +70,9 @@ export default {
                 payload.append("caption", this.caption)
                 payload.append("phone", this.phone_id)
                 payload.append("is_forwarded", this.is_forwarded)
+                if (this.reply_message_id !== '') {
+                    payload.append("reply_message_id", this.reply_message_id)
+                }
                 if (this.duration && this.duration > 0) {
                     payload.append("duration", this.duration)
                 }
@@ -87,6 +91,7 @@ export default {
         },
         handleReset() {
             this.caption = '';
+            this.reply_message_id = '';
             this.phone = '';
             this.type = window.TYPEUSER;
             this.selectedFileName = null;
@@ -123,6 +128,12 @@ export default {
             <form class="ui form">
                 <FormRecipient v-model:type="type" v-model:phone="phone"/>
                 
+                <div class="field" v-if="isShowAttributes()">
+                    <label>Reply Message ID</label>
+                    <input v-model="reply_message_id" type="text"
+                           placeholder="Optional: 57D29F74B7FC62F57D8AC2C840279B5B/3EB0288F008D32FCD0A424"
+                           aria-label="reply_message_id">
+                </div>
                 <div class="field">
                     <label>Caption</label>
                     <textarea v-model="caption" placeholder="Type some caption (optional)..."

--- a/src/views/components/SendFile.js
+++ b/src/views/components/SendFile.js
@@ -70,8 +70,9 @@ export default {
                 payload.append("caption", this.caption)
                 payload.append("phone", this.phone_id)
                 payload.append("is_forwarded", this.is_forwarded)
-                if (this.reply_message_id !== '') {
-                    payload.append("reply_message_id", this.reply_message_id)
+                const replyMessageID = this.reply_message_id.trim()
+                if (this.isShowAttributes() && replyMessageID !== '') {
+                    payload.append("reply_message_id", replyMessageID)
                 }
                 if (this.duration && this.duration > 0) {
                     payload.append("duration", this.duration)

--- a/src/views/components/SendImage.js
+++ b/src/views/components/SendImage.js
@@ -79,8 +79,9 @@ export default {
                 payload.append("compress", this.compress)
                 payload.append("caption", this.caption)
                 payload.append("is_forwarded", this.is_forwarded)
-                if (this.reply_message_id !== '') {
-                    payload.append("reply_message_id", this.reply_message_id)
+                const replyMessageID = this.reply_message_id.trim()
+                if (this.isShowAttributes() && replyMessageID !== '') {
+                    payload.append("reply_message_id", replyMessageID)
                 }
                 if (this.duration && this.duration > 0) {
                     payload.append("duration", this.duration)

--- a/src/views/components/SendImage.js
+++ b/src/views/components/SendImage.js
@@ -11,6 +11,7 @@ export default {
             view_once: false,
             compress: false,
             caption: '',
+            reply_message_id: '',
             type: window.TYPEUSER,
             loading: false,
             selected_file: null,
@@ -78,6 +79,9 @@ export default {
                 payload.append("compress", this.compress)
                 payload.append("caption", this.caption)
                 payload.append("is_forwarded", this.is_forwarded)
+                if (this.reply_message_id !== '') {
+                    payload.append("reply_message_id", this.reply_message_id)
+                }
                 if (this.duration && this.duration > 0) {
                     payload.append("duration", this.duration)
                 }
@@ -108,6 +112,7 @@ export default {
             this.compress = false;
             this.phone = '';
             this.caption = '';
+            this.reply_message_id = '';
             this.preview_url = null;
             this.selected_file = null;
             this.image_url = null;
@@ -153,6 +158,12 @@ export default {
             <form class="ui form">
                 <FormRecipient v-model:type="type" v-model:phone="phone" :show-status="true"/>
                 
+                <div class="field" v-if="isShowAttributes()">
+                    <label>Reply Message ID</label>
+                    <input v-model="reply_message_id" type="text"
+                           placeholder="Optional: 57D29F74B7FC62F57D8AC2C840279B5B/3EB0288F008D32FCD0A424"
+                           aria-label="reply_message_id">
+                </div>
                 <div class="field">
                     <label>Caption</label>
                     <textarea v-model="caption" type="text" placeholder="Hello this is image caption"

--- a/src/views/components/SendVideo.js
+++ b/src/views/components/SendVideo.js
@@ -98,8 +98,9 @@ export default {
                 payload.append("compress", this.compress)
                 payload.append("gif_playback", this.gif_playback)
                 payload.append("is_forwarded", this.is_forwarded)
-                if (this.reply_message_id !== '') {
-                    payload.append("reply_message_id", this.reply_message_id)
+                const replyMessageID = this.reply_message_id.trim()
+                if (this.isShowAttributes() && replyMessageID !== '') {
+                    payload.append("reply_message_id", replyMessageID)
                 }
                 if (this.duration && this.duration > 0) {
                     payload.append("duration", this.duration)

--- a/src/views/components/SendVideo.js
+++ b/src/views/components/SendVideo.js
@@ -14,6 +14,7 @@ export default {
     data() {
         return {
             caption: '',
+            reply_message_id: '',
             view_once: false,
             compress: false,
             gif_playback: false,
@@ -97,6 +98,9 @@ export default {
                 payload.append("compress", this.compress)
                 payload.append("gif_playback", this.gif_playback)
                 payload.append("is_forwarded", this.is_forwarded)
+                if (this.reply_message_id !== '') {
+                    payload.append("reply_message_id", this.reply_message_id)
+                }
                 if (this.duration && this.duration > 0) {
                     payload.append("duration", this.duration)
                 }
@@ -123,6 +127,7 @@ export default {
         },
         handleReset() {
             this.caption = '';
+            this.reply_message_id = '';
             this.view_once = false;
             this.compress = false;
             this.gif_playback = false;
@@ -164,6 +169,12 @@ export default {
             <form class="ui form">
                 <FormRecipient v-model:type="type" v-model:phone="phone" :show-status="true"/>
                 
+                <div class="field" v-if="isShowAttributes()">
+                    <label>Reply Message ID</label>
+                    <input v-model="reply_message_id" type="text"
+                           placeholder="Optional: 57D29F74B7FC62F57D8AC2C840279B5B/3EB0288F008D32FCD0A424"
+                           aria-label="reply_message_id">
+                </div>
                 <div class="field">
                     <label>Caption</label>
                     <textarea v-model="caption" placeholder="Type some caption (optional)..."


### PR DESCRIPTION
## Summary
- add optional `reply_message_id` support for image, file, video, and audio send requests
- reuse reply context construction so media messages can quote stored messages without changing response shapes
- expose the reply field in embedded media send forms and OpenAPI docs

## Root Cause
Only text send requests carried `reply_message_id` into `SendText`; media request DTOs and usecase paths had no field or `ContextInfo` merge step.

## Test Plan
- `cd src && go test ./usecase -run TestMergeReplyContext`
- `cd src && go test ./validations -run TestValidateSend`
- `cd src && go test ./...`

Refs #704