### PR TITLE
fix(chat): fall back chat-list name to phone number when empty (#675)

### DIFF
--- a/docs/agent-progress.md
+++ b/docs/agent-progress.md
@@ -1,0 +1,36 @@
+# Agent Progress
+
+_Recurring `/loop` task: triage open GitHub issues, fix the highest-priority bug, run tests, open a draft PR._
+
+## Run 2 — 2026-06-09 (iteration 2)
+
+Iteration 1 shipped #688 (PR #714, since **merged** to main as `9266165`). This run picked the next actionable bug.
+
+### Selected issue: #675 item A — chat-list name shows blank
+
+> "On the conversation list, the 'name' column should display the phone number when the contact name is empty. Currently this mapping doesn't work, making it hard to identify the sender."
+
+### Root cause
+
+`ListChats` and `GetChatMessages` ([src/usecase/chat.go](src/usecase/chat.go)) mapped `chatInfo.Name = chat.Name` verbatim. `GetChats` reads the stored name straight from sqlite with no fallback, so a chat persisted before a pushname/group subject is known (or with a stale empty name) returns `"name": ""` to the API and the web UI — the row shows blank.
+
+### Fix
+
+Added `chatDisplayName(jid, name)` — returns the stored name when present, else a JID-derived fallback mirroring the storage-layer convention in `GetChatNameWithPushNameByDevice`: `"Status"` for `status@broadcast`, phone number for 1:1, `Group <id>` / `Newsletter <id>` for those address spaces. Applied in both `ListChats` and `GetChatMessages`.
+
+### Review follow-up (PR #715)
+
+- `kilo-code-bot` flagged that the fallback returned the lowercase local part `"status"` for `status@broadcast` instead of the contracted `"Status"`. **Fixed** in `e0a462e` by adding the `status@broadcast` → `"Status"` special case before the local-part fallback, with test coverage. Replied on the thread and resolved it.
+
+### Verification
+
+- `gofmt` clean; `go build ./...` clean.
+- `go test ./...` — all packages pass (post-merge with main).
+- `TestChatDisplayName` covers: non-empty passthrough (1:1 + group), empty→phone, empty→`Group <id>`, empty→`Newsletter <id>`, empty→lid local part, empty→`Status`, non-empty `status@broadcast`.
+
+Status: **done** — draft PR [#715](https://github.com/aldinokemal/go-whatsapp-web-multidevice/pull/715), review feedback addressed.
+
+### Note for future iterations
+
+- #674 (Chatwoot 401) turned out to be a **real bug** (whitespace in API token/URL), fixed by the maintainer in PR #713 — not user config as first triaged. Lesson: verify "config" hunches against the code before dismissing.
+- The cleanly-fixable bug backlog is now thin; remaining open bugs are WhatsApp/whatsmeow-side or already addressed pending close.

--- a/docs/agent-progress.md
+++ b/docs/agent-progress.md
@@ -12,7 +12,7 @@ Iteration 1 shipped #688 (PR #714, since **merged** to main as `9266165`). This 
 
 ### Root cause
 
-`ListChats` and `GetChatMessages` ([src/usecase/chat.go](src/usecase/chat.go)) mapped `chatInfo.Name = chat.Name` verbatim. `GetChats` reads the stored name straight from sqlite with no fallback, so a chat persisted before a pushname/group subject is known (or with a stale empty name) returns `"name": ""` to the API and the web UI — the row shows blank.
+`ListChats` and `GetChatMessages` ([src/usecase/chat.go](../src/usecase/chat.go)) mapped `chatInfo.Name = chat.Name` verbatim. `GetChats` reads the stored name straight from sqlite with no fallback, so a chat persisted before a pushname/group subject is known (or with a stale empty name) returns `"name": ""` to the API and the web UI — the row shows blank.
 
 ### Fix
 

--- a/src/usecase/chat.go
+++ b/src/usecase/chat.go
@@ -31,11 +31,16 @@ func NewChatService(chatStorageRepo domainChatStorage.IChatStorageRepository) do
 // before a pushname/group subject is known (or with stale empty names), which
 // otherwise surfaces as a blank "name" in the chat list and makes the sender
 // impossible to identify (issue #675). The fallback mirrors the storage-layer
-// convention in GetChatNameWithPushName: phone number for 1:1, "Group <id>" /
-// "Newsletter <id>" for those address spaces.
+// convention in GetChatNameWithPushName: "Status" for status@broadcast, phone
+// number for 1:1, "Group <id>" / "Newsletter <id>" for those address spaces.
 func chatDisplayName(jid, name string) string {
 	if name != "" {
 		return name
+	}
+	// Mirror the storage-layer contract (GetChatNameWithPushNameByDevice):
+	// status@broadcast is always titled "Status", never its lowercase JID local part.
+	if jid == "status@broadcast" {
+		return "Status"
 	}
 	user := utils.ExtractPhoneFromJID(jid)
 	switch {

--- a/src/usecase/chat.go
+++ b/src/usecase/chat.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	domainChat "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chat"
@@ -22,6 +23,28 @@ type serviceChat struct {
 func NewChatService(chatStorageRepo domainChatStorage.IChatStorageRepository) domainChat.IChatUsecase {
 	return &serviceChat{
 		chatStorageRepo: chatStorageRepo,
+	}
+}
+
+// chatDisplayName returns a human-readable name for a chat, falling back to a
+// JID-derived label when the stored name is empty. Some chats are persisted
+// before a pushname/group subject is known (or with stale empty names), which
+// otherwise surfaces as a blank "name" in the chat list and makes the sender
+// impossible to identify (issue #675). The fallback mirrors the storage-layer
+// convention in GetChatNameWithPushName: phone number for 1:1, "Group <id>" /
+// "Newsletter <id>" for those address spaces.
+func chatDisplayName(jid, name string) string {
+	if name != "" {
+		return name
+	}
+	user := utils.ExtractPhoneFromJID(jid)
+	switch {
+	case utils.IsGroupJID(jid):
+		return "Group " + user
+	case strings.HasSuffix(jid, "@newsletter"):
+		return "Newsletter " + user
+	default:
+		return user
 	}
 }
 
@@ -60,7 +83,7 @@ func (service serviceChat) ListChats(ctx context.Context, request domainChat.Lis
 	for _, chat := range chats {
 		chatInfo := domainChat.ChatInfo{
 			JID:                 chat.JID,
-			Name:                chat.Name,
+			Name:                chatDisplayName(chat.JID, chat.Name),
 			LastMessageTime:     chat.LastMessageTime.Format(time.RFC3339),
 			EphemeralExpiration: chat.EphemeralExpiration,
 			CreatedAt:           chat.CreatedAt.Format(time.RFC3339),
@@ -196,7 +219,7 @@ func (service serviceChat) GetChatMessages(ctx context.Context, request domainCh
 	// Create chat info for response
 	chatInfo := domainChat.ChatInfo{
 		JID:                 chat.JID,
-		Name:                chat.Name,
+		Name:                chatDisplayName(chat.JID, chat.Name),
 		LastMessageTime:     chat.LastMessageTime.Format(time.RFC3339),
 		EphemeralExpiration: chat.EphemeralExpiration,
 		CreatedAt:           chat.CreatedAt.Format(time.RFC3339),

--- a/src/usecase/chat_test.go
+++ b/src/usecase/chat_test.go
@@ -97,3 +97,30 @@ func (r *chatUsecaseRepoStub) GetChatMessageCount(string) (int64, error) {
 func (r *chatUsecaseRepoStub) CreateReaction(context.Context, *events.Message) error {
 	return nil
 }
+
+// TestChatDisplayName pins the chat-list name fallback (issue #675): a stored
+// name is returned verbatim, but an empty name must never leak to the API as a
+// blank string — it falls back to a JID-derived label so the sender stays
+// identifiable.
+func TestChatDisplayName(t *testing.T) {
+	cases := []struct {
+		name string
+		jid  string
+		in   string
+		want string
+	}{
+		{"keeps non-empty 1:1 name", "628123456789@s.whatsapp.net", "Alice", "Alice"},
+		{"empty 1:1 falls back to phone", "628123456789@s.whatsapp.net", "", "628123456789"},
+		{"empty group falls back to Group id", "120363999000111@g.us", "", "Group 120363999000111"},
+		{"keeps non-empty group name", "120363999000111@g.us", "Family", "Family"},
+		{"empty newsletter falls back to Newsletter id", "120363111@newsletter", "", "Newsletter 120363111"},
+		{"empty lid falls back to lid local part", "1234567890abcd@lid", "", "1234567890abcd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chatDisplayName(tc.jid, tc.in); got != tc.want {
+				t.Fatalf("chatDisplayName(%q, %q) = %q, want %q", tc.jid, tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/usecase/chat_test.go
+++ b/src/usecase/chat_test.go
@@ -115,6 +115,8 @@ func TestChatDisplayName(t *testing.T) {
 		{"keeps non-empty group name", "120363999000111@g.us", "Family", "Family"},
 		{"empty newsletter falls back to Newsletter id", "120363111@newsletter", "", "Newsletter 120363111"},
 		{"empty lid falls back to lid local part", "1234567890abcd@lid", "", "1234567890abcd"},
+		{"empty status broadcast titled Status not local part", "status@broadcast", "", "Status"},
+		{"keeps non-empty status broadcast name", "status@broadcast", "Status", "Status"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses item **A** of #675 — on the chat list, the `name` column rendered blank when the stored contact name was empty, making the sender impossible to identify.

## Root cause

`ListChats` (`src/usecase/chat.go`) mapped the response name verbatim:

```go
chatInfo := domainChat.ChatInfo{ JID: chat.JID, Name: chat.Name, ... }
```

`GetChats` reads `chat.Name` straight from sqlite with no fallback. A chat persisted before a pushname / group subject is known (or carrying a stale empty name) is therefore returned to the API and the web UI as `"name": ""`, so the list row shows nothing. `GetChatMessages` had the same raw mapping for its `chat_info.name`.

## Change

Add `chatDisplayName(jid, name)`: returns the stored name when present, otherwise a JID-derived fallback that mirrors the existing storage-layer convention in `GetChatNameWithPushName`:

- 1:1 → phone number (JID local part)
- `@g.us` → `Group <id>`
- `@newsletter` → `Newsletter <id>`

Applied in both `ListChats` and `GetChatMessages`. Behavior is unchanged whenever a name already exists; only previously-blank names are filled.

## Scope notes

- #675 item **B** (captioned media dropped the attachment) and the group-name-on-sync part of #580 are **already fixed** in `77db428`; this PR covers only the still-open chat-list naming gap.
- The `CHATWOOT_SUFFIX_NAME` feature request in #675 is out of scope for this bugfix.

## Tests

- New `TestChatDisplayName`: non-empty passthrough (1:1 + group), empty→phone, empty→`Group <id>`, empty→`Newsletter <id>`, empty→lid local part.
- `gofmt` clean; `go build ./...` clean; `go test ./...` passes (all packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
