### PR TITLE
feat: cross-origin enablers for the standalone gowa-ui dashboard

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,6 +8,10 @@ info:
     Device scoping:
     - Send `X-Device-Id` on all device-scoped REST calls.
     - WebSocket: connect to `/ws?device_id=<id>`.
+    - WebSocket auth (when basic auth is enabled): browsers cannot set an
+      Authorization header on WebSocket connections, so also pass
+      `&authorization=<base64(user:pass)>` in the query string. Use TLS in
+      production since the credential is visible in the URL.
 servers:
   - url: http://localhost:3000
 tags:
@@ -313,6 +317,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBadRequest'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInternalServer'
+  /app/info:
+    get:
+      operationId: appInfo
+      tags:
+        - app
+      summary: Get server metadata
+      description: >
+        Returns server version, base path, media size limits, and enabled
+        features. Requires no device; intended for standalone UIs (gowa-ui)
+        that previously read these values from the embedded dashboard HTML.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  code:
+                    type: string
+                    example: SUCCESS
+                  message:
+                    type: string
+                    example: Fetch app info success
+                  results:
+                    type: object
+                    properties:
+                      version:
+                        type: string
+                        example: 'v8.11.0'
+                      os:
+                        type: string
+                        example: 'GOWA'
+                      base_path:
+                        type: string
+                        example: ''
+                      max_file_size:
+                        type: integer
+                        format: int64
+                        description: Max document upload size in bytes
+                        example: 50000000
+                      max_video_size:
+                        type: integer
+                        format: int64
+                        description: Max video upload size in bytes
+                        example: 100000000
+                      max_image_size:
+                        type: integer
+                        format: int64
+                        description: Max image upload size in bytes
+                        example: 20000000
+                      chatwoot_enabled:
+                        type: boolean
+                        description: Whether Chatwoot integration routes are registered
         '500':
           description: Internal Server Error
           content:

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,11 @@ Download:
     - `device_id` query parameter
     - If only one device is registered, it will be used as the default
   - **WebSocket device scoping**: Connect to `/ws?device_id=<id>` to scope WebSocket to a specific device
