### PR TITLE
feat(webhook): add option to forward receipts from all linked devices

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,7 @@ To use environment variables:
 | `WHATSAPP_WEBHOOK_SECRET`               | Webhook secret for validation                                 | `secret`                                     | `WHATSAPP_WEBHOOK_SECRET=super-secret-key`    |
 | `WHATSAPP_WEBHOOK_INSECURE_SKIP_VERIFY` | Skip TLS verification for webhooks (insecure)                 | `false`                                      | `WHATSAPP_WEBHOOK_INSECURE_SKIP_VERIFY=true`  |
 | `WHATSAPP_WEBHOOK_EVENTS`               | Whitelist of events to forward (comma-separated, empty = all) | -                                            | `WHATSAPP_WEBHOOK_EVENTS=message,message.ack` |
+| `WHATSAPP_WEBHOOK_ALL_DEVICE_RECEIPTS`  | Forward receipts from all linked devices (not only primary)   | `false`                                      | `WHATSAPP_WEBHOOK_ALL_DEVICE_RECEIPTS=true`   |
 | `WHATSAPP_ACCOUNT_VALIDATION`           | Enable account validation                                     | `true`                                       | `WHATSAPP_ACCOUNT_VALIDATION=false`           |
 | `WHATSAPP_PRESENCE_ON_CONNECT`          | Presence on connect: `available`, `unavailable`, or `none`    | `unavailable`                                | `WHATSAPP_PRESENCE_ON_CONNECT=unavailable`    |
 | `WHATSAPP_PRESENCE_PULSE_ENABLED`       | Enable daily available/unavailable presence pulse             | `true`                                       | `WHATSAPP_PRESENCE_PULSE_ENABLED=false`       |

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -144,6 +144,9 @@ func initEnvConfig() {
 		events := strings.Split(envWebhookEvents, ",")
 		config.WhatsappWebhookEvents = events
 	}
+	if viper.IsSet("whatsapp_webhook_all_device_receipts") {
+		config.WhatsappWebhookAllDeviceReceipts = viper.GetBool("whatsapp_webhook_all_device_receipts")
+	}
 	if viper.IsSet("whatsapp_account_validation") {
 		config.WhatsappAccountValidation = viper.GetBool("whatsapp_account_validation")
 	}
