### PR TITLE
fix(chatwoot): trim whitespace from API token and URL (#674)

### DIFF
--- a/src/infrastructure/chatwoot/client.go
+++ b/src/infrastructure/chatwoot/client.go
@@ -128,9 +128,15 @@ func init() {
 }
 
 func NewClient() *Client {
+	// Trim surrounding whitespace before normalizing. Tokens and URLs supplied
+	// via Docker secret files, .env lines, or shell heredocs routinely carry a
+	// trailing newline; an untrimmed token produces a malformed
+	// "api_access_token" header and Chatwoot answers every request with a 401
+	// ("You need to sign in or sign up before continuing"), and a trailing
+	// newline on the URL survives the slash trim and corrupts every endpoint.
 	return &Client{
-		BaseURL:   strings.TrimRight(config.ChatwootURL, "/"),
-		APIToken:  config.ChatwootAPIToken,
+		BaseURL:   strings.TrimRight(strings.TrimSpace(config.ChatwootURL), "/"),
+		APIToken:  strings.TrimSpace(config.ChatwootAPIToken),
 		AccountID: config.ChatwootAccountID,
 		InboxID:   config.ChatwootInboxID,
 		HTTPClient: &http.Client{

--- a/src/infrastructure/chatwoot/client_methods_test.go
+++ b/src/infrastructure/chatwoot/client_methods_test.go
@@ -48,23 +48,34 @@ func TestNewClient_TrimsTrailingSlashAndMapsConfig(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name    string
-		url     string
-		wantURL string
+		name      string
+		url       string
+		token     string
+		wantURL   string
+		wantToken string
 	}{
 		// The trailing slash matters: endpoints are built with
 		// fmt.Sprintf("%s/api/v1/...") so a stray slash would yield a
 		// double-slash path. TrimRight removes any run of trailing slashes.
-		{"single trailing slash", "https://chatwoot.example.com/", "https://chatwoot.example.com"},
-		{"multiple trailing slashes", "https://chatwoot.example.com///", "https://chatwoot.example.com"},
-		{"no trailing slash", "https://chatwoot.example.com", "https://chatwoot.example.com"},
-		{"empty url stays empty", "", ""},
+		{"single trailing slash", "https://chatwoot.example.com/", "tok-123", "https://chatwoot.example.com", "tok-123"},
+		{"multiple trailing slashes", "https://chatwoot.example.com///", "tok-123", "https://chatwoot.example.com", "tok-123"},
+		{"no trailing slash", "https://chatwoot.example.com", "tok-123", "https://chatwoot.example.com", "tok-123"},
+		{"empty url stays empty", "", "tok-123", "", "tok-123"},
+		// Tokens/URLs from Docker secret files, .env lines, or shell heredocs
+		// commonly carry surrounding whitespace or a trailing newline. An
+		// untrimmed token yields a malformed "api_access_token" header and a
+		// 401 from Chatwoot (issue #674); a newline on the URL survives the
+		// slash trim and corrupts every endpoint. Both must be trimmed.
+		{"token with trailing newline", "https://chatwoot.example.com", "tok-123\n", "https://chatwoot.example.com", "tok-123"},
+		{"token with surrounding spaces", "https://chatwoot.example.com", "  tok-123  ", "https://chatwoot.example.com", "tok-123"},
+		{"url with trailing newline before slash", "https://chatwoot.example.com/\n", "tok-123", "https://chatwoot.example.com", "tok-123"},
+		{"url with surrounding whitespace", "  https://chatwoot.example.com/  ", "tok-123", "https://chatwoot.example.com", "tok-123"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			config.ChatwootURL = tc.url
-			config.ChatwootAPIToken = "tok-123"
+			config.ChatwootAPIToken = tc.token
 			config.ChatwootAccountID = 7
 			config.ChatwootInboxID = 9
 
@@ -73,8 +84,8 @@ func TestNewClient_TrimsTrailingSlashAndMapsConfig(t *testing.T) {
 			if c.BaseURL != tc.wantURL {
 				t.Errorf("BaseURL = %q, want %q", c.BaseURL, tc.wantURL)
 			}
-			if c.APIToken != "tok-123" {
-				t.Errorf("APIToken = %q, want tok-123", c.APIToken)
+			if c.APIToken != tc.wantToken {
+				t.Errorf("APIToken = %q, want %q", c.APIToken, tc.wantToken)
 			}
 			if c.AccountID != 7 {
 				t.Errorf("AccountID = %d, want 7", c.AccountID)


### PR DESCRIPTION
## Problem

Issue #674: Chatwoot integration returns `401 Unauthorized` even with a correct API token. The reported log:

```
msg="Chatwoot: failed to find/create contact for 62818xxxx0680: failed to search contact: status 401 body {\"errors\":[\"You need to sign in or sign up before continuing.\"]}"
```

That body is Devise's (Chatwoot's auth layer) default response when **no valid token reaches the endpoint**.

## Root cause

The Chatwoot API token is consumed verbatim. `NewClient` mapped `config.ChatwootAPIToken` straight onto the client (only the **URL** was `TrimRight(…, "/")`-ed). Tokens supplied via Docker secret files, `.env` lines, or shell heredocs routinely carry a **trailing newline or surrounding whitespace**. The untrimmed value is then sent as the `api_access_token` header, which Chatwoot rejects with the 401 above.

A trailing newline on the **URL** is a sibling hazard: it survives the existing slash-trim (`TrimRight(url, "/")` does not strip `\n`) and corrupts every endpoint.

## Fix

In `NewClient` (`src/infrastructure/chatwoot/client.go`), `strings.TrimSpace` both the token and the URL before normalizing.

## Tests

Extended `TestNewClient_TrimsTrailingSlashAndMapsConfig` with token-newline, token-spaces, url-newline, and url-whitespace cases.

`go test ./...` — all packages pass.

Fixes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)