### PR TITLE
feat(newsletter): add endpoint to get latest newsletter messages

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3170,6 +3170,56 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorInternalServer'
+  /newsletter/messages:
+    get:
+      operationId: getNewsletterMessages
+      tags:
+        - newsletter
+      summary: Get latest newsletter (channel) messages
+      description: |
+        Fetches the latest messages posted in a newsletter (channel) directly
+        from WhatsApp servers. You must be following/subscribed to the
+        newsletter to fetch its messages.
+      parameters:
+        - $ref: '#/components/parameters/DeviceIdHeader'
+        - name: newsletter_id
+          in: query
+          required: true
+          schema:
+            type: string
+          example: '120363024512399999@newsletter'
+        - name: count
+          in: query
+          required: false
+          description: Number of messages to return (default 50, max 100)
+          schema:
+            type: integer
+            default: 50
+        - name: before
+          in: query
+          required: false
+          description: Fetch messages older than this message server ID, used for pagination
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NewsletterMessagesResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBadRequest'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInternalServer'
 
   /chatwoot/sync:
     post:
@@ -4050,6 +4100,48 @@ components:
             role:
               type: string
               example: "subscriber"
+    NewsletterMessagesResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          example: "SUCCESS"
+        message:
+          type: string
+          example: "Success get newsletter messages"
+        results:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/NewsletterMessage'
+    NewsletterMessage:
+      type: object
+      properties:
+        server_id:
+          type: integer
+          example: 123
+        message_id:
+          type: string
+          example: "3EB0XXXXXXXXXXXXXXXX"
+        type:
+          type: string
+          example: "text"
+        timestamp:
+          type: string
+          example: "2026-06-30T10:00:00Z"
+        views_count:
+          type: integer
+          example: 42
+        reaction_counts:
+          type: object
+          additionalProperties:
+            type: integer
+          example: { "😀": 3, "👍": 5 }
+        text:
+          type: string
+          example: "Hello from the channel!"
     MyListContactsResponse:
       type: object
       properties:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3195,12 +3195,15 @@ paths:
           schema:
             type: integer
             default: 50
+            minimum: 1
+            maximum: 100
         - name: before
           in: query
           required: false
           description: Fetch messages older than this message server ID, used for pagination
           schema:
             type: integer
+            minimum: 0
       responses:
         '200':
           description: OK

--- a/readme.md
+++ b/readme.md
@@ -600,6 +600,7 @@ You can fork or edit this source code !
 | ✅       | Set Group Topic                        | POST   | /group/topic                        |
 | ✅       | Get Group Invite Link                  | GET    | /group/invite-link                  |
 | ✅       | Unfollow Newsletter                    | POST   | /newsletter/unfollow                |
+| ✅       | Get Newsletter Messages                | GET    | /newsletter/messages                |
 | ✅       | Get Chat List                          | GET    | /chats                              |
 | ✅       | Get Chat Messages                      | GET    | /chat/:chat_jid/messages            |
 | ✅       | Label Chat                             | POST   | /chat/:chat_jid/label               |