@@ -357,6 +360,12 @@ func initFlags() {
 		"webhook-events", "",
 		config.WhatsappWebhookEvents,
 		`whitelist of events to forward to webhook (empty = all events) --webhook-events <string> | example: --webhook-events="message,message.ack,group.participants"`,
+	)
+	rootCmd.PersistentFlags().BoolVarP(
+		&config.WhatsappWebhookAllDeviceReceipts,
+		"webhook-all-device-receipts", "",
+		config.WhatsappWebhookAllDeviceReceipts,
+		`forward receipts from all linked devices instead of only the primary device --webhook-all-device-receipts <true/false> | example: --webhook-all-device-receipts=true`,
 	)
 	rootCmd.PersistentFlags().BoolVarP(
 		&config.WhatsappAccountValidation,

--- a/src/config/settings.go
+++ b/src/config/settings.go
@@ -35,6 +35,7 @@ var (
 	WhatsappWebhookSecret             = "secret"
 	WhatsappWebhookInsecureSkipVerify = false          // Skip TLS certificate verification for webhooks (insecure)
 	WhatsappWebhookEvents             []string         // Whitelist of events to forward to webhook (empty = all events)
+	WhatsappWebhookAllDeviceReceipts           = false // Forward receipts from all linked devices, not only the primary device
 	WhatsappAutoRejectCall                     = false // Auto-reject incoming calls
 	WhatsappLogLevel                           = "ERROR"
 	WhatsappSettingMaxImageSize       int64    = 20000000  // 20MB

--- a/src/infrastructure/whatsapp/event_receipt.go
+++ b/src/infrastructure/whatsapp/event_receipt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/types"
@@ -77,20 +78,28 @@ func createReceiptPayload(ctx context.Context, evt *events.Receipt, deviceID str
 	return body
 }
 
+// shouldForwardReceipt reports whether a receipt event should be forwarded to webhooks.
+//
+// By default only receipts sent from the primary device (Device == 0) are forwarded.
+// WhatsApp emits a separate receipt event for each linked device (phone, web, desktop,
+// etc.) of a user, so forwarding everything would duplicate webhooks for users whose
+// phone is online.
+//
+// However, when the counterpart uses WhatsApp mainly through linked/companion devices
+// (WhatsApp Web, Desktop, another gateway instance) and their primary phone stays
+// offline, every receipt they emit comes from a non-zero device and would be dropped —
+// delivered/read status then never reaches the webhook at all. Enabling
+// --webhook-all-device-receipts (env WHATSAPP_WEBHOOK_ALL_DEVICE_RECEIPTS) forwards
+// receipts from every device; downstream consumers should apply receipts idempotently
+// (e.g. a monotonic sent < delivered < read merge), which makes duplicates harmless.
+func shouldForwardReceipt(evt *events.Receipt) bool {
+	return config.WhatsappWebhookAllDeviceReceipts || evt.Sender.Device == 0
+}
+
 // forwardReceiptToWebhook forwards message acknowledgement events to the configured webhook URLs.
-//
-// IMPORTANT: We only forward receipts from the primary device (Device == 0).
-// WhatsApp sends separate receipt events for each linked device (phone, web, desktop, etc.)
-// of a user. For example, if a user has 3 devices, you would receive 3 "delivered" receipts
-// for the same message. To avoid duplicate webhooks and simplify downstream processing,
-// we only send the receipt from the primary device (Device == 0).
-//
-// If you need receipts from all devices in the future, remove the Device == 0 check below.
 func forwardReceiptToWebhook(ctx context.Context, evt *events.Receipt, deviceID string, client *whatsmeow.Client) error {
-	// Only forward receipts from the primary device to avoid duplicates.
-	// See function comment above for detailed explanation.
-	if evt.Sender.Device != 0 {
-		logrus.Debugf("Skipping receipt webhook for linked device %d (only primary device receipts are forwarded)", evt.Sender.Device)
+	if !shouldForwardReceipt(evt) {
+		logrus.Debugf("Skipping receipt webhook for linked device %d (enable --webhook-all-device-receipts to forward receipts from all devices)", evt.Sender.Device)
 		return nil
 	}
 

--- a/src/infrastructure/whatsapp/event_receipt_test.go
+++ b/src/infrastructure/whatsapp/event_receipt_test.go
@@ -1,0 +1,45 @@
+package whatsapp
+
+import (
+	"testing"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+func receiptFromDevice(device uint16) *events.Receipt {
+	return &events.Receipt{
+		MessageSource: types.MessageSource{
+			Sender: types.JID{User: "6289685028129", Device: device, Server: types.DefaultUserServer},
+		},
+	}
+}
+
+func TestShouldForwardReceipt_PrimaryDeviceOnlyByDefault(t *testing.T) {
+	original := config.WhatsappWebhookAllDeviceReceipts
+	defer func() { config.WhatsappWebhookAllDeviceReceipts = original }()
+
+	config.WhatsappWebhookAllDeviceReceipts = false
+
+	if !shouldForwardReceipt(receiptFromDevice(0)) {
+		t.Error("receipt from the primary device (Device == 0) should be forwarded by default")
+	}
+	if shouldForwardReceipt(receiptFromDevice(2)) {
+		t.Error("receipt from a linked device should be skipped by default")
+	}
+}
+
+func TestShouldForwardReceipt_AllDevicesWhenEnabled(t *testing.T) {
+	original := config.WhatsappWebhookAllDeviceReceipts
+	defer func() { config.WhatsappWebhookAllDeviceReceipts = original }()
+
+	config.WhatsappWebhookAllDeviceReceipts = true
+
+	if !shouldForwardReceipt(receiptFromDevice(0)) {
+		t.Error("receipt from the primary device should be forwarded when all-device forwarding is enabled")
+	}
+	if !shouldForwardReceipt(receiptFromDevice(5)) {
+		t.Error("receipt from a linked device should be forwarded when all-device forwarding is enabled")
+	}
+}


### PR DESCRIPTION
## Context

`forwardReceiptToWebhook` currently drops every receipt whose sender is not the primary device (`evt.Sender.Device != 0`). The intent — avoiding duplicate webhooks when a user has several linked devices — is sound, but it has a blind spot: **when the counterpart uses WhatsApp exclusively through linked/companion devices** (WhatsApp Web/Desktop, or another gateway instance) **and their primary phone stays offline, every receipt they emit comes from a non-zero device**, so `message.ack` webhooks are never delivered at all. Downstream systems can then never render delivered/read (gray/blue tick) status.

We hit this in production: two accounts operated entirely through companion devices exchanged messages for weeks — the webhook endpoint received **264 `message.ack` events on the day the devices were paired (physical phones online) and exactly 1 during the following 25 days**. The receipts arrived at whatsmeow correctly the whole time but were silently dropped by this check (the skip is only logged at debug level).

This PR adds an opt-in flag, keeping the default behavior unchanged:

- `--webhook-all-device-receipts=true` (env `WHATSAPP_WEBHOOK_ALL_DEVICE_RECEIPTS=true`) forwards receipts from every device.
- Default (`false`) keeps forwarding only primary-device receipts, exactly as before.
- The check is extracted into a small `shouldForwardReceipt` helper with unit tests.
- Consumers that enable the flag should apply receipts idempotently (e.g. a monotonic `sent < delivered < read` merge), which makes multi-device duplicates harmless — noted in the code comment and readme.

## Test Results

- `go build ./...`, `go vet ./...`, `gofmt -l` all clean.
- New unit tests pass: `TestShouldForwardReceipt_PrimaryDeviceOnlyByDefault`, `TestShouldForwardReceipt_AllDevicesWhenEnabled`.
- Verified on a live deployment (v8.5.0 base + this change, flag enabled): `delivered` receipts reach the webhook ~1.5 s and `read` receipts ~4 s after the counterpart reads, including when both parties are companion-device-only; receipt `ids` carry the sender-side canonical message IDs, so ticks can be matched directly to the sent messages. With the flag off, behavior is byte-identical to current `main`.
