### PR TITLE
fix(media): return public URL for downloaded media

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1871,19 +1871,26 @@ paths:
                       status:
                         type: string
                         example: Media downloaded successfully
-                      mime_type:
+                      message_id:
                         type: string
-                        example: image/jpeg
+                        example: 3EB0ABC123456789
+                      media_type:
+                        type: string
+                        example: audio
+                      filename:
+                        type: string
+                        example: audio.ogg
+                      file_path:
+                        type: string
+                        description: Local server file path where the media was saved
+                        example: statics/media/6289685028129/2026-06-09/audio.ogg
+                      file_url:
+                        type: string
+                        description: Public URL for downloading the saved media when it is stored under the served statics directory
+                        example: http://localhost:3000/statics/media/6289685028129/2026-06-09/audio.ogg
                       file_size:
                         type: integer
                         example: 524288
-                      file_name:
-                        type: string
-                        example: image.jpg
-                      data:
-                        type: string
-                        format: byte
-                        description: Base64 encoded media data
         '400':
           description: Bad Request
           content:

--- a/src/domains/message/message.go
+++ b/src/domains/message/message.go
@@ -49,5 +49,6 @@ type DownloadMediaResponse struct {
 	MediaType string `json:"media_type"`
 	Filename  string `json:"filename"`
 	FilePath  string `json:"file_path"`
+	FileURL   string `json:"file_url,omitempty"`
 	FileSize  int64  `json:"file_size"`
 }

--- a/src/ui/rest/message.go
+++ b/src/ui/rest/message.go
@@ -1,6 +1,12 @@
 package rest
 
 import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	domainMessage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/message"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
@@ -174,6 +180,9 @@ func (controller *Message) DownloadMedia(c *fiber.Ctx) error {
 
 	response, err := controller.Service.DownloadMedia(ctx, request)
 	utils.PanicIfNeeded(err)
+	if response.FileURL == "" {
+		response.FileURL = publicStaticFileURL(c, response.FilePath)
+	}
 
 	return c.JSON(utils.ResponseData{
 		Status:  200,
@@ -181,4 +190,30 @@ func (controller *Message) DownloadMedia(c *fiber.Ctx) error {
 		Message: response.Status,
 		Results: response,
 	})
+}
+
+func publicStaticFileURL(c *fiber.Ctx, filePath string) string {
+	staticPath := publicStaticPath(filePath)
+	if staticPath == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s://%s%s%s", c.Protocol(), c.Hostname(), config.AppBasePath, staticPath)
+}
+
+func publicStaticPath(filePath string) string {
+	if filePath == "" {
+		return ""
+	}
+
+	normalizedPath := filepath.FromSlash(strings.ReplaceAll(filePath, "\\", "/"))
+	rel, err := filepath.Rel("statics", normalizedPath)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return ""
+	}
+
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return "/statics/" + strings.Join(parts, "/")
 }

--- a/src/ui/rest/message.go
+++ b/src/ui/rest/message.go
@@ -173,12 +173,7 @@ func (controller *Message) DownloadMedia(c *fiber.Ctx) error {
 	request.Phone = c.Query("phone")
 	utils.SanitizePhone(&request.Phone)
 
-	ctx := c.UserContext()
-	if device, ok := c.Locals("device").(*whatsapp.DeviceInstance); ok {
-		ctx = whatsapp.ContextWithDevice(ctx, device)
-	}
-
-	response, err := controller.Service.DownloadMedia(ctx, request)
+	response, err := controller.Service.DownloadMedia(whatsapp.ContextWithDevice(c.UserContext(), getDeviceFromCtx(c)), request)
 	utils.PanicIfNeeded(err)
 	if response.FileURL == "" {
 		response.FileURL = publicStaticFileURL(c, response.FilePath)

--- a/src/ui/rest/message_test.go
+++ b/src/ui/rest/message_test.go
@@ -24,6 +24,11 @@ func TestPublicStaticPath(t *testing.T) {
 			want:     "",
 		},
 		{
+			name:     "path traversal",
+			filePath: "../../etc/passwd",
+			want:     "",
+		},
+		{
 			name:     "empty path",
 			filePath: "",
 			want:     "",

--- a/src/ui/rest/message_test.go
+++ b/src/ui/rest/message_test.go
@@ -1,0 +1,40 @@
+package rest
+
+import "testing"
+
+func TestPublicStaticPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		want     string
+	}{
+		{
+			name:     "media file under statics",
+			filePath: "statics/media/628123/2026-06-09/audio file.ogg",
+			want:     "/statics/media/628123/2026-06-09/audio%20file.ogg",
+		},
+		{
+			name:     "windows separators",
+			filePath: "statics\\media\\628123\\2026-06-09\\voice.ogg",
+			want:     "/statics/media/628123/2026-06-09/voice.ogg",
+		},
+		{
+			name:     "outside statics",
+			filePath: "storages/audio.ogg",
+			want:     "",
+		},
+		{
+			name:     "empty path",
+			filePath: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := publicStaticPath(tt.filePath); got != tt.want {
+				t.Fatalf("publicStaticPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Refs #543.

Adds a `file_url` field to `GET /message/:message_id/download` responses when the downloaded media lands under the served `statics` directory. This keeps the existing `file_path` response for compatibility, while giving n8n and other workflow tools a direct HTTP URL to fetch audio/image/video/document media without guessing how local paths map to public routes.

Also updates the OpenAPI response schema for the endpoint to match the actual Go response fields (`message_id`, `media_type`, `filename`, `file_path`, `file_url`, `file_size`).

## Tests

- `go test ./ui/rest`
- `go test ./...`
