### PR TITLE
fix(chatwoot): use saved WhatsApp contact name instead of phone number (#688)

### DIFF
--- a/src/infrastructure/whatsapp/chatwoot_content_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_content_test.go
@@ -243,6 +243,102 @@ func TestExtractChatwootContactInfo(t *testing.T) {
 	})
 }
 
+// TestExtractChatwootContactInfoPrefersSavedAddressBookName pins the issue #688
+// fix: a 1:1 contact's Chatwoot name must prefer the operator's saved
+// address-book name (resolved from the WhatsApp contact store) over the event
+// pushname and the bare phone number, while still falling back cleanly when no
+// saved name exists. The contact-store lookup is stubbed via contactDisplayNameFn.
+func TestExtractChatwootContactInfoPrefersSavedAddressBookName(t *testing.T) {
+	ctx := context.Background()
+	orig := contactDisplayNameFn
+	defer func() { contactDisplayNameFn = orig }()
+
+	t.Run("incoming 1:1 prefers saved name over pushname", func(t *testing.T) {
+		contactDisplayNameFn = func(_ context.Context, jid string) string {
+			if jid == "628123456789@s.whatsapp.net" {
+				return "Saved Name"
+			}
+			return ""
+		}
+		info, err := extractChatwootContactInfo(ctx, map[string]any{
+			"from":      "628123456789@s.whatsapp.net",
+			"chat_id":   "628123456789@s.whatsapp.net",
+			"from_name": "Pushy",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Name != "Saved Name" {
+			t.Fatalf("expected saved address-book name, got %q", info.Name)
+		}
+	})
+
+	t.Run("incoming 1:1 falls back to pushname when no saved name", func(t *testing.T) {
+		contactDisplayNameFn = func(context.Context, string) string { return "" }
+		info, err := extractChatwootContactInfo(ctx, map[string]any{
+			"from":      "628123456789@s.whatsapp.net",
+			"chat_id":   "628123456789@s.whatsapp.net",
+			"from_name": "Pushy",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Name != "Pushy" {
+			t.Fatalf("expected fallback to pushname, got %q", info.Name)
+		}
+	})
+
+	t.Run("incoming 1:1 falls back to phone when no saved name and no pushname", func(t *testing.T) {
+		contactDisplayNameFn = func(context.Context, string) string { return "" }
+		info, err := extractChatwootContactInfo(ctx, map[string]any{
+			"from":    "628123456789@s.whatsapp.net",
+			"chat_id": "628123456789@s.whatsapp.net",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Name != "628123456789" {
+			t.Fatalf("expected fallback to phone identifier, got %q", info.Name)
+		}
+	})
+
+	t.Run("outgoing 1:1 uses recipient saved name", func(t *testing.T) {
+		contactDisplayNameFn = func(_ context.Context, jid string) string {
+			if jid == "628999@s.whatsapp.net" {
+				return "Recipient Saved"
+			}
+			return ""
+		}
+		info, err := extractChatwootContactInfo(ctx, map[string]any{
+			"from":       "628000@s.whatsapp.net",
+			"chat_id":    "628999@s.whatsapp.net",
+			"is_from_me": true,
+			"from_name":  "Me",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Name != "Recipient Saved" {
+			t.Fatalf("expected recipient saved name for outgoing, got %q", info.Name)
+		}
+	})
+
+	t.Run("outgoing 1:1 falls back to identifier when no saved name", func(t *testing.T) {
+		contactDisplayNameFn = func(context.Context, string) string { return "" }
+		info, err := extractChatwootContactInfo(ctx, map[string]any{
+			"from":       "628000@s.whatsapp.net",
+			"chat_id":    "628999@s.whatsapp.net",
+			"is_from_me": true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Name != info.Identifier {
+			t.Fatalf("expected Name==Identifier for outgoing fallback, got Name=%q Identifier=%q", info.Name, info.Identifier)
+		}
+	})
+}
+
 // TestBuildChatwootMessageContent pins how a message payload is rendered into the
 // (content, attachments) pair Chatwoot receives. The media handling and group
 // sender-prefixing are the regression-prone parts: a dropped attachment or a

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -20,6 +20,10 @@ import (
 var (
 	submitWebhookFn     = submitWebhook
 	getChatwootClientFn = chatwoot.GetDefaultClient
+	// contactDisplayNameFn resolves the operator-saved address-book name for a
+	// 1:1 JID from the WhatsApp contact store. It is a seam so tests can stub
+	// the lookup without a real client/store.
+	contactDisplayNameFn = lookupContactDisplayName
 )
 
 // mutexShardCount is the number of mutex shards for contact synchronization.
@@ -199,10 +203,23 @@ func extractChatwootContactInfo(ctx context.Context, data map[string]any) (*chat
 		logrus.Infof("Chatwoot: Detected group message, using group contact: %s", info.Name)
 	} else if isFromMe {
 		info.Identifier = chatwootIdentifierForJID(chatID)
-		info.Name = info.Identifier
+		// The contact is the recipient (chatID). Prefer the operator's saved
+		// address-book name so an operator-initiated chat isn't created with a
+		// bare phone number; there is no useful pushname for our own messages.
+		info.Name = contactDisplayNameFn(ctx, chatID)
+		if info.Name == "" {
+			info.Name = info.Identifier
+		}
 	} else {
 		info.Identifier = chatwootIdentifierForJID(from)
-		info.Name = fromName
+		// Prefer the operator's saved address-book name (FullName), then the
+		// sender's pushname from the event, then the bare phone/identifier.
+		// Using only the pushname meant a number the operator had saved under a
+		// real name still surfaced in Chatwoot as its phone number (issue #688).
+		info.Name = contactDisplayNameFn(ctx, from)
+		if info.Name == "" {
+			info.Name = fromName
+		}
 		if info.Name == "" {
 			info.Name = info.Identifier
 		}
@@ -227,6 +244,41 @@ func chatwootIdentifierForJID(jid string) string {
 		return jid
 	}
 	return utils.ExtractPhoneFromJID(jid)
+}
+
+// lookupContactDisplayName returns the operator-saved address-book name for a
+// 1:1 WhatsApp JID from the local contact store, preferring the saved FullName
+// over the contact's self-set pushname and business name (the same priority and
+// source used by the /user/my/contacts endpoint). It returns "" when no client
+// is available or the contact is unknown, letting callers fall back to the live
+// event pushname / phone number.
+func lookupContactDisplayName(ctx context.Context, jid string) string {
+	client := ClientFromContext(ctx)
+	if client == nil || client.Store == nil || client.Store.Contacts == nil {
+		return ""
+	}
+	parsed, err := types.ParseJID(jid)
+	if err != nil || parsed.IsEmpty() {
+		return ""
+	}
+	// The incoming context may already be canceled (this runs from a goroutine,
+	// mirroring getGroupName); use a fresh short deadline for the local read.
+	freshCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	contact, err := client.Store.Contacts.GetContact(freshCtx, parsed)
+	if err != nil || !contact.Found {
+		return ""
+	}
+	switch {
+	case contact.FullName != "":
+		return contact.FullName
+	case contact.PushName != "":
+		return contact.PushName
+	case contact.BusinessName != "":
+		return contact.BusinessName
+	default:
+		return ""
+	}
 }
 
 // extractMediaPath returns the on-disk path for a media field in the


### PR DESCRIPTION
## Summary

Fixes #688 — for 1:1 chats, the WhatsApp contact name the operator saved (and which already renders correctly at `GET /user/my/contacts`) was not used for Chatwoot; the contact surfaced as a bare phone number instead.

## Root cause

`extractChatwootContactInfo` (`src/infrastructure/whatsapp/webhook_forward.go`) named a 1:1 Chatwoot contact from the **event pushname** (`from_name`) only, falling back to the phone number:

```go
info.Name = fromName
if info.Name == "" { info.Name = info.Identifier } // phone number
```

It never consulted the operator's saved **address-book name** (`FullName`), even though it's available from the same `client.Store.Contacts` store that backs `/user/my/contacts`. So a saved contact with no/different pushname showed as its phone number.

> Note: the *other* half of the report — a manual Chatwoot edit being overwritten on each new message — was already fixed in `77db428` (`FindOrCreateContact` now preserves manually-edited 1:1 names). This PR addresses the remaining half: actually using the saved name.

## Change

- Add `lookupContactDisplayName(ctx, jid)`: resolves the saved name from the local contact store with priority **FullName → PushName → BusinessName** (mirroring the existing `contactDisplayName` helper and `/user/my/contacts`). Returns `""` when no client/contact, so callers fall back safely.
- In `extractChatwootContactInfo`, for both incoming and outgoing 1:1 chats, prefer the saved name, then the event pushname, then the phone identifier.
- Wired behind a `contactDisplayNameFn` function-variable seam, matching the existing `sendMessageFn` / `subscribePresenceFn` test-seam convention in this package.

Behavior is unchanged when no saved name exists (existing tests stay green). Group handling is untouched.

## Tests

- New `TestExtractChatwootContactInfoPrefersSavedAddressBookName`: incoming prefers saved name → pushname → phone; outgoing prefers recipient saved name → identifier.
- `go build ./...` clean; `go test ./...` passes (all packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