--- a/src/config/settings.go
+++ b/src/config/settings.go
@@ -44,6 +44,7 @@ var (
 	WhatsappTypeUser                           = "@s.whatsapp.net"
 	WhatsappTypeGroup                          = "@g.us"
 	WhatsappTypeLid                            = "@lid"
+	WhatsappTypeNewsletter                     = "@newsletter"
 	WhatsappAccountValidation                  = true
 	WhatsappPresenceOnConnect                  = "unavailable" // Presence to send on connect: "available", "unavailable", or "none"
 	WhatsappPresencePulseEnabled               = true          // Periodically pulse presence available, then unavailable

--- a/src/domains/newsletter/newsletter.go
+++ b/src/domains/newsletter/newsletter.go
@@ -4,8 +4,36 @@ import "context"
 
 type INewsletterUsecase interface {
 	Unfollow(ctx context.Context, request UnfollowRequest) (err error)
+	GetMessages(ctx context.Context, request GetMessagesRequest) (response GetMessagesResponse, err error)
 }
 
 type UnfollowRequest struct {
 	NewsletterID string `json:"newsletter_id" form:"newsletter_id"`
+}
+
+// GetMessagesRequest fetches the latest messages posted in a newsletter (channel)
+// directly from WhatsApp servers.
+type GetMessagesRequest struct {
+	NewsletterID string `json:"newsletter_id" query:"newsletter_id"`
+	// Count limits how many messages are returned. Defaults to 50, capped at 100.
+	Count int `json:"count" query:"count"`
+	// Before paginates backwards from a given message server ID (exclusive),
+	// used to load older messages than the ones already fetched.
+	Before int `json:"before" query:"before"`
+}
+
+// Message represents a single newsletter (channel) message returned by
+// GetMessagesRequest.
+type Message struct {
+	ServerID       int            `json:"server_id"`
+	MessageID      string         `json:"message_id"`
+	Type           string         `json:"type"`
+	Timestamp      string         `json:"timestamp"`
+	ViewsCount     int            `json:"views_count"`
+	ReactionCounts map[string]int `json:"reaction_counts,omitempty"`
+	Text           string         `json:"text,omitempty"`
+}
+
+type GetMessagesResponse struct {
+	Data []Message `json:"data"`
 }

--- a/src/ui/rest/newsletter.go
+++ b/src/ui/rest/newsletter.go
@@ -14,6 +14,7 @@ type Newsletter struct {
 func InitRestNewsletter(app fiber.Router, service domainNewsletter.INewsletterUsecase) Newsletter {
 	rest := Newsletter{Service: service}
 	app.Post("/newsletter/unfollow", rest.Unfollow)
+	app.Get("/newsletter/messages", rest.GetMessages)
 	return rest
 }
 
@@ -29,5 +30,21 @@ func (controller *Newsletter) Unfollow(c *fiber.Ctx) error {
 		Status:  200,
 		Code:    "SUCCESS",
 		Message: "Success unfollow newsletter",
+	})
+}
+
+func (controller *Newsletter) GetMessages(c *fiber.Ctx) error {
+	var request domainNewsletter.GetMessagesRequest
+	err := c.QueryParser(&request)
+	utils.PanicIfNeeded(err)
+
+	response, err := controller.Service.GetMessages(whatsapp.ContextWithDevice(c.UserContext(), getDeviceFromCtx(c)), request)
+	utils.PanicIfNeeded(err)
+
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: "Success get newsletter messages",
+		Results: response,
 	})
 }

--- a/src/usecase/newsletter.go
+++ b/src/usecase/newsletter.go
@@ -2,12 +2,15 @@ package usecase
 
 import (
 	"context"
+	"time"
 
 	domainNewsletter "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/newsletter"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/validations"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
 )
 
 type serviceNewsletter struct{}
@@ -32,4 +35,47 @@ func (service serviceNewsletter) Unfollow(ctx context.Context, request domainNew
 	}
 
 	return client.UnfollowNewsletter(ctx, JID)
+}
+
+func (service serviceNewsletter) GetMessages(ctx context.Context, request domainNewsletter.GetMessagesRequest) (response domainNewsletter.GetMessagesResponse, err error) {
+	if err = validations.ValidateGetNewsletterMessages(ctx, &request); err != nil {
+		return response, err
+	}
+
+	client := whatsapp.ClientFromContext(ctx)
+	if client == nil {
+		return response, pkgError.ErrWaCLI
+	}
+
+	JID, err := utils.ValidateJidWithLogin(client, request.NewsletterID)
+	if err != nil {
+		return response, err
+	}
+
+	params := &whatsmeow.GetNewsletterMessagesParams{
+		Count: request.Count,
+	}
+	if request.Before != 0 {
+		params.Before = types.MessageServerID(request.Before)
+	}
+
+	messages, err := client.GetNewsletterMessages(ctx, JID, params)
+	if err != nil {
+		return response, err
+	}
+
+	response.Data = make([]domainNewsletter.Message, 0, len(messages))
+	for _, msg := range messages {
+		response.Data = append(response.Data, domainNewsletter.Message{
+			ServerID:       int(msg.MessageServerID),
+			MessageID:      string(msg.MessageID),
+			Type:           msg.Type,
+			Timestamp:      msg.Timestamp.Format(time.RFC3339),
+			ViewsCount:     msg.ViewsCount,
+			ReactionCounts: msg.ReactionCounts,
+			Text:           utils.ExtractMessageTextFromProto(msg.Message),
+		})
+	}
+
+	return response, nil
 }

--- a/src/validations/newsletter_validation.go
+++ b/src/validations/newsletter_validation.go
@@ -18,3 +18,22 @@ func ValidateUnfollowNewsletter(ctx context.Context, request domainNewsletter.Un
 
 	return nil
 }
