### PR TITLE
Fix: Random API send timeouts under heavy incoming message load

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -10,6 +10,9 @@ APP_TRUSTED_PROXIES=0.0.0.0/0
 # Database Settings
 DB_URI=file:storages/whatsapp.db?_foreign_keys=on
 DB_KEYS_URI=
+# Max concurrent SQLite connections for chat storage (default: 5, min: 1).
+# Increase if API sends time out under heavy incoming message load.
+CHAT_STORAGE_MAX_OPEN_CONNS=5
 
 # WhatsApp Settings
 WHATSAPP_AUTO_REPLY="Auto reply message"

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -112,6 +112,11 @@ func initEnvConfig() {
 	if envDBKEYSURI := viper.GetString("db_keys_uri"); envDBKEYSURI != "" {
 		config.DBKeysURI = envDBKEYSURI
 	}
+	if viper.IsSet("chat_storage_max_open_conns") {
+		if n := viper.GetInt("chat_storage_max_open_conns"); n > 0 {
+			config.ChatStorageMaxOpenConns = n
+		}
+	}
 
 	// WhatsApp settings
 	if envAutoReply := viper.GetString("whatsapp_auto_reply"); envAutoReply != "" {
@@ -520,8 +525,12 @@ func initChatStorage() (*sql.DB, error) {
 	}
 
 	// Configure connection pool
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
+	maxConns := config.ChatStorageMaxOpenConns
+	if maxConns < 1 {
+		maxConns = 1
+	}
+	db.SetMaxOpenConns(maxConns)
+	db.SetMaxIdleConns(maxConns)
 
 	// Test connection
 	if err := db.Ping(); err != nil {

--- a/src/config/settings.go
+++ b/src/config/settings.go
@@ -53,6 +53,7 @@ var (
 	ChatStorageURI               = "file:storages/chatstorage.db"
 	ChatStorageEnableForeignKeys = true
 	ChatStorageEnableWAL         = true
+	ChatStorageMaxOpenConns      = 5 // Max concurrent SQLite connections for chat storage (WAL allows concurrent readers + 1 writer)
 
 	ChatwootEnabled   = false
 	ChatwootURL       = ""

--- a/src/pkg/sqlite/sqlite_cgo.go
+++ b/src/pkg/sqlite/sqlite_cgo.go
@@ -20,7 +20,7 @@ func FormatChatStorageURI(baseURI string, enableWAL bool, enableFK bool) string 
 	q := u.Query()
 	if enableWAL {
 		q.Set("_journal_mode", "WAL")
-		q.Set("_busy_timeout", "5000")
+		q.Set("_busy_timeout", "30000")
 	}
 	if enableFK {
 		q.Set("_foreign_keys", "on")


### PR DESCRIPTION
### Problem

When multiple WhatsApp devices are connected and receiving heavy traffic
from busy groups (especially with media), REST API send requests randomly
time out with a 45-second deadline exceeded error. The issue is
intermittent and worsens with higher incoming message volume.

### Root Cause

The chat storage SQLite connection pool was hardcoded to
`SetMaxOpenConns(1)` / `SetMaxIdleConns(1)`, serializing **all** database
access across all devices, event handlers, REST API handlers, and
background workers through a single connection.

Although WAL mode is enabled (which allows concurrent readers + 1 writer),
the single-connection pool defeats this — every DB read in the send path
(such as `GetChat` for ephemeral expiration, `GetMessageByIDAndDevice` for
reply context) queues behind event-handler writes from incoming messages,
consuming the 45-second request timeout.

Additionally, the CGO SQLite build had a `busy_timeout` of only 5 seconds,
while the purego build uses 30 seconds. With increased connection
concurrency, write contention rises, and 5 seconds is too short — queries
fail with `SQLITE_BUSY` instead of waiting.

### Changes

1. **`src/config/settings.go`**: Added `ChatStorageMaxOpenConns` config
   variable with a default of 5 (enough for multi-device + API + workers).

2. **`src/cmd/root.go`**: 
   - Added `viper.IsSet("chat_storage_max_open_conns")` env binding
     (env var: `CHAT_STORAGE_MAX_OPEN_CONNS`), following the existing
     pattern used by `chatwoot_account_id` and other integer configs.
   - Replaced hardcoded `SetMaxOpenConns(1)` / `SetMaxIdleConns(1)` with
     the configurable value, clamped to a minimum of 1.

3. **`src/pkg/sqlite/sqlite_cgo.go`**: Increased `_busy_timeout` from
   `5000` to `30000` to match the purego build. This prevents
   `SQLITE_BUSY` errors when multiple connections contend for writes.

4. **`src/.env.example`**: Documented the new `CHAT_STORAGE_MAX_OPEN_CONNS`
   environment variable.

### Why 5 connections?

- SQLite WAL mode allows N concurrent readers + 1 writer simultaneously
- With `MaxOpenConns(1)`, even reads are serialized at the Go pool level
- A default of 5 provides enough concurrency for 3 devices + REST API +
  background workers, while keeping SQLite write contention manageable
- The `busy_timeout` of 30s ensures contended writes wait instead of failing

### Backward Compatibility

- Default behavior changes from 1 connection to 5 connections
- Users who need the old behavior can set `CHAT_STORAGE_MAX_OPEN_CONNS=1`
- WAL mode + `busy_timeout=30000` makes 5 connections safe — SQLite
  handles write contention gracefully by waiting up to 30 seconds

### Usage

```bash
# Default (5 connections) — no config needed
docker compose up

# Increase for more devices / higher load
CHAT_STORAGE_MAX_OPEN_CONNS=10

# Revert to old behavior if needed
CHAT_STORAGE_MAX_OPEN_CONNS=1
Testing
- go vet ./... — pass
- go build . — pass
- go test ./... — all existing tests pass