### PR TITLE
Persist WhatsApp media direct paths for download support

### DIFF
--- a/src/domains/chatstorage/chatstorage.go
+++ b/src/domains/chatstorage/chatstorage.go
@@ -27,6 +27,7 @@ type Message struct {
 	CallMetadata     string     `db:"call_metadata"`
 	Filename         string     `db:"filename"`
 	URL              string     `db:"url"`
+	DirectPath       string     `db:"direct_path"`
 	MediaKey         []byte     `db:"media_key"`
 	FileSHA256       []byte     `db:"file_sha256"`
 	FileEncSHA256    []byte     `db:"file_enc_sha256"`
@@ -90,6 +91,7 @@ type MediaInfo struct {
 	MediaType     string
 	Filename      string
 	URL           string
+	DirectPath    string
 	MediaKey      []byte
 	FileSHA256    []byte
 	FileEncSHA256 []byte

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -88,7 +88,7 @@ func (r *SQLiteRepository) GetChatByDevice(deviceID, jid string) (*domainChatSto
 func (r *SQLiteRepository) GetMessageByID(id string) (*domainChatStorage.Message, error) {
 	query := `
 		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
-			media_type, call_metadata, filename, url, media_key, file_sha256,
+			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
 		FROM messages
 		WHERE id = ?
@@ -108,7 +108,7 @@ func (r *SQLiteRepository) GetMessageByID(id string) (*domainChatStorage.Message
 func (r *SQLiteRepository) GetMessageByIDAndDevice(deviceID, id string) (*domainChatStorage.Message, error) {
 	query := `
 		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
-			media_type, call_metadata, filename, url, media_key, file_sha256,
+			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
 		FROM messages
 		WHERE id = ? AND device_id = ?
@@ -316,11 +316,11 @@ func (r *SQLiteRepository) StoreMessage(message *domainChatStorage.Message) erro
 	// Try update first, then insert if no rows affected (cross-db compatible)
 	result, err := r.db.Exec(`
 		UPDATE messages SET sender = ?, content = ?, timestamp = ?, is_from_me = ?,
-			media_type = ?, call_metadata = ?, filename = ?, url = ?, media_key = ?, file_sha256 = ?,
+			media_type = ?, call_metadata = ?, filename = ?, url = ?, direct_path = ?, media_key = ?, file_sha256 = ?,
 			file_enc_sha256 = ?, file_length = ?, referral_metadata = ?, updated_at = ?
 		WHERE id = ? AND chat_jid = ? AND device_id = ?
 	`, message.Sender, message.Content, message.Timestamp, message.IsFromMe,
-		message.MediaType, message.CallMetadata, message.Filename, message.URL, message.MediaKey, message.FileSHA256,
+		message.MediaType, message.CallMetadata, message.Filename, message.URL, message.DirectPath, message.MediaKey, message.FileSHA256,
 		message.FileEncSHA256, message.FileLength, message.ReferralMetadata, message.UpdatedAt,
 		message.ID, message.ChatJID, message.DeviceID)
 	if err != nil {
@@ -332,12 +332,12 @@ func (r *SQLiteRepository) StoreMessage(message *domainChatStorage.Message) erro
 		_, err = r.db.Exec(`
 			INSERT INTO messages (
 				id, chat_jid, device_id, sender, content, timestamp, is_from_me,
-				media_type, call_metadata, filename, url, media_key, file_sha256,
+				media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 				file_enc_sha256, file_length, referral_metadata, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, message.ID, message.ChatJID, message.DeviceID, message.Sender, message.Content,
 			message.Timestamp, message.IsFromMe, message.MediaType, message.CallMetadata, message.Filename,
-			message.URL, message.MediaKey, message.FileSHA256, message.FileEncSHA256,
+			message.URL, message.DirectPath, message.MediaKey, message.FileSHA256, message.FileEncSHA256,
 			message.FileLength, message.ReferralMetadata, message.CreatedAt, message.UpdatedAt)
 	}
 	return err
@@ -358,7 +358,7 @@ func (r *SQLiteRepository) StoreMessagesBatch(messages []*domainChatStorage.Mess
 	// Prepare statements for update and insert
 	updateStmt, err := tx.Prepare(`
 		UPDATE messages SET sender = ?, content = ?, timestamp = ?, is_from_me = ?,
-			media_type = ?, call_metadata = ?, filename = ?, url = ?, media_key = ?, file_sha256 = ?,
+			media_type = ?, call_metadata = ?, filename = ?, url = ?, direct_path = ?, media_key = ?, file_sha256 = ?,
 			file_enc_sha256 = ?, file_length = ?, referral_metadata = ?, updated_at = ?
 		WHERE id = ? AND chat_jid = ? AND device_id = ?
 	`)
@@ -370,9 +370,9 @@ func (r *SQLiteRepository) StoreMessagesBatch(messages []*domainChatStorage.Mess
 	insertStmt, err := tx.Prepare(`
 		INSERT INTO messages (
 			id, chat_jid, device_id, sender, content, timestamp, is_from_me,
-			media_type, call_metadata, filename, url, media_key, file_sha256,
+			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare insert statement: %w", err)
@@ -390,7 +390,7 @@ func (r *SQLiteRepository) StoreMessagesBatch(messages []*domainChatStorage.Mess
 
 		result, err := updateStmt.Exec(
 			message.Sender, message.Content, message.Timestamp, message.IsFromMe,
-			message.MediaType, message.CallMetadata, message.Filename, message.URL, message.MediaKey, message.FileSHA256,
+			message.MediaType, message.CallMetadata, message.Filename, message.URL, message.DirectPath, message.MediaKey, message.FileSHA256,
 			message.FileEncSHA256, message.FileLength, message.ReferralMetadata, message.UpdatedAt,
 			message.ID, message.ChatJID, message.DeviceID,
 		)
@@ -403,7 +403,7 @@ func (r *SQLiteRepository) StoreMessagesBatch(messages []*domainChatStorage.Mess
 			_, err = insertStmt.Exec(
 				message.ID, message.ChatJID, message.DeviceID, message.Sender, message.Content,
 				message.Timestamp, message.IsFromMe, message.MediaType, message.CallMetadata, message.Filename,
-				message.URL, message.MediaKey, message.FileSHA256, message.FileEncSHA256,
+				message.URL, message.DirectPath, message.MediaKey, message.FileSHA256, message.FileEncSHA256,
 				message.FileLength, message.ReferralMetadata, message.CreatedAt, message.UpdatedAt,
 			)
 			if err != nil {
@@ -507,7 +507,7 @@ func (r *SQLiteRepository) GetMessages(filter *domainChatStorage.MessageFilter) 
 
 	query := `
 		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
-			media_type, call_metadata, filename, url, media_key, file_sha256,
+			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
 		FROM messages
 		WHERE ` + strings.Join(conditions, " AND ") + `
@@ -580,7 +580,7 @@ func (r *SQLiteRepository) SearchMessages(deviceID, chatJID, searchText string, 
 
 	query := `
 		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
-			media_type, call_metadata, filename, url, media_key, file_sha256,
+			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
 		FROM messages
 		WHERE ` + strings.Join(conditions, " AND ") + `
@@ -941,7 +941,7 @@ func (r *SQLiteRepository) scanMessage(scanner interface{ Scan(...any) error }) 
 	err := scanner.Scan(
 		&message.ID, &message.ChatJID, &message.DeviceID, &message.Sender, &message.Content,
 		&message.Timestamp, &message.IsFromMe, &message.MediaType, &message.CallMetadata, &message.Filename,
-		&message.URL, &message.MediaKey, &message.FileSHA256, &message.FileEncSHA256,
+		&message.URL, &message.DirectPath, &message.MediaKey, &message.FileSHA256, &message.FileEncSHA256,
 		&message.FileLength, &message.ReferralMetadata, &message.CreatedAt, &message.UpdatedAt,
 	)
 	return message, err
@@ -1338,7 +1338,7 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 
 	// Extract message content and media info
 	content := utils.ExtractMessageTextFromProto(evt.Message)
-	mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength := utils.ExtractMediaInfo(evt.Message)
+	mediaType, filename, mediaURL, directPath, mediaKey, fileSHA256, fileEncSHA256, fileLength := utils.ExtractMediaInfo(evt.Message)
 
 	// Skip if there's no content and no media
 	if content == "" && mediaType == "" {
@@ -1363,7 +1363,8 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 		IsFromMe:         evt.Info.IsFromMe,
 		MediaType:        mediaType,
 		Filename:         filename,
-		URL:              url,
+		URL:              mediaURL,
+		DirectPath:       directPath,
 		MediaKey:         mediaKey,
 		FileSHA256:       fileSHA256,
 		FileEncSHA256:    fileEncSHA256,
@@ -1424,10 +1425,11 @@ func (r *SQLiteRepository) storeEditedMessage(ctx context.Context, evt *events.M
 			IsFromMe:  evt.Info.IsFromMe,
 		}
 
-		if mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength := utils.ExtractMediaInfo(editedMessage); mediaType != "" || newContent != "" {
+		if mediaType, filename, mediaURL, directPath, mediaKey, fileSHA256, fileEncSHA256, fileLength := utils.ExtractMediaInfo(editedMessage); mediaType != "" || newContent != "" {
 			currentMessage.MediaType = mediaType
 			currentMessage.Filename = filename
-			currentMessage.URL = url
+			currentMessage.URL = mediaURL
+			currentMessage.DirectPath = directPath
 			currentMessage.MediaKey = mediaKey
 			currentMessage.FileSHA256 = fileSHA256
 			currentMessage.FileEncSHA256 = fileEncSHA256
@@ -1466,12 +1468,12 @@ func (r *SQLiteRepository) storeEditedMessage(ctx context.Context, evt *events.M
 		if _, err := tx.Exec(`
 			INSERT INTO messages (
 				id, chat_jid, device_id, sender, content, timestamp, is_from_me,
-				media_type, call_metadata, filename, url, media_key, file_sha256,
+				media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 				file_enc_sha256, file_length, referral_metadata, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, currentMessage.ID, currentMessage.ChatJID, currentMessage.DeviceID, currentMessage.Sender, currentMessage.Content,
 			currentMessage.Timestamp, currentMessage.IsFromMe, currentMessage.MediaType, currentMessage.CallMetadata, currentMessage.Filename,
-			currentMessage.URL, currentMessage.MediaKey, currentMessage.FileSHA256, currentMessage.FileEncSHA256,
+			currentMessage.URL, currentMessage.DirectPath, currentMessage.MediaKey, currentMessage.FileSHA256, currentMessage.FileEncSHA256,
 			currentMessage.FileLength, currentMessage.ReferralMetadata, now, now); err != nil {
 			return fmt.Errorf("failed to insert edited message %s: %w", originalMessageID, err)
 		}
@@ -1487,7 +1489,7 @@ func (r *SQLiteRepository) storeEditedMessage(ctx context.Context, evt *events.M
 func (r *SQLiteRepository) getMessageByDeviceAndChatIDAndMessageID(deviceID, chatJID, messageID string) (*domainChatStorage.Message, error) {
 	query := `
 		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
-			media_type, call_metadata, filename, url, media_key, file_sha256,
+			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
 		FROM messages
 		WHERE id = ? AND chat_jid = ? AND device_id = ?
@@ -1835,11 +1837,11 @@ func (r *SQLiteRepository) StoreSentMessageWithContext(ctx context.Context, mess
 	}
 
 	// Extract media info from the protobuf message if available
-	var mediaType, filename, mediaURL string
+	var mediaType, filename, mediaURL, directPath string
 	var mediaKey, fileSHA256, fileEncSHA256 []byte
 	var fileLength uint64
 	if msg != nil {
-		mediaType, filename, mediaURL, mediaKey, fileSHA256, fileEncSHA256, fileLength = utils.ExtractMediaInfo(msg)
+		mediaType, filename, mediaURL, directPath, mediaKey, fileSHA256, fileEncSHA256, fileLength = utils.ExtractMediaInfo(msg)
 	}
 
 	// Store the sent message
@@ -1854,6 +1856,7 @@ func (r *SQLiteRepository) StoreSentMessageWithContext(ctx context.Context, mess
 		MediaType:     mediaType,
 		Filename:      filename,
 		URL:           mediaURL,
+		DirectPath:    directPath,
 		MediaKey:      mediaKey,
 		FileSHA256:    fileSHA256,
 		FileEncSHA256: fileEncSHA256,
@@ -2103,5 +2106,8 @@ func (r *SQLiteRepository) getMigrations() []string {
 
 		// Migration 29: Fetch due Chatwoot retry jobs in stable order
 		`CREATE INDEX IF NOT EXISTS idx_chatwoot_forward_queue_due ON chatwoot_forward_queue(next_attempt_at, id)`,
+
+		// Migration 30: Store WhatsApp media direct paths for downloads
+		`ALTER TABLE messages ADD COLUMN direct_path TEXT DEFAULT ''`,
 	}
 }

--- a/src/infrastructure/chatstorage/sqlite_repository_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_test.go
@@ -184,6 +184,98 @@ func TestStoreSentMessageWithContextRequiresDeviceInContext(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepositoryStoresMessageDirectPath(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "device-a@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+	now := time.Date(2026, time.June, 19, 8, 0, 0, 0, time.UTC)
+	directPath := "/v/t62.7118-24/media.enc?ccb=11-4"
+
+	if err := repo.StoreChat(&domainChatStorage.Chat{
+		DeviceID:        deviceID,
+		JID:             chatJID,
+		Name:            chatJID,
+		LastMessageTime: now,
+	}); err != nil {
+		t.Fatalf("store chat: %v", err)
+	}
+	if err := repo.StoreMessage(&domainChatStorage.Message{
+		ID:            "msg-media-1",
+		ChatJID:       chatJID,
+		DeviceID:      deviceID,
+		Sender:        "628999999999@s.whatsapp.net",
+		Timestamp:     now,
+		MediaType:     "image",
+		URL:           "https://mmg.whatsapp.net/v/t62.7118-24/media.enc?ccb=11-4",
+		DirectPath:    directPath,
+		MediaKey:      []byte("media-key"),
+		FileSHA256:    []byte("file-sha"),
+		FileEncSHA256: []byte("file-enc-sha"),
+		FileLength:    1234,
+	}); err != nil {
+		t.Fatalf("store message: %v", err)
+	}
+
+	got, err := repo.GetMessageByID("msg-media-1")
+	if err != nil {
+		t.Fatalf("get message by id: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected stored message")
+	}
+	if got.DirectPath != directPath {
+		t.Fatalf("DirectPath = %q, want %q", got.DirectPath, directPath)
+	}
+}
+
+func TestSQLiteRepositoryStoresBatchMessageDirectPath(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "device-a@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+	now := time.Date(2026, time.June, 19, 8, 0, 0, 0, time.UTC)
+	directPath := "/v/t62.7118-24/batch-media.enc?ccb=11-4"
+
+	if err := repo.StoreChat(&domainChatStorage.Chat{
+		DeviceID:        deviceID,
+		JID:             chatJID,
+		Name:            chatJID,
+		LastMessageTime: now,
+	}); err != nil {
+		t.Fatalf("store chat: %v", err)
+	}
+	if err := repo.StoreMessagesBatch([]*domainChatStorage.Message{{
+		ID:            "msg-media-batch-1",
+		ChatJID:       chatJID,
+		DeviceID:      deviceID,
+		Sender:        "628999999999@s.whatsapp.net",
+		Timestamp:     now,
+		MediaType:     "video",
+		URL:           "https://mmg.whatsapp.net/v/t62.7118-24/batch-media.enc?ccb=11-4",
+		DirectPath:    directPath,
+		MediaKey:      []byte("media-key"),
+		FileSHA256:    []byte("file-sha"),
+		FileEncSHA256: []byte("file-enc-sha"),
+		FileLength:    5678,
+	}}); err != nil {
+		t.Fatalf("store messages batch: %v", err)
+	}
+
+	messages, err := repo.GetMessages(&domainChatStorage.MessageFilter{
+		DeviceID: deviceID,
+		ChatJID:  chatJID,
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected one message, got %d", len(messages))
+	}
+	if messages[0].DirectPath != directPath {
+		t.Fatalf("DirectPath = %q, want %q", messages[0].DirectPath, directPath)
+	}
+}
+
 func seedChatMessage(t *testing.T, repo *SQLiteRepository, deviceID, chatJID, messageID, content string, timestamp time.Time) {
 	t.Helper()
 	if err := repo.StoreChat(&domainChatStorage.Chat{

--- a/src/infrastructure/chatwoot/sync.go
+++ b/src/infrastructure/chatwoot/sync.go
@@ -16,9 +16,7 @@ import (
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow"
-	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
-	"google.golang.org/protobuf/proto"
 )
 
 // SyncService handles message history synchronization to Chatwoot
@@ -440,7 +438,7 @@ func (s *SyncService) syncChatPG(
 }
 
 func hasDownloadableChatwootMedia(msg *domainChatStorage.Message) bool {
-	return msg != nil && msg.MediaType != "" && msg.URL != "" && len(msg.MediaKey) > 0
+	return msg != nil && msg.MediaType != "" && utils.ResolveMediaDirectPath(msg.DirectPath, msg.URL) != "" && len(msg.MediaKey) > 0
 }
 
 func chatwootRESTMediaCandidates(messages []*domainChatStorage.Message, opts SyncOptions) []*domainChatStorage.Message {
@@ -635,59 +633,26 @@ func (s *SyncService) syncMessageWithOptions(
 
 // downloadMedia downloads media for a message and returns the temp file path
 func (s *SyncService) downloadMedia(ctx context.Context, msg *domainChatStorage.Message, waClient *whatsmeow.Client) (string, error) {
-	if msg.URL == "" || len(msg.MediaKey) == 0 {
-		return "", fmt.Errorf("missing media URL or key")
+	directPath := utils.ResolveMediaDirectPath(msg.DirectPath, msg.URL)
+	if directPath == "" || len(msg.MediaKey) == 0 {
+		return "", fmt.Errorf("missing media direct path or key")
 	}
 
 	if waClient == nil {
 		return "", fmt.Errorf("WhatsApp client not available")
 	}
 
-	// Create downloadable message based on type
-	var downloadable whatsmeow.DownloadableMessage
-
-	switch msg.MediaType {
-	case "image":
-		downloadable = &waE2E.ImageMessage{
-			URL:           proto.String(msg.URL),
-			MediaKey:      msg.MediaKey,
-			FileSHA256:    msg.FileSHA256,
-			FileEncSHA256: msg.FileEncSHA256,
-			FileLength:    proto.Uint64(msg.FileLength),
-		}
-	case "video":
-		downloadable = &waE2E.VideoMessage{
-			URL:           proto.String(msg.URL),
-			MediaKey:      msg.MediaKey,
-			FileSHA256:    msg.FileSHA256,
-			FileEncSHA256: msg.FileEncSHA256,
-			FileLength:    proto.Uint64(msg.FileLength),
-		}
-	case "audio", "ptt":
-		downloadable = &waE2E.AudioMessage{
-			URL:           proto.String(msg.URL),
-			MediaKey:      msg.MediaKey,
-			FileSHA256:    msg.FileSHA256,
-			FileEncSHA256: msg.FileEncSHA256,
-			FileLength:    proto.Uint64(msg.FileLength),
-		}
-	case "document":
-		downloadable = &waE2E.DocumentMessage{
-			URL:           proto.String(msg.URL),
-			MediaKey:      msg.MediaKey,
-			FileSHA256:    msg.FileSHA256,
-			FileEncSHA256: msg.FileEncSHA256,
-			FileLength:    proto.Uint64(msg.FileLength),
-		}
-	case "sticker":
-		downloadable = &waE2E.StickerMessage{
-			URL:           proto.String(msg.URL),
-			MediaKey:      msg.MediaKey,
-			FileSHA256:    msg.FileSHA256,
-			FileEncSHA256: msg.FileEncSHA256,
-			FileLength:    proto.Uint64(msg.FileLength),
-		}
-	default:
+	downloadable, err := utils.BuildDownloadableMessage(
+		msg.MediaType,
+		msg.URL,
+		directPath,
+		msg.Filename,
+		msg.MediaKey,
+		msg.FileSHA256,
+		msg.FileEncSHA256,
+		msg.FileLength,
+	)
+	if err != nil {
 		return "", fmt.Errorf("unsupported media type: %s", msg.MediaType)
 	}
 

--- a/src/infrastructure/chatwoot/sync_rest_test.go
+++ b/src/infrastructure/chatwoot/sync_rest_test.go
@@ -94,12 +94,17 @@ func TestHasDownloadableChatwootMedia(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "media with direct path and key",
+			msg:  &domainChatStorage.Message{MediaType: "image", DirectPath: "/v/t62.7118-24/file.enc?ccb=11-4", MediaKey: []byte("key")},
+			want: true,
+		},
+		{
 			name: "text message",
 			msg:  &domainChatStorage.Message{Content: "hello"},
 			want: false,
 		},
 		{
-			name: "media without url",
+			name: "media without url or direct path",
 			msg:  &domainChatStorage.Message{MediaType: "image", MediaKey: []byte("key")},
 			want: false,
 		},

--- a/src/infrastructure/whatsapp/history_sync.go
+++ b/src/infrastructure/whatsapp/history_sync.go
@@ -232,7 +232,7 @@ func processConversationMessages(ctx context.Context, data *waHistorySync.Histor
 
 			// Extract message content and media info
 			content := utils.ExtractMessageTextFromProto(msg.GetMessage())
-			mediaType, filename, url, mediaKey, fileSHA256, fileEncSHA256, fileLength := utils.ExtractMediaInfo(msg.GetMessage())
+			mediaType, filename, mediaURL, directPath, mediaKey, fileSHA256, fileEncSHA256, fileLength := utils.ExtractMediaInfo(msg.GetMessage())
 
 			// Skip if there's no content and no media
 			if content == "" && mediaType == "" {
@@ -255,7 +255,8 @@ func processConversationMessages(ctx context.Context, data *waHistorySync.Histor
 				IsFromMe:      isFromMe,
 				MediaType:     mediaType,
 				Filename:      filename,
-				URL:           url,
+				URL:           mediaURL,
+				DirectPath:    directPath,
 				MediaKey:      mediaKey,
 				FileSHA256:    fileSHA256,
 				FileEncSHA256: fileEncSHA256,

--- a/src/pkg/utils/whatsapp.go
+++ b/src/pkg/utils/whatsapp.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"mime"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,6 +19,7 @@ import (
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
@@ -236,16 +238,16 @@ func ExtractMediaCaption(msg *waE2E.Message) string {
 }
 
 // ExtractMediaInfo extracts media information from a WhatsApp message
-func ExtractMediaInfo(msg *waE2E.Message) (mediaType string, filename string, url string, mediaKey []byte, fileSHA256 []byte, fileEncSHA256 []byte, fileLength uint64) {
+func ExtractMediaInfo(msg *waE2E.Message) (mediaType string, filename string, mediaURL string, directPath string, mediaKey []byte, fileSHA256 []byte, fileEncSHA256 []byte, fileLength uint64) {
 	if msg == nil {
-		return "", "", "", nil, nil, nil, 0
+		return "", "", "", "", nil, nil, nil, 0
 	}
 
 	// Check for image message
 	if img := msg.GetImageMessage(); img != nil {
 		filename = GenerateMediaFilename("image", "jpg", img.GetCaption())
 		return "image", filename,
-			img.GetURL(), img.GetMediaKey(), img.GetFileSHA256(),
+			img.GetURL(), img.GetDirectPath(), img.GetMediaKey(), img.GetFileSHA256(),
 			img.GetFileEncSHA256(), img.GetFileLength()
 	}
 
@@ -253,7 +255,7 @@ func ExtractMediaInfo(msg *waE2E.Message) (mediaType string, filename string, ur
 	if vid := msg.GetVideoMessage(); vid != nil {
 		filename = GenerateMediaFilename("video", "mp4", vid.GetCaption())
 		return "video", filename,
-			vid.GetURL(), vid.GetMediaKey(), vid.GetFileSHA256(),
+			vid.GetURL(), vid.GetDirectPath(), vid.GetMediaKey(), vid.GetFileSHA256(),
 			vid.GetFileEncSHA256(), vid.GetFileLength()
 	}
 
@@ -261,7 +263,7 @@ func ExtractMediaInfo(msg *waE2E.Message) (mediaType string, filename string, ur
 	if ptv := msg.GetPtvMessage(); ptv != nil {
 		filename = GenerateMediaFilename("video_note", "mp4", ptv.GetCaption())
 		return "video_note", filename,
-			ptv.GetURL(), ptv.GetMediaKey(), ptv.GetFileSHA256(),
+			ptv.GetURL(), ptv.GetDirectPath(), ptv.GetMediaKey(), ptv.GetFileSHA256(),
 			ptv.GetFileEncSHA256(), ptv.GetFileLength()
 	}
 
@@ -273,7 +275,7 @@ func ExtractMediaInfo(msg *waE2E.Message) (mediaType string, filename string, ur
 		}
 		filename = GenerateMediaFilename("audio", extension, "")
 		return "audio", filename,
-			aud.GetURL(), aud.GetMediaKey(), aud.GetFileSHA256(),
+			aud.GetURL(), aud.GetDirectPath(), aud.GetMediaKey(), aud.GetFileSHA256(),
 			aud.GetFileEncSHA256(), aud.GetFileLength()
 	}
 
@@ -284,7 +286,7 @@ func ExtractMediaInfo(msg *waE2E.Message) (mediaType string, filename string, ur
 			filename = GenerateMediaFilename("document", "", doc.GetTitle())
 		}
 		return "document", filename,
-			doc.GetURL(), doc.GetMediaKey(), doc.GetFileSHA256(),
+			doc.GetURL(), doc.GetDirectPath(), doc.GetMediaKey(), doc.GetFileSHA256(),
 			doc.GetFileEncSHA256(), doc.GetFileLength()
 	}
 
@@ -292,11 +294,92 @@ func ExtractMediaInfo(msg *waE2E.Message) (mediaType string, filename string, ur
 	if sticker := msg.GetStickerMessage(); sticker != nil {
 		filename = GenerateMediaFilename("sticker", "webp", "")
 		return "sticker", filename,
-			sticker.GetURL(), sticker.GetMediaKey(), sticker.GetFileSHA256(),
+			sticker.GetURL(), sticker.GetDirectPath(), sticker.GetMediaKey(), sticker.GetFileSHA256(),
 			sticker.GetFileEncSHA256(), sticker.GetFileLength()
 	}
 
-	return "", "", "", nil, nil, nil, 0
+	return "", "", "", "", nil, nil, nil, 0
+}
+
+// ResolveMediaDirectPath returns storedDirectPath, or derives a direct path
+// from legacy rows that only persisted the full WhatsApp media URL.
+func ResolveMediaDirectPath(storedDirectPath, mediaURL string) string {
+	storedDirectPath = strings.TrimSpace(storedDirectPath)
+	if storedDirectPath != "" {
+		return storedDirectPath
+	}
+
+	mediaURL = strings.TrimSpace(mediaURL)
+	if mediaURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(mediaURL)
+	if err != nil {
+		return ""
+	}
+	requestURI := parsed.RequestURI()
+	if strings.HasPrefix(requestURI, "/") {
+		return requestURI
+	}
+	return ""
+}
+
+// BuildDownloadableMessage reconstructs a whatsmeow downloadable media proto
+// from stored chat media metadata.
+func BuildDownloadableMessage(mediaType, mediaURL, directPath, filename string, mediaKey, fileSHA256, fileEncSHA256 []byte, fileLength uint64) (whatsmeow.DownloadableMessage, error) {
+	resolvedDirectPath := ResolveMediaDirectPath(directPath, mediaURL)
+
+	switch mediaType {
+	case "image":
+		return &waE2E.ImageMessage{
+			URL:           proto.String(mediaURL),
+			DirectPath:    proto.String(resolvedDirectPath),
+			MediaKey:      mediaKey,
+			FileSHA256:    fileSHA256,
+			FileEncSHA256: fileEncSHA256,
+			FileLength:    proto.Uint64(fileLength),
+		}, nil
+	case "video", "video_note":
+		return &waE2E.VideoMessage{
+			URL:           proto.String(mediaURL),
+			DirectPath:    proto.String(resolvedDirectPath),
+			MediaKey:      mediaKey,
+			FileSHA256:    fileSHA256,
+			FileEncSHA256: fileEncSHA256,
+			FileLength:    proto.Uint64(fileLength),
+		}, nil
+	case "audio", "ptt":
+		return &waE2E.AudioMessage{
+			URL:           proto.String(mediaURL),
+			DirectPath:    proto.String(resolvedDirectPath),
+			MediaKey:      mediaKey,
+			FileSHA256:    fileSHA256,
+			FileEncSHA256: fileEncSHA256,
+			FileLength:    proto.Uint64(fileLength),
+		}, nil
+	case "document":
+		return &waE2E.DocumentMessage{
+			URL:           proto.String(mediaURL),
+			DirectPath:    proto.String(resolvedDirectPath),
+			MediaKey:      mediaKey,
+			FileSHA256:    fileSHA256,
+			FileEncSHA256: fileEncSHA256,
+			FileLength:    proto.Uint64(fileLength),
+			FileName:      proto.String(filename),
+		}, nil
+	case "sticker":
+		return &waE2E.StickerMessage{
+			URL:           proto.String(mediaURL),
+			DirectPath:    proto.String(resolvedDirectPath),
+			MediaKey:      mediaKey,
+			FileSHA256:    fileSHA256,
+			FileEncSHA256: fileEncSHA256,
+			FileLength:    proto.Uint64(fileLength),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported media type: %s", mediaType)
+	}
 }
 
 // ExtractContextInfo returns the ContextInfo from whichever message sub-type

--- a/src/pkg/utils/whatsapp_test.go
+++ b/src/pkg/utils/whatsapp_test.go
@@ -1,9 +1,11 @@
 package utils
 
 import (
+	"bytes"
 	"testing"
 
 	"go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestDetermineMediaExtension(t *testing.T) {
@@ -239,6 +241,194 @@ func TestExtractMessageTextFromProtoContactsArrayMessage(t *testing.T) {
 				t.Fatalf("ExtractMessageTextFromProto() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExtractMediaInfoIncludesDirectPath(t *testing.T) {
+	mediaKey := []byte("media-key")
+	fileSHA256 := []byte("file-sha")
+	fileEncSHA256 := []byte("file-enc-sha")
+	fileLength := uint64(1234)
+	mediaURL := "https://mmg.whatsapp.net/v/t62.7118-24/media.enc?ccb=11-4"
+	directPath := "/v/t62.7118-24/media.enc?ccb=11-4"
+
+	tests := []struct {
+		name     string
+		msg      *waE2E.Message
+		wantType string
+	}{
+		{
+			name: "Image",
+			msg: &waE2E.Message{ImageMessage: &waE2E.ImageMessage{
+				URL:           proto.String(mediaURL),
+				DirectPath:    proto.String(directPath),
+				MediaKey:      mediaKey,
+				FileSHA256:    fileSHA256,
+				FileEncSHA256: fileEncSHA256,
+				FileLength:    proto.Uint64(fileLength),
+			}},
+			wantType: "image",
+		},
+		{
+			name: "Video",
+			msg: &waE2E.Message{VideoMessage: &waE2E.VideoMessage{
+				URL:           proto.String(mediaURL),
+				DirectPath:    proto.String(directPath),
+				MediaKey:      mediaKey,
+				FileSHA256:    fileSHA256,
+				FileEncSHA256: fileEncSHA256,
+				FileLength:    proto.Uint64(fileLength),
+			}},
+			wantType: "video",
+		},
+		{
+			name: "VideoNote",
+			msg: &waE2E.Message{PtvMessage: &waE2E.VideoMessage{
+				URL:           proto.String(mediaURL),
+				DirectPath:    proto.String(directPath),
+				MediaKey:      mediaKey,
+				FileSHA256:    fileSHA256,
+				FileEncSHA256: fileEncSHA256,
+				FileLength:    proto.Uint64(fileLength),
+			}},
+			wantType: "video_note",
+		},
+		{
+			name: "Audio",
+			msg: &waE2E.Message{AudioMessage: &waE2E.AudioMessage{
+				URL:           proto.String(mediaURL),
+				DirectPath:    proto.String(directPath),
+				MediaKey:      mediaKey,
+				FileSHA256:    fileSHA256,
+				FileEncSHA256: fileEncSHA256,
+				FileLength:    proto.Uint64(fileLength),
+			}},
+			wantType: "audio",
+		},
+		{
+			name: "Document",
+			msg: &waE2E.Message{DocumentMessage: &waE2E.DocumentMessage{
+				URL:           proto.String(mediaURL),
+				DirectPath:    proto.String(directPath),
+				MediaKey:      mediaKey,
+				FileSHA256:    fileSHA256,
+				FileEncSHA256: fileEncSHA256,
+				FileLength:    proto.Uint64(fileLength),
+				FileName:      proto.String("report.pdf"),
+			}},
+			wantType: "document",
+		},
+		{
+			name: "Sticker",
+			msg: &waE2E.Message{StickerMessage: &waE2E.StickerMessage{
+				URL:           proto.String(mediaURL),
+				DirectPath:    proto.String(directPath),
+				MediaKey:      mediaKey,
+				FileSHA256:    fileSHA256,
+				FileEncSHA256: fileEncSHA256,
+				FileLength:    proto.Uint64(fileLength),
+			}},
+			wantType: "sticker",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, _, gotURL, gotDirectPath, gotMediaKey, gotFileSHA256, gotFileEncSHA256, gotFileLength := ExtractMediaInfo(tt.msg)
+			if gotType != tt.wantType {
+				t.Fatalf("mediaType = %q, want %q", gotType, tt.wantType)
+			}
+			if gotURL != mediaURL {
+				t.Fatalf("url = %q, want %q", gotURL, mediaURL)
+			}
+			if gotDirectPath != directPath {
+				t.Fatalf("directPath = %q, want %q", gotDirectPath, directPath)
+			}
+			if !bytes.Equal(gotMediaKey, mediaKey) {
+				t.Fatalf("mediaKey = %q, want %q", gotMediaKey, mediaKey)
+			}
+			if !bytes.Equal(gotFileSHA256, fileSHA256) {
+				t.Fatalf("fileSHA256 = %q, want %q", gotFileSHA256, fileSHA256)
+			}
+			if !bytes.Equal(gotFileEncSHA256, fileEncSHA256) {
+				t.Fatalf("fileEncSHA256 = %q, want %q", gotFileEncSHA256, fileEncSHA256)
+			}
+			if gotFileLength != fileLength {
+				t.Fatalf("fileLength = %d, want %d", gotFileLength, fileLength)
+			}
+		})
+	}
+}
+
+func TestBuildDownloadableMessageSetsDirectPath(t *testing.T) {
+	mediaKey := []byte("media-key")
+	fileSHA256 := []byte("file-sha")
+	fileEncSHA256 := []byte("file-enc-sha")
+	fileLength := uint64(1234)
+	directPath := "/v/t62.7118-24/media.enc?ccb=11-4"
+
+	tests := []struct {
+		name      string
+		mediaType string
+		wantType  any
+	}{
+		{name: "Image", mediaType: "image", wantType: &waE2E.ImageMessage{}},
+		{name: "Video", mediaType: "video", wantType: &waE2E.VideoMessage{}},
+		{name: "VideoNote", mediaType: "video_note", wantType: &waE2E.VideoMessage{}},
+		{name: "Audio", mediaType: "audio", wantType: &waE2E.AudioMessage{}},
+		{name: "PTT", mediaType: "ptt", wantType: &waE2E.AudioMessage{}},
+		{name: "Document", mediaType: "document", wantType: &waE2E.DocumentMessage{}},
+		{name: "Sticker", mediaType: "sticker", wantType: &waE2E.StickerMessage{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildDownloadableMessage(tt.mediaType, "https://mmg.whatsapp.net/ignored", directPath, "report.pdf", mediaKey, fileSHA256, fileEncSHA256, fileLength)
+			if err != nil {
+				t.Fatalf("BuildDownloadableMessage() error = %v", err)
+			}
+			if got.GetDirectPath() != directPath {
+				t.Fatalf("directPath = %q, want %q", got.GetDirectPath(), directPath)
+			}
+			switch tt.wantType.(type) {
+			case *waE2E.ImageMessage:
+				if _, ok := got.(*waE2E.ImageMessage); !ok {
+					t.Fatalf("message type = %T, want *waE2E.ImageMessage", got)
+				}
+			case *waE2E.VideoMessage:
+				if _, ok := got.(*waE2E.VideoMessage); !ok {
+					t.Fatalf("message type = %T, want *waE2E.VideoMessage", got)
+				}
+			case *waE2E.AudioMessage:
+				if _, ok := got.(*waE2E.AudioMessage); !ok {
+					t.Fatalf("message type = %T, want *waE2E.AudioMessage", got)
+				}
+			case *waE2E.DocumentMessage:
+				if _, ok := got.(*waE2E.DocumentMessage); !ok {
+					t.Fatalf("message type = %T, want *waE2E.DocumentMessage", got)
+				}
+			case *waE2E.StickerMessage:
+				if _, ok := got.(*waE2E.StickerMessage); !ok {
+					t.Fatalf("message type = %T, want *waE2E.StickerMessage", got)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveMediaDirectPathFallsBackToURLRequestURI(t *testing.T) {
+	storedDirectPath := "/stored/path.enc?auth=stored"
+	mediaURL := "https://mmg.whatsapp.net/v/t62.7118-24/media.enc?ccb=11-4&oh=token"
+	wantFallback := "/v/t62.7118-24/media.enc?ccb=11-4&oh=token"
+
+	if got := ResolveMediaDirectPath(storedDirectPath, mediaURL); got != storedDirectPath {
+		t.Fatalf("ResolveMediaDirectPath() = %q, want stored direct path %q", got, storedDirectPath)
+	}
+	if got := ResolveMediaDirectPath("", mediaURL); got != wantFallback {
+		t.Fatalf("ResolveMediaDirectPath() = %q, want URL request URI %q", got, wantFallback)
+	}
+	if got := ResolveMediaDirectPath("", "://not-a-url"); got != "" {
+		t.Fatalf("ResolveMediaDirectPath() = %q, want empty for invalid URL", got)
 	}
 }
 

--- a/src/usecase/message.go
+++ b/src/usecase/message.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/validations"
 	"github.com/sirupsen/logrus"
-	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/appstate"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/proto/waSyncAction"
@@ -286,8 +285,10 @@ func (service serviceMessage) DownloadMedia(ctx context.Context, request domainM
 		return response, fmt.Errorf("message with ID %s not found", request.MessageID)
 	}
 
+	directPath := utils.ResolveMediaDirectPath(message.DirectPath, message.URL)
+
 	// Check if message has media
-	if message.MediaType == "" || message.URL == "" {
+	if message.MediaType == "" || directPath == "" {
 		return response, fmt.Errorf("message %s does not contain downloadable media", request.MessageID)
 	}
 
@@ -305,57 +306,22 @@ func (service serviceMessage) DownloadMedia(ctx context.Context, request domainM
 		return response, fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	// Create a downloadable message interface based on media type
-	var downloadableMsg any
-
-	switch message.MediaType {
-	case "image":
-		downloadableMsg = &waE2E.ImageMessage{
-			URL:           proto.String(message.URL),
-			MediaKey:      message.MediaKey,
-			FileSHA256:    message.FileSHA256,
-			FileEncSHA256: message.FileEncSHA256,
-			FileLength:    proto.Uint64(message.FileLength),
-		}
-	case "video":
-		downloadableMsg = &waE2E.VideoMessage{
-			URL:           proto.String(message.URL),
-			MediaKey:      message.MediaKey,
-			FileSHA256:    message.FileSHA256,
-			FileEncSHA256: message.FileEncSHA256,
-			FileLength:    proto.Uint64(message.FileLength),
-		}
-	case "audio":
-		downloadableMsg = &waE2E.AudioMessage{
-			URL:           proto.String(message.URL),
-			MediaKey:      message.MediaKey,
-			FileSHA256:    message.FileSHA256,
-			FileEncSHA256: message.FileEncSHA256,
-			FileLength:    proto.Uint64(message.FileLength),
-		}
-	case "document":
-		downloadableMsg = &waE2E.DocumentMessage{
-			URL:           proto.String(message.URL),
-			MediaKey:      message.MediaKey,
-			FileSHA256:    message.FileSHA256,
-			FileEncSHA256: message.FileEncSHA256,
-			FileLength:    proto.Uint64(message.FileLength),
-			FileName:      proto.String(message.Filename),
-		}
-	case "sticker":
-		downloadableMsg = &waE2E.StickerMessage{
-			URL:           proto.String(message.URL),
-			MediaKey:      message.MediaKey,
-			FileSHA256:    message.FileSHA256,
-			FileEncSHA256: message.FileEncSHA256,
-			FileLength:    proto.Uint64(message.FileLength),
-		}
-	default:
+	downloadableMsg, err := utils.BuildDownloadableMessage(
+		message.MediaType,
+		message.URL,
+		directPath,
+		message.Filename,
+		message.MediaKey,
+		message.FileSHA256,
+		message.FileEncSHA256,
+		message.FileLength,
+	)
+	if err != nil {
 		return response, fmt.Errorf("unsupported media type: %s", message.MediaType)
 	}
 
 	// Download the media using existing utils.ExtractMedia function
-	extractedMedia, err := utils.ExtractMedia(ctx, client, dateDir, downloadableMsg.(whatsmeow.DownloadableMessage))
+	extractedMedia, err := utils.ExtractMedia(ctx, client, dateDir, downloadableMsg)
 	if err != nil {
 		return response, fmt.Errorf("failed to download media: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Store WhatsApp media `direct_path` alongside legacy media URLs in chat messages
- Use the stored direct path, with a URL fallback for older rows, when rebuilding downloadable media
- Add repository and utility coverage for direct-path extraction, resolution, and download reconstruction

Closes #730

## Testing
- Added unit tests for message persistence, media extraction, direct-path fallback, and downloadable media reconstruction
- Added repository tests covering single and batch message storage of `direct_path`