### PR TITLE
fix(build/Dockerfile): correct src/ path and use CGO for go-sqlite3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,9 @@
+FROM aldinokemal2104/go-whatsapp-web-multidevice:latest
+USER root
+RUN apk add --no-cache gcc musl-dev go git make
+WORKDIR /build
+COPY ./src /build
+RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o /app/whatsapp .
+USER gowauser
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["rest"]


### PR DESCRIPTION
## Problem

`build/Dockerfile` doesn't build out of the box. Two issues:

1. `COPY . /build` puts source at `/build` but `go.mod` is at `/build/src/go.mod` — so `go build` fails with:
   ```
   go: go.mod file not found in current directory or any parent directory
   ```

2. The image can also be built with CGO disabled, which breaks go-sqlite3 at runtime:
   ```
   failed to initialize chat storage: failed to ping database: 
   Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work.
   ```

## Fix

```diff
-FROM aldinokemal2104/go-whatsapp-web-multidevice:latest
-USER root
-RUN apk add --no-cache gcc musl-dev go git make
-WORKDIR /build
-COPY . /build
-RUN CGO_ENABLED=1 go build -ldflags="-s -w -buildvcs=false" -o /app/whatsapp .
-USER gowauser
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["rest"]
+FROM aldinokemal2104/go-whatsapp-web-multidevice:latest
+USER root
+RUN apk add --no-cache gcc musl-dev go git make
+WORKDIR /build
+COPY ./src /build
+RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o /app/whatsapp .
+USER gowauser
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["rest"]
```

Removed `-buildvcs=false` from ldflags (Go 1.24+ only, not portable).

## Verified

- Built successfully on go1.22 host
- Container starts cleanly, devices auto-connect from preserved whatsapp.db
- Chatwoot integration works (live messages → Chatwoot)
- In production at oneto7.in since 2026-07-08