+
+func ValidateGetNewsletterMessages(ctx context.Context, request *domainNewsletter.GetMessagesRequest) error {
+	// Set default count if not provided
+	if request.Count == 0 {
+		request.Count = 50
+	}
+
+	err := validation.ValidateStructWithContext(ctx, request,
+		validation.Field(&request.NewsletterID, validation.Required),
+		validation.Field(&request.Count, validation.Min(1), validation.Max(100)),
+		validation.Field(&request.Before, validation.Min(0)),
+	)
+
+	if err != nil {
+		return pkgError.ValidationError(err.Error())
+	}
+
+	return nil
+}

--- a/src/validations/newsletter_validation.go
+++ b/src/validations/newsletter_validation.go
@@ -2,6 +2,9 @@ package validations
 
 import (
 	"context"
+	"strings"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	domainNewsletter "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/newsletter"
 	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -26,7 +29,7 @@ func ValidateGetNewsletterMessages(ctx context.Context, request *domainNewslette
 	}
 
 	err := validation.ValidateStructWithContext(ctx, request,
-		validation.Field(&request.NewsletterID, validation.Required),
+		validation.Field(&request.NewsletterID, validation.Required, validation.By(validateNewsletterJIDShape)),
 		validation.Field(&request.Count, validation.Min(1), validation.Max(100)),
 		validation.Field(&request.Before, validation.Min(0)),
 	)
@@ -35,5 +38,21 @@ func ValidateGetNewsletterMessages(ctx context.Context, request *domainNewslette
 		return pkgError.ValidationError(err.Error())
 	}
 
+	return nil
+}
+
+// validateNewsletterJIDShape rejects newsletter IDs that are not shaped like a
+// newsletter JID (e.g. a phone/group JID), so mistargeted requests fail fast
+// with a clear validation error instead of a WhatsApp protocol round-trip.
+func validateNewsletterJIDShape(value any) error {
+	id, ok := value.(string)
+	if !ok || id == "" {
+		// Presence is already enforced by validation.Required; skip format
+		// checking on empty/non-string values here.
+		return nil
+	}
+	if !strings.HasSuffix(id, config.WhatsappTypeNewsletter) {
+		return pkgError.ValidationError("must end with " + config.WhatsappTypeNewsletter)
+	}
 	return nil
 }

--- a/src/validations/newsletter_validation_test.go
+++ b/src/validations/newsletter_validation_test.go
@@ -48,3 +48,58 @@ func TestValidateUnfollowNewsletter(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateGetNewsletterMessages(t *testing.T) {
+	tests := []struct {
+		name       string
+		request    domainNewsletter.GetMessagesRequest
+		err        any
+		wantCount  int
+		wantBefore int
+	}{
+		{
+			name:      "should success with valid newsletter id and default count",
+			request:   domainNewsletter.GetMessagesRequest{NewsletterID: "120363123456789@newsletter"},
+			err:       nil,
+			wantCount: 50,
+		},
+		{
+			name:       "should success with explicit count and before",
+			request:    domainNewsletter.GetMessagesRequest{NewsletterID: "120363123456789@newsletter", Count: 10, Before: 100},
+			err:        nil,
+			wantCount:  10,
+			wantBefore: 100,
+		},
+		{
+			name:    "should error with empty newsletter id",
+			request: domainNewsletter.GetMessagesRequest{},
+			err:     pkgError.ValidationError("newsletter_id: cannot be blank."),
+		},
+		{
+			name:      "should error when count exceeds max",
+			request:   domainNewsletter.GetMessagesRequest{NewsletterID: "120363123456789@newsletter", Count: 101},
+			err:       pkgError.ValidationError("count: must be no greater than 100."),
+			wantCount: 101,
+		},
+		{
+			name:      "should error with negative before",
+			request:   domainNewsletter.GetMessagesRequest{NewsletterID: "120363123456789@newsletter", Before: -1},
+			err:       pkgError.ValidationError("before: must be no less than 0."),
+			wantCount: 50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.request
+			err := ValidateGetNewsletterMessages(context.Background(), &req)
+			assert.Equal(t, tt.err, err)
+			if tt.wantCount != 0 {
+				assert.Equal(t, tt.wantCount, req.Count)
+			}
+			if tt.wantBefore != 0 {
+				assert.Equal(t, tt.wantBefore, req.Before)
+			}
+		})
+	}
+}

--- a/src/validations/newsletter_validation_test.go
+++ b/src/validations/newsletter_validation_test.go
@@ -87,6 +87,18 @@ func TestValidateGetNewsletterMessages(t *testing.T) {
 			err:       pkgError.ValidationError("before: must be no less than 0."),
 			wantCount: 50,
 		},
