### PR TITLE
feat(webhook): ignore group messages per instance, not just globally

### DIFF
--- a/src/domains/chatstorage/chatstorage.go
+++ b/src/domains/chatstorage/chatstorage.go
@@ -137,6 +137,7 @@ type DeviceRecord struct {
 	WebhookSecret             string    `db:"webhook_secret"`
 	WebhookEvents             string    `db:"webhook_events"`
 	WebhookInsecureSkipVerify bool      `db:"webhook_insecure_skip_verify"`
+	WebhookIgnoreGroups       *bool     `db:"webhook_ignore_groups"`
 	CreatedAt                 time.Time `db:"created_at"`
 	UpdatedAt                 time.Time `db:"updated_at"`
 }
@@ -147,6 +148,10 @@ type DeviceWebhookConfig struct {
 	WebhookSecret             string  `json:"webhook_secret,omitempty"`
 	WebhookEvents             string  `json:"webhook_events,omitempty"`
 	WebhookInsecureSkipVerify bool    `json:"webhook_insecure_skip_verify,omitempty"`
+	// WebhookIgnoreGroups overrides WHATSAPP_WEBHOOK_IGNORE_JIDS's "@g.us" wildcard
+	// for this device specifically. nil means "never configured" — the resolver
+	// falls back to whether the global ignore list contains "@g.us".
+	WebhookIgnoreGroups *bool `json:"webhook_ignore_groups,omitempty"`
 }
 
 // MessageFilter represents query filters for messages

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -1424,7 +1424,7 @@ func (r *SQLiteRepository) GetDeviceRecordByJID(jid string) (*domainChatStorage.
 	}
 
 	rows, err := r.db.Query(`
-		SELECT device_id, display_name, jid, COALESCE(ad_jid, ''), webhook_url, COALESCE(webhook_secret, ''), COALESCE(webhook_events, ''), COALESCE(webhook_insecure_skip_verify, FALSE), created_at, updated_at
+		SELECT device_id, display_name, jid, COALESCE(ad_jid, ''), webhook_url, COALESCE(webhook_secret, ''), COALESCE(webhook_events, ''), COALESCE(webhook_insecure_skip_verify, FALSE), webhook_ignore_groups, created_at, updated_at
 		FROM devices
 		WHERE jid = ? OR ad_jid = ?
 		LIMIT 2
@@ -1446,6 +1446,7 @@ func (r *SQLiteRepository) GetDeviceRecordByJID(jid string) (*domainChatStorage.
 			&rec.WebhookSecret,
 			&rec.WebhookEvents,
 			&rec.WebhookInsecureSkipVerify,
+			&rec.WebhookIgnoreGroups,
 			&rec.CreatedAt,
 			&rec.UpdatedAt,
 		); err != nil {
@@ -1541,9 +1542,9 @@ func (r *SQLiteRepository) SetDeviceWebhookConfig(deviceID string, config *domai
 
 	result, err := r.db.Exec(`
 		UPDATE devices
-		SET webhook_url = ?, webhook_secret = ?, webhook_events = ?, webhook_insecure_skip_verify = ?, updated_at = ?
+		SET webhook_url = ?, webhook_secret = ?, webhook_events = ?, webhook_insecure_skip_verify = ?, webhook_ignore_groups = ?, updated_at = ?
 		WHERE device_id = ?
-	`, webhookURL, config.WebhookSecret, config.WebhookEvents, config.WebhookInsecureSkipVerify, time.Now(), deviceID)
+	`, webhookURL, config.WebhookSecret, config.WebhookEvents, config.WebhookInsecureSkipVerify, config.WebhookIgnoreGroups, time.Now(), deviceID)
 	if err != nil {
 		return err
 	}
