### PR TITLE
fix: sent messages missing from chat storage under write contention

### DIFF
--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -2203,15 +2203,42 @@ func (r *SQLiteRepository) StoreSentMessageWithContext(ctx context.Context, mess
 	normalizedJID := whatsapp.NormalizeJIDFromLID(ctx, jid, client)
 	chatJID := normalizedJID.String()
 
+	// Extract media info from the protobuf message if available
+	var mediaType, filename, mediaURL, directPath string
+	var mediaKey, fileSHA256, fileEncSHA256 []byte
+	var fileLength uint64
+	if msg != nil {
+		mediaType, filename, mediaURL, directPath, mediaKey, fileSHA256, fileEncSHA256, fileLength = utils.ExtractMediaInfo(msg)
+	}
+
+	// Store the message BEFORE the chat row. The reverse order left a visible
+	// inconsistency when the context deadline expired between the two writes:
+	// the chat surfaced with a fresh last_message_time while the message
+	// itself was missing. Losing only the chat bump is invisible instead —
+	// the next stored message repairs it.
+	message := &domainChatStorage.Message{
+		ID:            messageID,
+		ChatJID:       chatJID,
+		DeviceID:      deviceID,
+		Sender:        senderJID,
+		Content:       content,
+		Timestamp:     timestamp,
+		IsFromMe:      true,
+		MediaType:     mediaType,
+		Filename:      filename,
+		URL:           mediaURL,
+		DirectPath:    directPath,
+		MediaKey:      mediaKey,
+		FileSHA256:    fileSHA256,
+		FileEncSHA256: fileEncSHA256,
+		FileLength:    fileLength,
+	}
+	if err := r.StoreMessage(message); err != nil {
+		return fmt.Errorf("failed to store message: %w", err)
+	}
+
 	// Get chat name (no pushname available for sent messages) - device scoped
 	chatName := r.GetChatNameWithPushNameByDevice(deviceID, normalizedJID, chatJID, normalizedJID.User, "")
-
-	// Check context again before database operations
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
 
 	// Get existing chat to preserve ephemeral_expiration and archived status (device-scoped)
 	existingChat, err := r.GetChatByDevice(deviceID, chatJID)
@@ -2236,41 +2263,7 @@ func (r *SQLiteRepository) StoreSentMessageWithContext(ctx context.Context, mess
 		return fmt.Errorf("failed to store chat: %w", err)
 	}
 
-	// Check context one more time before storing message
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-
-	// Extract media info from the protobuf message if available
-	var mediaType, filename, mediaURL, directPath string
-	var mediaKey, fileSHA256, fileEncSHA256 []byte
-	var fileLength uint64
-	if msg != nil {
-		mediaType, filename, mediaURL, directPath, mediaKey, fileSHA256, fileEncSHA256, fileLength = utils.ExtractMediaInfo(msg)
-	}
-
-	// Store the sent message
-	message := &domainChatStorage.Message{
-		ID:            messageID,
-		ChatJID:       chatJID,
-		DeviceID:      deviceID,
-		Sender:        senderJID,
-		Content:       content,
-		Timestamp:     timestamp,
-		IsFromMe:      true,
-		MediaType:     mediaType,
-		Filename:      filename,
-		URL:           mediaURL,
-		DirectPath:    directPath,
-		MediaKey:      mediaKey,
-		FileSHA256:    fileSHA256,
-		FileEncSHA256: fileEncSHA256,
-		FileLength:    fileLength,
-	}
-
-	return r.StoreMessage(message)
+	return nil
 }
 
 // _____________________________________________________________________________________________________________________

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -68,15 +68,18 @@ func (service serviceSend) wrapSendMessage(ctx context.Context, client *whatsmeo
 
 	// Store message asynchronously with timeout.
 	// Preserve device context (for device_id scoping) but detach from request cancellation.
+	// The budget must survive chat-storage write contention (history sync batches
+	// hold the SQLite writer for a while; busy_timeout is 30s) — with a short
+	// deadline the sent message is silently missing from the chat viewer.
 	go func() {
-		storeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		storeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 		defer cancel()
 
 		if err := service.chatStorageRepo.StoreSentMessageWithContext(storeCtx, ts.ID, senderJID, recipient.String(), content, ts.Timestamp, msg); err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				logrus.Warn("Timeout storing sent message")
+				logrus.Warnf("Timeout storing sent message %s to %s", ts.ID, recipient.String())
 			} else {
-				logrus.Warnf("Failed to store sent message: %v", err)
+				logrus.Warnf("Failed to store sent message %s to %s: %v", ts.ID, recipient.String(), err)
 			}
 		}
 	}()


### PR DESCRIPTION
## Symptom

Send a message (e.g. from the dashboard or the REST API) while a freshly-paired device is still processing history sync: the chat's `last_message_time` updates, but `GET /chat/{jid}/messages` returns 0 messages — the sent message reached WhatsApp but never landed in chat storage.

## Root cause

`wrapSendMessage` stores the sent message in a detached goroutine with a **2-second** budget, while the chat-storage SQLite connection uses `busy_timeout=30000` — so during history-sync write bursts a queued write happily waits longer than the whole budget. Worse, `StoreSentMessageWithContext` wrote the **chat row first** and checked the context deadline *between* the two writes, so the common partial failure was exactly the misleading state above: bumped chat, missing message, and only a server-side warn log.

## Fix

- Store the message row **before** the chat bump — a partial failure now loses only the `last_message_time` update, which is invisible and self-heals on the next message.
- Raise the detached store budget from 2s to 15s (still bounded, comfortably under `busy_timeout`).
- Failure logs now include the message ID and recipient so drops are diagnosable.

## Verification

`go vet` and the full `go test ./...` suite pass. Reproduced the original symptom on a live server (paired device mid-history-sync, sent to a group → chat bumped to *now*, 0 messages; `Timeout storing sent message` in logs matches the 2s expiry).

Independent of #765/#766 — can merge in any order.