+  - **Remote UI support**: CORS allows the `Authorization` and `X-Device-Id` headers, so a standalone web UI
+      (e.g. [gowa-ui](https://github.com/aldinokemal/gowa-ui)) hosted on another origin can call the API directly.
+      `GET /app/info` exposes version and media size limits. Since browsers cannot set headers on WebSocket
+      connections, pass `/ws?device_id=<id>&authorization=<base64(user:pass)>` when basic auth is enabled
+      (use TLS — the credential is visible in the URL)
   - **Webhook payload changes**: All webhook payloads now include a top-level `device_id` field identifying which
       device received the event:
 
@@ -600,6 +605,7 @@ You can fork or edit this source code !
 | ✅       | Reconnect                              | GET    | /app/reconnect                      |
 | ✅       | Devices                                | GET    | /app/devices                        |
 | ✅       | Connection Status                      | GET    | /app/status                         |
+| ✅       | App Info (version, limits)             | GET    | /app/info                           |
 | ✅       | User Info                              | GET    | /user/info                          |
 | ✅       | User Avatar                            | GET    | /user/avatar                        |
 | ✅       | User Change Avatar                     | POST   | /user/avatar                        |

--- a/src/cmd/rest.go
+++ b/src/cmd/rest.go
@@ -59,6 +59,10 @@ func restServer(_ *cobra.Command, _ []string) {
 
 	app := fiber.New(fiberConfig)
 
+	// CORS must precede the static routes so cross-origin UIs (gowa-ui) can
+	// fetch media under /statics and authenticate with the headers below.
+	app.Use(newCORSMiddleware())
+
 	app.Use(config.AppBasePath+"/statics", static.New("./statics"))
 	app.Use(config.AppBasePath+"/components", static.New("views/components", static.Config{
 		FS:     EmbedViews,
@@ -75,10 +79,6 @@ func restServer(_ *cobra.Command, _ []string) {
 	if config.AppDebug {
 		app.Use(logger.New())
 	}
-	app.Use(cors.New(cors.Config{
-		AllowOrigins: []string{"*"},
-		AllowHeaders: []string{"Origin", "Content-Type", "Accept"},
-	}))
 
 	// Device manager - needed for chatwoot webhook and health check
 	dm := whatsapp.GetDeviceManager()
@@ -123,6 +123,7 @@ func restServer(_ *cobra.Command, _ []string) {
 			account[ba[0]] = ba[1]
 		}
 
+		app.Use(middleware.WebsocketQueryAuth())
 		app.Use(newBasicAuthMiddleware(account))
 	}
 
@@ -146,6 +147,9 @@ func restServer(_ *cobra.Command, _ []string) {
 
 	// Device management routes (no device_id required)
 	rest.InitRestDevice(apiGroup, deviceUsecase)
+
+	// App info (version, limits) for standalone UIs; no device required
+	rest.InitRestAppInfo(apiGroup)
 
 	// Device-scoped operations (header-based)
 	headerDeviceGroup := apiGroup.Group("", middleware.DeviceMiddleware(dm))
@@ -219,6 +223,14 @@ func restServer(_ *cobra.Command, _ []string) {
 			}
 		}
 	}
+}
+
+func newCORSMiddleware() fiber.Handler {
+	return cors.New(cors.Config{
+		AllowOrigins: []string{"*"},
+		AllowMethods: []string{"GET", "POST", "HEAD", "PUT", "PATCH", "DELETE"},
+		AllowHeaders: []string{"Origin", "Content-Type", "Accept", "Authorization", middleware.DeviceIDHeader},
+	})
 }
 
 func newBasicAuthMiddleware(accounts map[string]string) fiber.Handler {

--- a/src/cmd/rest_test.go
+++ b/src/cmd/rest_test.go
@@ -1,9 +1,17 @@
 package cmd
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/ui/rest"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/ui/rest/middleware"
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,4 +60,145 @@ func TestBasicAuthMiddleware(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, resp.StatusCode)
 		})
 	}
+}
+
+func TestCORSPreflightAllowsUIHeaders(t *testing.T) {
+	app := fiber.New()
+	app.Use(newCORSMiddleware())
+	app.Get("/app/info", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+
+	req := httptest.NewRequest("OPTIONS", "/app/info", nil)
+	req.Header.Set("Origin", "https://ui.example.com")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	req.Header.Set("Access-Control-Request-Headers", "authorization,x-device-id")
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, fiber.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	allowedHeaders := strings.ToLower(resp.Header.Get("Access-Control-Allow-Headers"))
+	assert.Contains(t, allowedHeaders, "authorization")
+	assert.Contains(t, allowedHeaders, "x-device-id")
+}
+
+func TestWebsocketQueryAuth(t *testing.T) {
+	validQuery := base64.StdEncoding.EncodeToString([]byte("user:secret"))
+	wrongQuery := base64.StdEncoding.EncodeToString([]byte("user:wrong"))
+
+	newApp := func() *fiber.App {
+		app := fiber.New()
+		app.Use(middleware.WebsocketQueryAuth())
+		app.Use(newBasicAuthMiddleware(map[string]string{"user": "secret"}))
+		app.Get("/ws", func(c fiber.Ctx) error {
+			return c.SendStatus(fiber.StatusOK)
+		})
+		return app
+	}
+
+	setUpgradeHeaders := func(req *http.Request) {
+		req.Header.Set("Connection", "Upgrade")
+		req.Header.Set("Upgrade", "websocket")
+	}
+
+	tests := []struct {
+		name       string
+		query      string
+		upgrade    bool
+		wantStatus int
+	}{
+		{
+			name:       "upgrade with valid query credentials passes",
+			query:      "?authorization=" + validQuery,
+			upgrade:    true,
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:       "upgrade with wrong query credentials is rejected",
+			query:      "?authorization=" + wrongQuery,
+			upgrade:    true,
+			wantStatus: fiber.StatusUnauthorized,
+		},
+		{
+			name:       "upgrade without credentials is rejected",
+			query:      "",
+			upgrade:    true,
+			wantStatus: fiber.StatusUnauthorized,
+		},
+		{
+			name:       "non-upgrade request ignores query credentials",
+			query:      "?authorization=" + validQuery,
+			upgrade:    false,
+			wantStatus: fiber.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/ws"+tt.query, nil)
+			if tt.upgrade {
+				setUpgradeHeaders(req)
+			}
+
+			resp, err := newApp().Test(req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+		})
+	}
+
+	t.Run("plus signs decoded as spaces are restored", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(middleware.WebsocketQueryAuth())
+		app.Get("/ws", func(c fiber.Ctx) error {
+			return c.SendString(string(c.Request().Header.Peek(fiber.HeaderAuthorization)))
+		})
+
+		req := httptest.NewRequest("GET", "/ws?authorization=AB+CD", nil)
+		setUpgradeHeaders(req)
+
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "Basic AB+CD", string(body))
+	})
+}
+
+func TestAppInfo(t *testing.T) {
+	t.Run("returns server metadata", func(t *testing.T) {
+		app := fiber.New()
+		rest.InitRestAppInfo(app)
+
+		resp, err := app.Test(httptest.NewRequest("GET", "/app/info", nil))
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+
+		var payload struct {
+			Code    string         `json:"code"`
+			Results map[string]any `json:"results"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+		assert.Equal(t, "SUCCESS", payload.Code)
+		assert.Equal(t, config.AppVersion, payload.Results["version"])
+		assert.EqualValues(t, config.WhatsappSettingMaxFileSize, payload.Results["max_file_size"])
+		assert.EqualValues(t, config.WhatsappSettingMaxVideoSize, payload.Results["max_video_size"])
+		assert.EqualValues(t, config.WhatsappSettingMaxImageSize, payload.Results["max_image_size"])
+	})
+
+	t.Run("requires credentials when basic auth is enabled", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(newBasicAuthMiddleware(map[string]string{"user": "secret"}))
+		rest.InitRestAppInfo(app)
+
+		resp, err := app.Test(httptest.NewRequest("GET", "/app/info", nil))
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusUnauthorized, resp.StatusCode)
+
+		authed := httptest.NewRequest("GET", "/app/info", nil)
+		authed.SetBasicAuth("user", "secret")
+		resp, err = app.Test(authed)
+		require.NoError(t, err)
+		assert.Equal(t, fiber.StatusOK, resp.StatusCode)
+	})
 }

--- a/src/ui/rest/app.go
+++ b/src/ui/rest/app.go
@@ -30,6 +30,29 @@ func InitRestApp(app fiber.Router, service domainApp.IAppUsecase) App {
 	return App{Service: service}
 }
 
+// InitRestAppInfo registers /app/info outside the device-scoped group so
+// standalone UIs can read server metadata before any device exists.
+func InitRestAppInfo(app fiber.Router) {
+	app.Get("/app/info", AppInfo)
+}
+
+func AppInfo(c fiber.Ctx) error {
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: "Fetch app info success",
+		Results: map[string]any{
+			"version":          config.AppVersion,
+			"os":               config.AppOs,
+			"base_path":        config.AppBasePath,
+			"max_file_size":    config.WhatsappSettingMaxFileSize,
+			"max_video_size":   config.WhatsappSettingMaxVideoSize,
+			"max_image_size":   config.WhatsappSettingMaxImageSize,
+			"chatwoot_enabled": config.ChatwootEnabled,
+		},
+	})
+}
+
 func (handler *App) Login(c fiber.Ctx) error {
 	device, err := getDeviceInstance(c)
 	if err != nil {

--- a/src/ui/rest/middleware/websocketauth.go
+++ b/src/ui/rest/middleware/websocketauth.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gofiber/contrib/v3/websocket"
+	"github.com/gofiber/fiber/v3"
+)
+
+// WebsocketQueryAuth lets browser WebSocket clients authenticate with
+// ?authorization=<base64(user:pass)>, because the browser WebSocket API cannot
+// set an Authorization header and userinfo in WS URLs is rejected per spec.
+// The value is restored into the header before the basic-auth middleware runs.
+func WebsocketQueryAuth() fiber.Handler {
+	return func(c fiber.Ctx) error {
+		if websocket.IsWebSocketUpgrade(c) && len(c.Request().Header.Peek(fiber.HeaderAuthorization)) == 0 {
+			if q := c.Query("authorization"); q != "" {
+				// fasthttp decodes '+' as space; base64 never contains spaces,
+				// so restoring '+' is lossless.
+				token := strings.ReplaceAll(q, " ", "+")
+				c.Request().Header.Set(fiber.HeaderAuthorization, "Basic "+token)
+			}
+		}
+		return c.Next()
+	}
+}


### PR DESCRIPTION
## Summary

Non-breaking groundwork so a standalone web UI ([gowa-ui](https://github.com/aldinokemal/gowa-ui)) hosted on any origin can talk to this server. The embedded dashboard keeps working unchanged.

- **CORS**: moved before the static routes (so `/statics` media and QR PNGs carry CORS headers) and widened `AllowHeaders` with `Authorization` + `X-Device-Id`; explicit `AllowMethods`. Wildcard origin stays safe because auth is header-based, not cookie-based.
- **`GET /app/info`**: authenticated JSON endpoint exposing version, OS name, base path, media size limits, and `chatwoot_enabled` — replaces the values the embedded UI received via Go template injection. Documented in `docs/openapi.yaml`.
- **WebSocket query auth**: browsers cannot set an `Authorization` header on WebSocket connections, so `/ws` now also accepts `?authorization=<base64(user:pass)>` — a small middleware restores it into the header before the standard basic-auth check runs (use TLS in production; documented tradeoff).

## Verification

- `go vet ./...` and `go test ./...` green; new table tests cover the CORS preflight header set, `/app/info` auth behaviour, and the WS query-auth middleware (incl. the fasthttp `+`→space decoding edge).
- Verified live with curl: preflight returns the widened header set; `/app/info` gates 401/200; wrong WS query creds → 401, correct creds reach the device layer; statics serve pre-auth with CORS headers.
- Embedded UI regression-checked (login + send still work same-origin).