### PR TITLE
fix: don't panic on non-multipart POST /send/file requests

### DIFF
--- a/src/ui/rest/send.go
+++ b/src/ui/rest/send.go
@@ -76,10 +76,11 @@ func (controller *Send) SendFile(c *fiber.Ctx) error {
 	err := c.BodyParser(&request)
 	utils.PanicIfNeeded(err)
 
-	file, err := c.FormFile("file")
-	utils.PanicIfNeeded(err)
+	// Try to get file but ignore error if not provided (e.g. file_url is used instead)
+	if file, errFile := c.FormFile("file"); errFile == nil {
+		request.File = file
+	}
 
-	request.File = file
 	utils.SanitizePhone(&request.Phone)
 
 	response, err := controller.Service.SendFile(whatsapp.ContextWithDevice(c.UserContext(), getDeviceFromCtx(c)), request)

--- a/src/ui/rest/send_test.go
+++ b/src/ui/rest/send_test.go
@@ -1,0 +1,113 @@
+package rest
+
+import (
+	"bytes"
+	"context"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	domainSend "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/send"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/ui/rest/middleware"
+	"github.com/gofiber/fiber/v2"
+)
+
+// sendFileStubUsecase implements domainSend.ISendUsecase by embedding the
+// interface (so unrelated methods are never invoked by these tests) while
+// recording the FileRequest actually received by SendFile.
+type sendFileStubUsecase struct {
+	domainSend.ISendUsecase
+	receivedRequest domainSend.FileRequest
+	called          bool
+}
+
+func (s *sendFileStubUsecase) SendFile(_ context.Context, request domainSend.FileRequest) (domainSend.GenericResponse, error) {
+	s.called = true
+	s.receivedRequest = request
+	return domainSend.GenericResponse{Status: "ok"}, nil
+}
+
+func newSendFileTestApp(stub *sendFileStubUsecase) *fiber.App {
+	app := fiber.New()
+	app.Use(middleware.Recovery())
+	controller := Send{Service: stub}
+	app.Post("/send/file", controller.SendFile)
+	return app
+}
+
+// TestSendFileJSONBodyWithFileURLDoesNotPanic is a regression test for
+// https://github.com/aldinokemal/go-whatsapp-web-multidevice/issues/744:
+// a JSON request carrying file_url (no multipart file part) must reach the
+// usecase instead of panicking into a 500 from the unguarded FormFile error.
+func TestSendFileJSONBodyWithFileURLDoesNotPanic(t *testing.T) {
+	stub := &sendFileStubUsecase{}
+	app := newSendFileTestApp(stub)
+
+	body := `{"phone":"628123456789@s.whatsapp.net","file_url":"https://example.com/doc.pdf"}`
+	req := httptest.NewRequest(http.MethodPost, "/send/file", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want %d (request should not panic into a 500)", resp.StatusCode, fiber.StatusOK)
+	}
+	if !stub.called {
+		t.Fatalf("usecase SendFile was not called")
+	}
+	if stub.receivedRequest.FileURL == nil || *stub.receivedRequest.FileURL != "https://example.com/doc.pdf" {
+		t.Fatalf("FileURL = %v, want https://example.com/doc.pdf", stub.receivedRequest.FileURL)
+	}
+	if stub.receivedRequest.File != nil {
+		t.Fatalf("File = %+v, want nil since no multipart file part was sent", stub.receivedRequest.File)
+	}
+}
+
+// TestSendFileMultipartStillPopulatesFile ensures the original multipart
+// upload path keeps working after guarding the FormFile error.
+func TestSendFileMultipartStillPopulatesFile(t *testing.T) {
+	stub := &sendFileStubUsecase{}
+	app := newSendFileTestApp(stub)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if err := writer.WriteField("phone", "628123456789@s.whatsapp.net"); err != nil {
+		t.Fatalf("WriteField: %v", err)
+	}
+	part, err := writer.CreateFormFile("file", "doc.pdf")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write([]byte("%PDF-1.4 fake content")); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/send/file", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, fiber.StatusOK)
+	}
+	if !stub.called {
+		t.Fatalf("usecase SendFile was not called")
+	}
+	if stub.receivedRequest.File == nil {
+		t.Fatalf("File = nil, want populated multipart.FileHeader")
+	}
+	if stub.receivedRequest.File.Filename != "doc.pdf" {
+		t.Fatalf("File.Filename = %q, want doc.pdf", stub.receivedRequest.File.Filename)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #744.

### Problem
`POST /send/file` panicked into a 500 whenever the request wasn't `multipart/form-data`, because `SendFile` called `c.FormFile("file")` and panicked unconditionally on error:

```go
file, err := c.FormFile("file")
utils.PanicIfNeeded(err)
```

`SendImage`, `SendVideo`, `SendAudio`, and `SendSticker` all guard this same lookup with `if err == nil`. `SendFile` was the only handler that didn't, which made the `file_url` JSON path (already implemented in `usecase.SendFile` and `validations.ValidateSendFile`) unreachable dead code.

### Fix
Match the sibling handlers and ignore the `FormFile` error when no multipart file part is present, letting `request.FileURL` (or usecase-level validation) take over:

```go
if file, errFile := c.FormFile("file"); errFile == nil {
    request.File = file
}
```

### Testing
Added `src/ui/rest/send_test.go` with two regression tests run against a stub `ISendUsecase`:
- `TestSendFileJSONBodyWithFileURLDoesNotPanic` reproduces the exact issue repro (JSON body with `file_url`, no multipart part) and asserts a 200 instead of a panic-induced 500.
- `TestSendFileMultipartStillPopulatesFile` asserts the original multipart upload path still populates `request.File`.

Verified the first test fails with the pre-fix code (reproducing the issue's exact panic message) and passes after the fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fbd2685-8a5e-4bf0-9229-f5a325bc97ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fbd2685-8a5e-4bf0-9229-f5a325bc97ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