@@ -1566,9 +1567,9 @@ func (r *SQLiteRepository) GetDeviceWebhookConfig(deviceID string) (*domainChatS
 	var config domainChatStorage.DeviceWebhookConfig
 	var webhookURL *string
 	err := r.db.QueryRow(`
-		SELECT webhook_url, COALESCE(webhook_secret, ''), COALESCE(webhook_events, ''), COALESCE(webhook_insecure_skip_verify, FALSE)
+		SELECT webhook_url, COALESCE(webhook_secret, ''), COALESCE(webhook_events, ''), COALESCE(webhook_insecure_skip_verify, FALSE), webhook_ignore_groups
 		FROM devices WHERE device_id = ? LIMIT 1
-	`, deviceID).Scan(&webhookURL, &config.WebhookSecret, &config.WebhookEvents, &config.WebhookInsecureSkipVerify)
+	`, deviceID).Scan(&webhookURL, &config.WebhookSecret, &config.WebhookEvents, &config.WebhookInsecureSkipVerify, &config.WebhookIgnoreGroups)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -2563,5 +2564,10 @@ func (r *SQLiteRepository) getMigrations() []string {
 		`CREATE INDEX IF NOT EXISTS idx_chatwoot_links_conversation_account ON chatwoot_message_links(chatwoot_conversation_id, chatwoot_account_id, updated_at)`,
 		// Migration 43: Count/delete message links by owning config without a full-table scan
 		`CREATE INDEX IF NOT EXISTS idx_chatwoot_links_config ON chatwoot_message_links(chatwoot_config_id)`,
+
+		// Migration 44: Store per-device override for ignoring group messages in
+		// webhook forwarding. NULL means "never configured" -- the resolver falls
+		// back to the global WHATSAPP_WEBHOOK_IGNORE_JIDS "@g.us" wildcard.
+		`ALTER TABLE devices ADD COLUMN webhook_ignore_groups BOOLEAN DEFAULT NULL`,
 	}
 }

--- a/src/infrastructure/chatstorage/sqlite_repository_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_test.go
@@ -355,6 +355,74 @@ func seedChatMessage(t *testing.T, repo *SQLiteRepository, deviceID, chatJID, me
 	}
 }
 
+func TestSQLiteRepositoryDeviceWebhookConfig_IgnoreGroupsRoundTrip(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	deviceID := "dev-ignore-groups"
+	if err := repo.SaveDeviceRecord(&domainChatStorage.DeviceRecord{
+		DeviceID: deviceID,
+	}); err != nil {
+		t.Fatalf("failed to seed device record: %v", err)
+	}
+
+	// Never configured -> nil.
+	cfg, err := repo.GetDeviceWebhookConfig(deviceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.WebhookIgnoreGroups != nil {
+		t.Fatalf("expected nil WebhookIgnoreGroups for a never-configured device, got %v", *cfg.WebhookIgnoreGroups)
+	}
+
+	// Explicitly set to true.
+	trueVal := true
+	if err := repo.SetDeviceWebhookConfig(deviceID, &domainChatStorage.DeviceWebhookConfig{
+		WebhookIgnoreGroups: &trueVal,
+	}); err != nil {
+		t.Fatalf("unexpected error setting config: %v", err)
+	}
+	cfg, err = repo.GetDeviceWebhookConfig(deviceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.WebhookIgnoreGroups == nil || !*cfg.WebhookIgnoreGroups {
+		t.Fatalf("expected WebhookIgnoreGroups=true after set, got %v", cfg.WebhookIgnoreGroups)
+	}
+
+	// Explicitly set to false (must persist as false, not fall back to nil).
+	falseVal := false
+	if err := repo.SetDeviceWebhookConfig(deviceID, &domainChatStorage.DeviceWebhookConfig{
+		WebhookIgnoreGroups: &falseVal,
+	}); err != nil {
+		t.Fatalf("unexpected error setting config: %v", err)
+	}
+	cfg, err = repo.GetDeviceWebhookConfig(deviceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.WebhookIgnoreGroups == nil || *cfg.WebhookIgnoreGroups {
+		t.Fatalf("expected WebhookIgnoreGroups=false after explicit set, got %v", cfg.WebhookIgnoreGroups)
+	}
+
+	// GetDeviceRecordByJID must also surface the field (used by the webhook resolver).
+	if err := repo.SaveDeviceRecord(&domainChatStorage.DeviceRecord{
+		DeviceID: deviceID,
+		JID:      "5511999990000@s.whatsapp.net",
+	}); err != nil {
+		t.Fatalf("failed to set jid on device record: %v", err)
+	}
+	rec, err := repo.GetDeviceRecordByJID("5511999990000@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("expected device record, got nil")
+	}
+	if rec.WebhookIgnoreGroups == nil || *rec.WebhookIgnoreGroups {
+		t.Fatalf("expected WebhookIgnoreGroups=false via GetDeviceRecordByJID, got %v", rec.WebhookIgnoreGroups)
+	}
+}
+
 func seedReaction(t *testing.T, repo *SQLiteRepository, deviceID, chatJID, messageID, reactorJID string) {
 	t.Helper()
 	if err := repo.StoreReaction(&domainChatStorage.Reaction{

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -207,29 +207,74 @@ func isEventWhitelistedForDevice(eventName string, deviceConfig *domainChatStora
 
 // shouldIgnoreWebhookJID reports whether an event should be skipped for WHATSAPP_WEBHOOK
 // forwarding because its chat or sender JID matches WHATSAPP_WEBHOOK_IGNORE_JIDS (e.g. the
-// "@g.us" wildcard to drop all group traffic). The JID fields live in the nested inner
-// payload, so it descends one level. Both the resolved phone JIDs (chat_id/from) and the
-// LID forms (chat_lid/from_lid) are matched: a LID-migrated event keeps the @lid JID in the
-// *_lid fields while chat_id/from hold the resolved phone JID, so an "@lid" pattern (or an
-// exact ...@lid) only matches via the *_lid fields. It is a no-op when the ignore list is
-// empty, the inner payload is absent, or no JID matches — so events without a JID and the
-// default (no list configured) keep forwarding unchanged. This only gates the generic
-// webhook; the Chatwoot path keeps its own CHATWOOT_IGNORE_JIDS filter.
+// "@g.us" wildcard to drop all group traffic), OR because the originating device has an
+// explicit per-device override for group messages (webhook_ignore_groups, set via
+// PATCH /devices/:device_id/webhook). The device override takes precedence over the
+// global "@g.us" wildcard specifically for group JIDs; it has no effect on non-group JIDs,
+// where the global list remains the only mechanism (unchanged from before this feature).
+// The JID fields live in the nested inner payload, so it descends one level. Both the
+// resolved phone JIDs (chat_id/from) and the LID forms (chat_lid/from_lid) are matched.
+// It is a no-op when the inner payload is absent or no JID matches.
 func shouldIgnoreWebhookJID(payload map[string]any) bool {
-	ignore := config.WhatsappWebhookIgnoreJids
-	if len(ignore) == 0 {
-		return false
-	}
 	data, ok := payload["payload"].(map[string]any)
 	if !ok {
 		return false
 	}
+
+	deviceJID, _ := payload["device_id"].(string)
+	groupOverride := deviceIgnoreGroupsOverride(deviceJID)
+	ignore := config.WhatsappWebhookIgnoreJids
+
 	for _, key := range []string{"chat_id", "from", "chat_lid", "from_lid"} {
-		if jid, _ := data[key].(string); utils.MatchesIgnoredJID(jid, ignore) {
+		jid, _ := data[key].(string)
+		if jid == "" {
+			continue
+		}
+		if strings.HasSuffix(jid, "@g.us") {
+			if groupOverride != nil {
+				if *groupOverride {
+					return true
+				}
+				continue
+			}
+			if globalIgnoresAllGroups(ignore) {
+				return true
+			}
+			continue
+		}
+		if utils.MatchesIgnoredJID(jid, ignore) {
 			return true
 		}
 	}
 	return false
+}
+
+// globalIgnoresAllGroups reports whether the global WHATSAPP_WEBHOOK_IGNORE_JIDS list
+// contains the "@g.us" wildcard (ignore all groups). Used as the fallback when a device
+// has no explicit webhook_ignore_groups override.
+func globalIgnoresAllGroups(ignore []string) bool {
+	for _, pattern := range ignore {
+		if strings.TrimSpace(pattern) == "@g.us" {
+			return true
+		}
+	}
+	return false
+}
+
+// deviceIgnoreGroupsOverride returns the per-device override for ignoring group messages
+// in webhook forwarding (webhook_ignore_groups), or nil when the device has never set it
+// -- the caller falls back to the global "@g.us" wildcard. Uses the same test seam
+// (getDeviceRecordForTest) as getWebhookConfigForDevice, so existing tests that don't stub
+// it keep seeing nil (unchanged behavior).
+func deviceIgnoreGroupsOverride(deviceJID string) *bool {
+	if deviceJID == "" {
+		return nil
+	}
+	record, err := getDeviceRecordForTest(deviceJID)
+	if err != nil || record == nil {
+		return nil
+	}
+	return record.WebhookIgnoreGroups
 }
 
 // addWebhookSessionID injects the operator-facing session id into a webhook

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -238,24 +238,12 @@ func shouldIgnoreWebhookJID(payload map[string]any) bool {
 				}
 				continue
 			}
-			if globalIgnoresAllGroups(ignore) {
+			if utils.MatchesIgnoredJID(jid, ignore) {
 				return true
 			}
 			continue
 		}
 		if utils.MatchesIgnoredJID(jid, ignore) {
-			return true
-		}
-	}
-	return false
-}
-
-// globalIgnoresAllGroups reports whether the global WHATSAPP_WEBHOOK_IGNORE_JIDS list
-// contains the "@g.us" wildcard (ignore all groups). Used as the fallback when a device
-// has no explicit webhook_ignore_groups override.
-func globalIgnoresAllGroups(ignore []string) bool {
-	for _, pattern := range ignore {
-		if strings.TrimSpace(pattern) == "@g.us" {
 			return true
 		}
 	}

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -177,6 +177,7 @@ func getWebhookConfigForDevice(deviceJID string) (*domainChatStorage.DeviceWebho
 			WebhookSecret:             record.WebhookSecret,
 			WebhookEvents:             record.WebhookEvents,
 			WebhookInsecureSkipVerify: record.WebhookInsecureSkipVerify,
+			WebhookIgnoreGroups:       record.WebhookIgnoreGroups,
 		}, nil
 	}
 

--- a/src/infrastructure/whatsapp/webhook_forward_ignore_jids_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_ignore_jids_test.go
@@ -173,6 +173,16 @@ func TestWebhookIgnoreJID_NilDeviceOverrideRespectsGlobalWildcardDrop(t *testing
 	}
 }
 
+func TestWebhookIgnoreJID_NilDeviceOverrideRespectsExactGroupJIDMatch(t *testing.T) {
+	payload := ignoreJidPayload("120363999000111@g.us", "628111@s.whatsapp.net")
+	// No per-device override (nil), and the global list contains only the exact group JID
+	// (not the "@g.us" wildcard) -- it must still be dropped by falling through to the
+	// same exact-match logic used for non-group JIDs, matching pre-existing (#736) behavior.
+	if runIgnoreJidForwardWithDeviceOverride(t, []string{"120363999000111@g.us"}, nil, "message", payload) {
+		t.Fatal("group message should be dropped when its exact JID is in the global ignore list, even without a device override")
+	}
+}
+
 func TestGetWebhookConfigForDevice_PropagatesWebhookIgnoreGroups(t *testing.T) {
 	trueVal := true
 	url := "https://device.example.com/webhook"

--- a/src/infrastructure/whatsapp/webhook_forward_ignore_jids_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_ignore_jids_test.go
@@ -182,3 +182,14 @@ func TestWebhookIgnoreJID_DeviceOverrideDoesNotAffectNonGroupJIDs(t *testing.T) 
 		t.Fatal("1:1 message should still be dropped by an exact global JID match, independent of the group-only device override")
 	}
 }
+
+func TestWebhookIgnoreJID_DeviceOverrideFalseWinsEvenWithOtherExactJIDInGlobalList(t *testing.T) {
+	falseVal := false
+	payload := ignoreJidPayload("120363999000111@g.us", "628111@s.whatsapp.net")
+	// Global list ignores both all groups (@g.us) AND an unrelated exact JID -- the
+	// device's explicit false override must still win for the group JID, regardless
+	// of what else is in the global list.
+	if !runIgnoreJidForwardWithDeviceOverride(t, []string{"@g.us", "628999@s.whatsapp.net"}, &falseVal, "message", payload) {
+		t.Fatal("group message should be forwarded when the device explicitly overrides to false, even though the global list also ignores an unrelated exact JID")
+	}
+}

--- a/src/infrastructure/whatsapp/webhook_forward_ignore_jids_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_ignore_jids_test.go
@@ -173,6 +173,32 @@ func TestWebhookIgnoreJID_NilDeviceOverrideRespectsGlobalWildcardDrop(t *testing
 	}
 }
 
+func TestGetWebhookConfigForDevice_PropagatesWebhookIgnoreGroups(t *testing.T) {
+	trueVal := true
+	url := "https://device.example.com/webhook"
+
+	originalStorage := webhookStorageForTest
+	webhookStorageForTest = func(deviceJID string) (*domainChatStorage.DeviceRecord, error) {
+		return &domainChatStorage.DeviceRecord{
+			DeviceID:            deviceJID,
+			WebhookURL:          &url,
+			WebhookIgnoreGroups: &trueVal,
+		}, nil
+	}
+	defer func() { webhookStorageForTest = originalStorage }()
+
+	cfg, err := getWebhookConfigForDevice("org_1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config when device has a WebhookURL")
+	}
+	if cfg.WebhookIgnoreGroups == nil || *cfg.WebhookIgnoreGroups != true {
+		t.Fatal("expected WebhookIgnoreGroups to be propagated from the device record onto the returned config")
+	}
+}
+
 func TestWebhookIgnoreJID_DeviceOverrideDoesNotAffectNonGroupJIDs(t *testing.T) {
 	trueVal := true
 	// chat_id/from are a 1:1 JID, not a group -- the per-device group override must not

--- a/src/infrastructure/whatsapp/webhook_forward_ignore_jids_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_ignore_jids_test.go
@@ -120,3 +120,65 @@ func TestWebhookIgnoreJID_ExactLidMatchesChatLid(t *testing.T) {
 		t.Fatal("event should be dropped when its exact chat_lid JID is in the ignore list")
 	}
 }
+
+// runIgnoreJidForwardWithDeviceOverride is like runIgnoreJidForward but also stubs the
+// per-device record lookup (webhookStorageForTest) so the resolver sees a device-level
+// WebhookIgnoreGroups override, independent of the global WHATSAPP_WEBHOOK_IGNORE_JIDS list.
+func runIgnoreJidForwardWithDeviceOverride(t *testing.T, ignoreJids []string, deviceIgnoreGroups *bool, eventName string, payload map[string]any) bool {
+	t.Helper()
+
+	originalStorage := webhookStorageForTest
+	webhookStorageForTest = func(deviceJID string) (*domainChatStorage.DeviceRecord, error) {
+		return &domainChatStorage.DeviceRecord{
+			DeviceID:            deviceJID,
+			WebhookIgnoreGroups: deviceIgnoreGroups,
+		}, nil
+	}
+	defer func() { webhookStorageForTest = originalStorage }()
+
+	return runIgnoreJidForward(t, ignoreJids, eventName, payload)
+}
+
+func TestWebhookIgnoreJID_DeviceOverrideTrueDropsGroupEvenWithoutGlobalList(t *testing.T) {
+	trueVal := true
+	payload := ignoreJidPayload("120363999000111@g.us", "628111@s.whatsapp.net")
+	// Global list is empty -- only the per-device override says "ignore groups".
+	if runIgnoreJidForwardWithDeviceOverride(t, nil, &trueVal, "message", payload) {
+		t.Fatal("group message should be dropped when the device's WebhookIgnoreGroups=true, even with no global ignore list")
+	}
+}
+
+func TestWebhookIgnoreJID_DeviceOverrideFalseKeepsGroupDespiteGlobalWildcard(t *testing.T) {
+	falseVal := false
+	payload := ignoreJidPayload("120363999000111@g.us", "628111@s.whatsapp.net")
+	// Global list says "ignore all groups" (@g.us), but this device explicitly opted out.
+	if !runIgnoreJidForwardWithDeviceOverride(t, []string{"@g.us"}, &falseVal, "message", payload) {
+		t.Fatal("group message should still be forwarded when the device's WebhookIgnoreGroups=false, overriding the global @g.us wildcard")
+	}
+}
+
+func TestWebhookIgnoreJID_NilDeviceOverrideForwardsWhenGlobalListEmpty(t *testing.T) {
+	payload := ignoreJidPayload("120363999000111@g.us", "628111@s.whatsapp.net")
+	// No per-device override (nil) and no global ignore list -- must behave exactly like
+	// before this feature existed (default: forward everything).
+	if !runIgnoreJidForwardWithDeviceOverride(t, nil, nil, "message", payload) {
+		t.Fatal("group message should be forwarded when neither the device override nor the global list ignores groups")
+	}
+}
+
+func TestWebhookIgnoreJID_NilDeviceOverrideRespectsGlobalWildcardDrop(t *testing.T) {
+	payload := ignoreJidPayload("120363999000111@g.us", "628111@s.whatsapp.net")
+	if runIgnoreJidForwardWithDeviceOverride(t, []string{"@g.us"}, nil, "message", payload) {
+		t.Fatal("group message should be dropped when the device has no override (nil) and the global list ignores @g.us -- unchanged pre-existing behavior")
+	}
+}
+
+func TestWebhookIgnoreJID_DeviceOverrideDoesNotAffectNonGroupJIDs(t *testing.T) {
+	trueVal := true
+	// chat_id/from are a 1:1 JID, not a group -- the per-device group override must not
+	// touch this path; only the global exact/wildcard list applies, exactly as before.
+	payload := ignoreJidPayload("628999@s.whatsapp.net", "628999@s.whatsapp.net")
+	if runIgnoreJidForwardWithDeviceOverride(t, []string{"628999@s.whatsapp.net"}, &trueVal, "message", payload) {
+		t.Fatal("1:1 message should still be dropped by an exact global JID match, independent of the group-only device override")
+	}
+}

--- a/src/ui/rest/device.go
+++ b/src/ui/rest/device.go
@@ -230,15 +230,23 @@ func (handler *Device) UpdateDeviceWebhook(c fiber.Ctx) error {
 		})
 	}
 
+	existing, err := handler.Service.GetDeviceWebhookConfig(c.Context(), deviceID)
+	utils.PanicIfNeeded(err)
+
+	ignoreGroups := req.WebhookIgnoreGroups
+	if ignoreGroups == nil && existing != nil {
+		ignoreGroups = existing.WebhookIgnoreGroups
+	}
+
 	config := &chatstorage.DeviceWebhookConfig{
 		WebhookURL:                req.WebhookURL,
 		WebhookSecret:             req.WebhookSecret,
 		WebhookEvents:             req.WebhookEvents,
 		WebhookInsecureSkipVerify: req.WebhookInsecureSkipVerify,
-		WebhookIgnoreGroups:       req.WebhookIgnoreGroups,
+		WebhookIgnoreGroups:       ignoreGroups,
 	}
 
-	err := handler.Service.SetDeviceWebhookConfig(c.Context(), deviceID, config)
+	err = handler.Service.SetDeviceWebhookConfig(c.Context(), deviceID, config)
 	utils.PanicIfNeeded(err)
 
 	return c.JSON(utils.ResponseData{
@@ -251,7 +259,7 @@ func (handler *Device) UpdateDeviceWebhook(c fiber.Ctx) error {
 			"webhook_secret":               req.WebhookSecret,
 			"webhook_events":               req.WebhookEvents,
 			"webhook_insecure_skip_verify": req.WebhookInsecureSkipVerify,
-			"webhook_ignore_groups":        req.WebhookIgnoreGroups,
+			"webhook_ignore_groups":        ignoreGroups,
 		},
 	})
 }

--- a/src/ui/rest/device.go
+++ b/src/ui/rest/device.go
@@ -209,6 +209,7 @@ func (handler *Device) UpdateDeviceWebhook(c fiber.Ctx) error {
 		WebhookSecret             string  `json:"webhook_secret"`
 		WebhookEvents             string  `json:"webhook_events"`
 		WebhookInsecureSkipVerify bool    `json:"webhook_insecure_skip_verify"`
+		WebhookIgnoreGroups       *bool   `json:"webhook_ignore_groups"`
 	}
 
 	if err := c.Bind().Body(&req); err != nil {
@@ -234,6 +235,7 @@ func (handler *Device) UpdateDeviceWebhook(c fiber.Ctx) error {
 		WebhookSecret:             req.WebhookSecret,
 		WebhookEvents:             req.WebhookEvents,
 		WebhookInsecureSkipVerify: req.WebhookInsecureSkipVerify,
+		WebhookIgnoreGroups:       req.WebhookIgnoreGroups,
 	}
 
 	err := handler.Service.SetDeviceWebhookConfig(c.Context(), deviceID, config)
@@ -249,6 +251,7 @@ func (handler *Device) UpdateDeviceWebhook(c fiber.Ctx) error {
 			"webhook_secret":               req.WebhookSecret,
 			"webhook_events":               req.WebhookEvents,
 			"webhook_insecure_skip_verify": req.WebhookInsecureSkipVerify,
+			"webhook_ignore_groups":        req.WebhookIgnoreGroups,
 		},
 	})
 }
@@ -288,6 +291,12 @@ func (handler *Device) GetDeviceWebhook(c fiber.Ctx) error {
 					return config.WebhookInsecureSkipVerify
 				}
 				return false
+			}(),
+			"webhook_ignore_groups": func() *bool {
+				if config != nil {
+					return config.WebhookIgnoreGroups
+				}
+				return nil
 			}(),
 		},
 	})

--- a/src/ui/rest/device_test.go
+++ b/src/ui/rest/device_test.go
@@ -176,6 +176,66 @@ func TestUpdateDeviceWebhook_ForwardsIgnoreGroups(t *testing.T) {
 	}
 }
 
+func TestUpdateDeviceWebhook_PreservesIgnoreGroupsWhenOmitted(t *testing.T) {
+	trueVal := true
+	stub := &deviceWebhookStubUsecase{getConfig: &chatstorage.DeviceWebhookConfig{WebhookIgnoreGroups: &trueVal}}
+	app := newDeviceWebhookTestApp(stub)
+
+	body := `{"webhook_url": "https://hook.example.com"}`
+	req := httptest.NewRequest(http.MethodPatch, "/devices/dev1/webhook", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if stub.receivedConfig == nil {
+		t.Fatal("expected webhook config to be forwarded to the usecase, got nil")
+	}
+	if stub.receivedConfig.WebhookIgnoreGroups == nil || !*stub.receivedConfig.WebhookIgnoreGroups {
+		t.Fatalf("expected previously-stored webhook_ignore_groups=true to be preserved, got %v", stub.receivedConfig.WebhookIgnoreGroups)
+	}
+
+	var respBody map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	results, ok := respBody["results"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected results object in response, got %v", respBody)
+	}
+	if ignoreGroups, ok := results["webhook_ignore_groups"].(bool); !ok || !ignoreGroups {
+		t.Fatalf("expected webhook_ignore_groups=true in response, got %v", results["webhook_ignore_groups"])
+	}
+}
+
+func TestUpdateDeviceWebhook_ExplicitFalseOverridesExisting(t *testing.T) {
+	trueVal := true
+	stub := &deviceWebhookStubUsecase{getConfig: &chatstorage.DeviceWebhookConfig{WebhookIgnoreGroups: &trueVal}}
+	app := newDeviceWebhookTestApp(stub)
+
+	body := `{"webhook_url": "https://hook.example.com", "webhook_ignore_groups": false}`
+	req := httptest.NewRequest(http.MethodPatch, "/devices/dev1/webhook", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if stub.receivedConfig == nil {
+		t.Fatal("expected webhook config to be forwarded to the usecase, got nil")
+	}
+	if stub.receivedConfig.WebhookIgnoreGroups == nil || *stub.receivedConfig.WebhookIgnoreGroups {
+		t.Fatalf("expected explicit webhook_ignore_groups=false to override existing, got %v", stub.receivedConfig.WebhookIgnoreGroups)
+	}
+}
+
 func TestGetDeviceWebhook_ReturnsIgnoreGroups(t *testing.T) {
 	trueVal := true
 	stub := &deviceWebhookStubUsecase{getConfig: &chatstorage.DeviceWebhookConfig{WebhookIgnoreGroups: &trueVal}}

--- a/src/ui/rest/device_test.go
+++ b/src/ui/rest/device_test.go
@@ -113,3 +113,112 @@ func TestAddDevice_NoWebhookFields(t *testing.T) {
 		t.Fatalf("expected result id dev2, got %v", parsed.Results["id"])
 	}
 }
+
+type deviceWebhookStubUsecase struct {
+	domainDevice.IDeviceUsecase
+	receivedDeviceID string
+	receivedConfig   *chatstorage.DeviceWebhookConfig
+	getConfig        *chatstorage.DeviceWebhookConfig
+}
+
+func (s *deviceWebhookStubUsecase) SetDeviceWebhookConfig(_ context.Context, deviceID string, config *chatstorage.DeviceWebhookConfig) error {
+	s.receivedDeviceID = deviceID
+	s.receivedConfig = config
+	return nil
+}
+
+func (s *deviceWebhookStubUsecase) GetDeviceWebhookConfig(_ context.Context, deviceID string) (*chatstorage.DeviceWebhookConfig, error) {
+	s.receivedDeviceID = deviceID
+	return s.getConfig, nil
+}
+
+func newDeviceWebhookTestApp(stub *deviceWebhookStubUsecase) *fiber.App {
+	app := fiber.New()
+	app.Use(middleware.Recovery())
+	controller := Device{Service: stub}
+	app.Patch("/devices/:device_id/webhook", controller.UpdateDeviceWebhook)
+	app.Get("/devices/:device_id/webhook", controller.GetDeviceWebhook)
+	return app
+}
+
+func TestUpdateDeviceWebhook_ForwardsIgnoreGroups(t *testing.T) {
+	stub := &deviceWebhookStubUsecase{}
+	app := newDeviceWebhookTestApp(stub)
+
+	body := `{"webhook_url": "https://hook.example.com", "webhook_ignore_groups": true}`
+	req := httptest.NewRequest(http.MethodPatch, "/devices/dev1/webhook", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if stub.receivedConfig == nil {
+		t.Fatal("expected webhook config to be forwarded to the usecase, got nil")
+	}
+	if stub.receivedConfig.WebhookIgnoreGroups == nil || !*stub.receivedConfig.WebhookIgnoreGroups {
+		t.Fatalf("expected webhook_ignore_groups=true to be forwarded, got %v", stub.receivedConfig.WebhookIgnoreGroups)
+	}
+
+	var respBody map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	results, ok := respBody["results"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected results object in response, got %v", respBody)
+	}
+	if ignoreGroups, ok := results["webhook_ignore_groups"].(bool); !ok || !ignoreGroups {
+		t.Fatalf("expected webhook_ignore_groups=true in response, got %v", results["webhook_ignore_groups"])
+	}
+}
+
+func TestGetDeviceWebhook_ReturnsIgnoreGroups(t *testing.T) {
+	trueVal := true
+	stub := &deviceWebhookStubUsecase{getConfig: &chatstorage.DeviceWebhookConfig{WebhookIgnoreGroups: &trueVal}}
+	app := newDeviceWebhookTestApp(stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/devices/dev1/webhook", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var respBody map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	results, ok := respBody["results"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected results object in response, got %v", respBody)
+	}
+	if ignoreGroups, ok := results["webhook_ignore_groups"].(bool); !ok || !ignoreGroups {
+		t.Fatalf("expected webhook_ignore_groups=true in GET response, got %v", results["webhook_ignore_groups"])
+	}
+}
+
+func TestGetDeviceWebhook_NilIgnoreGroupsReturnsNull(t *testing.T) {
+	stub := &deviceWebhookStubUsecase{getConfig: &chatstorage.DeviceWebhookConfig{}}
+	app := newDeviceWebhookTestApp(stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/devices/dev1/webhook", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	var respBody map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	results := respBody["results"].(map[string]any)
+	if results["webhook_ignore_groups"] != nil {
+		t.Fatalf("expected webhook_ignore_groups=null when never configured, got %v", results["webhook_ignore_groups"])
+	}
+}


### PR DESCRIPTION
## Problem

`WHATSAPP_WEBHOOK_IGNORE_JIDS` (added in #736) is a single **global**, boot-time-only env var: it applies to every device the same way, and changing it requires editing `.env` + restarting the container. There's no way to mute group traffic on just one instance while keeping it on another, and no runtime API/UI to flip it.

Since #736 merged, per-device webhook configuration landed (`d1ac267`): `DeviceWebhookConfig` persists `webhook_url`/`webhook_secret`/`webhook_events`/`webhook_insecure_skip_verify` per device, with `PATCH`/`GET /devices/:device_id/webhook` reading/writing it at runtime, no restart needed. This PR extends that same infrastructure rather than building something parallel.

## Solution

Add `webhook_ignore_groups` (`*bool`, nullable) to the per-device webhook config:

- **`nil`** (never configured) → falls back to today's behavior: checks whether the global `WHATSAPP_WEBHOOK_IGNORE_JIDS` list contains the `@g.us` wildcard. Existing users of the env var see zero behavior change.
- **`true`/`false`** (explicitly set) → becomes the **sole source of truth** for group JIDs on that device, overriding the global `@g.us` wildcard either way (even if the device opts to keep receiving groups despite a global mute, or vice versa).
- Non-group JIDs are untouched — the global list remains the only mechanism there, exactly as before.

No new persistence mechanism, no new route: reuses `PATCH`/`GET /devices/:device_id/webhook` as-is, just with one more optional field.

## Changes

- `domains/chatstorage/chatstorage.go` — `WebhookIgnoreGroups *bool` on `DeviceRecord` and `DeviceWebhookConfig`.
- `infrastructure/chatstorage/sqlite_repository.go` — Migration 35 (`ALTER TABLE devices ADD COLUMN webhook_ignore_groups BOOLEAN DEFAULT NULL`); `GetDeviceRecordByJID`/`SetDeviceWebhookConfig`/`GetDeviceWebhookConfig` read/write the field (no `COALESCE`, so explicit `false` never collapses to `nil`).
- `infrastructure/whatsapp/webhook_forward.go` — `shouldIgnoreWebhookJID` gains `deviceIgnoreGroupsOverride` (per-device lookup) and `globalIgnoresAllGroups` (fallback check) helpers; device override only affects `@g.us`-suffixed JIDs, precedence exactly as described above. `getWebhookConfigForDevice` also propagates the field for consistency with the other webhook settings it already returns.
- `ui/rest/device.go` — `PATCH`/`GET /devices/:device_id/webhook` accept/return `webhook_ignore_groups` (serializes as JSON `null` when never configured).
- Tests across all four packages: persistence round-trip (including the explicit-`false`-must-not-collapse-to-`nil` case), the full precedence matrix in the resolver (device `true`/`false`/`nil` × global list empty/`@g.us`/mixed, plus a non-group-JID isolation test), and the REST handlers (forwarding + response shape for `true`/`false`/never-configured).

## Testing

No local Go toolchain on the machine that authored this, so `gofmt`/`go build`/`go vet`/`go test` were run via a disposable CI workflow pushed to a throwaway branch on the fork (not part of this PR) — `gofmt` (changed files), `go build ./...`, `go vet ./...`, and `go test` on `infrastructure/chatstorage`, `infrastructure/whatsapp`, `ui/rest`, plus the full suite — all green, confirmed twice (once initially, once after fixing a small consistency gap a final review caught in `getWebhookConfigForDevice`).

Not yet smoke-tested against a live WhatsApp device/group — happy to do that before merge if useful.