+		{
+			name:      "should error with a non-newsletter jid (phone)",
+			request:   domainNewsletter.GetMessagesRequest{NewsletterID: "6289685028129@s.whatsapp.net"},
+			err:       pkgError.ValidationError("newsletter_id: must end with @newsletter."),
+			wantCount: 50,
+		},
+		{
+			name:      "should error with a non-newsletter jid (group)",
+			request:   domainNewsletter.GetMessagesRequest{NewsletterID: "120363123456789@g.us"},
+			err:       pkgError.ValidationError("newsletter_id: must end with @newsletter."),
+			wantCount: 50,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #643.

### Summary

The issue asks whether it's possible to fetch the latest message(s) from a newsletter (WhatsApp channel). It is: `whatsmeow` exposes `Client.GetNewsletterMessages(ctx, jid, params)`, which returns decrypted `*types.NewsletterMessage` items (including the underlying `waE2E.Message` for text/caption extraction), so this PR wires that up as a new REST endpoint.

- `GET /newsletter/messages?newsletter_id=...&count=...&before=...`
- `count` defaults to 50, capped at 100.
- `before` (a message server ID) pages backwards to load older messages.
- Each item includes `server_id`, `message_id`, `type`, `timestamp`, `views_count`, `reaction_counts`, and `text` (extracted via the existing `utils.ExtractMessageTextFromProto` helper used elsewhere for chat messages).
- Follows the same device-scoped/validate-then-call-whatsmeow pattern as the existing `Unfollow` newsletter usecase.

### Changes
* `src/domains/newsletter/newsletter.go`: add `GetMessagesRequest`/`GetMessagesResponse`/`Message` DTOs and extend `INewsletterUsecase`.
* `src/validations/newsletter_validation.go`: add `ValidateGetNewsletterMessages` (required `newsletter_id` shaped as a real `@newsletter` JID, `count` 1-100 default 50, `before` >= 0).
* `src/config/settings.go`: add `WhatsappTypeNewsletter` constant (`@newsletter`), matching the existing `WhatsappTypeUser`/`WhatsappTypeGroup`/`WhatsappTypeLid` constants.
* `src/usecase/newsletter.go`: implement `GetMessages`, calling `whatsmeow`'s `GetNewsletterMessages`.
* `src/ui/rest/newsletter.go`: register `GET /newsletter/messages`.
* `docs/openapi.yaml`, `readme.md`: document the new endpoint, including `minimum`/`maximum` bounds on `count`/`before` matching server-side validation.

### Review feedback addressed
* **CodeRabbit** — non-newsletter JIDs (phone/group) previously only failed deep inside a WhatsApp protocol round-trip; `ValidateGetNewsletterMessages` now rejects them up front with a clear `newsletter_id: must end with @newsletter.` validation error, with test coverage.
* **kilo-code-bot** — `docs/openapi.yaml` now declares `minimum: 1`/`maximum: 100` for `count` and `minimum: 0` for `before`, matching the validation layer.
* **CodeRabbit** also flagged `utils.ValidateJidWithLogin` as running phone-account validation on newsletter JIDs — verified this is not the case (see Testing) and left unchanged; it's the same shared helper already used unmodified by `Unfollow`.

### Testing
* ✅ `cd src && go build ./...`
* ✅ `cd src && go vet ./...`
* ✅ `cd src && go test ./...`
* ✅ Table-driven tests for `ValidateGetNewsletterMessages`, including non-newsletter JID rejection (phone and group JIDs).
* ✅ Verified the CodeRabbit `ValidateJidWithLogin` claim is incorrect: `IsOnWhatsapp` only runs the phone-number check when the JID contains `@s.whatsapp.net`; called `IsOnWhatsapp(nil, "...@newsletter")` directly and it returned `true` without touching the nil client (which would panic if the phone-check branch ran), proving newsletter JIDs already skip that path.
* ✅ Started the REST server and curled the new route end-to-end: missing `newsletter_id` → `400 VALIDATION_ERROR`, non-newsletter JIDs (phone/group) → `400 VALIDATION_ERROR` (new), out-of-range `count`/`before` → `400 VALIDATION_ERROR`, valid newsletter JID on a disconnected client → `500 INVALID_WA_CLI` (same failure mode as the existing `Unfollow` endpoint without a logged-in client).
* ⚠️ Could not test against a real subscribed WhatsApp channel end-to-end (requires QR login plus an actual channel subscription, unavailable in this sandbox).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d513fe7-caaa-429d-aeb7-0820b16aa394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d513fe7-caaa-429d-aeb7-0820b16aa394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

