### PR TITLE
fix: decode percent-encoded chat_jid path parameter

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2423,7 +2423,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Chat JID (e.g., phone@s.whatsapp.net for individual or groupid@g.us for group)
+          description: Chat JID (e.g., phone@s.whatsapp.net for individual or groupid@g.us for group). Percent-encoded values (e.g., groupid%40g.us) are accepted.
           example: '6289685028129@s.whatsapp.net'
         - name: limit
           in: query

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2511,7 +2511,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Chat JID (e.g., phone@s.whatsapp.net for individual or groupid@g.us for group)
+          description: Chat JID (e.g., phone@s.whatsapp.net for individual or groupid@g.us for group). Percent-encoded values (e.g., groupid%40g.us) are accepted.
           example: '6289685028129@s.whatsapp.net'
       requestBody:
         content:
@@ -2571,7 +2571,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Chat JID (e.g., phone@s.whatsapp.net for individual or groupid@g.us for group)
+          description: Chat JID (e.g., phone@s.whatsapp.net for individual or groupid@g.us for group). Percent-encoded values (e.g., groupid%40g.us) are accepted.
           example: '6289685028129@s.whatsapp.net'
       requestBody:
         content:
@@ -2619,7 +2619,7 @@ paths:
           schema:
             type: string
           required: true
-          description: Chat JID (e.g., phone@s.whatsapp.net for individual or groupid@g.us for group)
+          description: Chat JID (e.g., phone@s.whatsapp.net for individual or groupid@g.us for group). Percent-encoded values (e.g., groupid%40g.us) are accepted.
           example: '6289685028129@s.whatsapp.net'
       requestBody:
         content:

--- a/src/ui/rest/chat.go
+++ b/src/ui/rest/chat.go
@@ -1,6 +1,9 @@
 package rest
 
 import (
+	"net/url"
+	"strings"
+
 	domainChat "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chat"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
@@ -52,7 +55,11 @@ func (controller *Chat) GetChatMessages(c fiber.Ctx) error {
 	var request domainChat.GetChatMessagesRequest
 
 	// Parse path parameter
-	request.ChatJID = c.Params("chat_jid")
+	chatJID, err := chatJIDParam(c)
+	if err != nil {
+		return err
+	}
+	request.ChatJID = chatJID
 
 	// Parse query parameters
 	request.Limit = fiber.Query[int](c, "limit", 50)
@@ -89,7 +96,11 @@ func (controller *Chat) PinChat(c fiber.Ctx) error {
 	var request domainChat.PinChatRequest
 
 	// Parse path parameter
-	request.ChatJID = c.Params("chat_jid")
+	chatJID, err := chatJIDParam(c)
+	if err != nil {
+		return err
+	}
+	request.ChatJID = chatJID
 
 	// Parse JSON body
 	if err := c.Bind().Body(&request); err != nil {
@@ -116,7 +127,11 @@ func (controller *Chat) SetDisappearingTimer(c fiber.Ctx) error {
 	var request domainChat.SetDisappearingTimerRequest
 
 	// Parse path parameter
-	request.ChatJID = c.Params("chat_jid")
+	chatJID, err := chatJIDParam(c)
+	if err != nil {
+		return err
+	}
+	request.ChatJID = chatJID
 
 	// Parse JSON body
 	if err := c.Bind().Body(&request); err != nil {
@@ -143,7 +158,11 @@ func (controller *Chat) ArchiveChat(c fiber.Ctx) error {
 	var request domainChat.ArchiveChatRequest
 
 	// Parse path parameter
-	request.ChatJID = c.Params("chat_jid")
+	chatJID, err := chatJIDParam(c)
+	if err != nil {
+		return err
+	}
+	request.ChatJID = chatJID
 
 	// Parse JSON body
 	if err := c.Bind().Body(&request); err != nil {
@@ -164,4 +183,16 @@ func (controller *Chat) ArchiveChat(c fiber.Ctx) error {
 		Message: response.Message,
 		Results: response,
 	})
+}
+
+// chatJIDParam returns the chat_jid path parameter with percent-encoding
+// decoded. Fiber does not unescape path params, so URL-encoding clients send
+// "...%40g.us" which would miss every chat-storage lookup. strings.Clone
+// detaches the no-escapes passthrough from fiber's reusable param buffer.
+func chatJIDParam(c fiber.Ctx) (string, error) {
+	decoded, err := url.PathUnescape(c.Params("chat_jid"))
+	if err != nil {
+		return "", fiber.NewError(fiber.StatusBadRequest, "invalid chat_jid path parameter: "+err.Error())
+	}
+	return strings.Clone(decoded), nil
 }

--- a/src/ui/rest/chat.go
+++ b/src/ui/rest/chat.go
@@ -57,7 +57,12 @@ func (controller *Chat) GetChatMessages(c fiber.Ctx) error {
 	// Parse path parameter
 	chatJID, err := chatJIDParam(c)
 	if err != nil {
-		return err
+		return c.Status(400).JSON(utils.ResponseData{
+			Status:  400,
+			Code:    "BAD_REQUEST",
+			Message: "invalid chat_jid path parameter: " + err.Error(),
+			Results: nil,
+		})
 	}
 	request.ChatJID = chatJID
 
@@ -98,7 +103,12 @@ func (controller *Chat) PinChat(c fiber.Ctx) error {
 	// Parse path parameter
 	chatJID, err := chatJIDParam(c)
 	if err != nil {
-		return err
+		return c.Status(400).JSON(utils.ResponseData{
+			Status:  400,
+			Code:    "BAD_REQUEST",
+			Message: "invalid chat_jid path parameter: " + err.Error(),
+			Results: nil,
+		})
 	}
 	request.ChatJID = chatJID
 
@@ -129,7 +139,12 @@ func (controller *Chat) SetDisappearingTimer(c fiber.Ctx) error {
 	// Parse path parameter
 	chatJID, err := chatJIDParam(c)
 	if err != nil {
-		return err
+		return c.Status(400).JSON(utils.ResponseData{
+			Status:  400,
+			Code:    "BAD_REQUEST",
+			Message: "invalid chat_jid path parameter: " + err.Error(),
+			Results: nil,
+		})
 	}
 	request.ChatJID = chatJID
 
@@ -160,7 +175,12 @@ func (controller *Chat) ArchiveChat(c fiber.Ctx) error {
 	// Parse path parameter
 	chatJID, err := chatJIDParam(c)
 	if err != nil {
-		return err
+		return c.Status(400).JSON(utils.ResponseData{
+			Status:  400,
+			Code:    "BAD_REQUEST",
+			Message: "invalid chat_jid path parameter: " + err.Error(),
+			Results: nil,
+		})
 	}
 	request.ChatJID = chatJID
 
@@ -192,7 +212,7 @@ func (controller *Chat) ArchiveChat(c fiber.Ctx) error {
 func chatJIDParam(c fiber.Ctx) (string, error) {
 	decoded, err := url.PathUnescape(c.Params("chat_jid"))
 	if err != nil {
-		return "", fiber.NewError(fiber.StatusBadRequest, "invalid chat_jid path parameter: "+err.Error())
+		return "", err
 	}
 	return strings.Clone(decoded), nil
 }

--- a/src/ui/rest/chat_test.go
+++ b/src/ui/rest/chat_test.go
@@ -1,9 +1,12 @@
 package rest
 
 import (
+	"encoding/json"
+	"io"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/require"
 )
@@ -52,10 +55,10 @@ func TestChatJIDParamDecodesPercentEncoding(t *testing.T) {
 
 func TestChatJIDParamRejectsMalformedEscape(t *testing.T) {
 	app := fiber.New()
-	app.Get("/chat/:chat_jid/messages", func(c fiber.Ctx) error {
-		_, err := chatJIDParam(c)
-		return err
-	})
+	// The decode error path responds before the service is touched, so a
+	// zero-value controller is enough to exercise the real handler.
+	controller := &Chat{}
+	app.Get("/chat/:chat_jid/messages", controller.GetChatMessages)
 
 	req := httptest.NewRequest("GET", "/chat/placeholder/messages", nil)
 	// httptest.NewRequest rejects invalid escapes up front, so smuggle the
@@ -65,4 +68,11 @@ func TestChatJIDParamRejectsMalformedEscape(t *testing.T) {
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var envelope utils.ResponseData
+	require.NoError(t, json.Unmarshal(body, &envelope), "error must be the JSON envelope, got: %s", body)
+	require.Equal(t, "BAD_REQUEST", envelope.Code)
+	require.Contains(t, envelope.Message, "invalid chat_jid path parameter")
 }

--- a/src/ui/rest/chat_test.go
+++ b/src/ui/rest/chat_test.go
@@ -1,0 +1,68 @@
+package rest
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatJIDParamDecodesPercentEncoding(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "percent-encoded group JID",
+			path: "/chat/120363151317289139%40g.us/messages",
+			want: "120363151317289139@g.us",
+		},
+		{
+			name: "raw group JID",
+			path: "/chat/120363151317289139@g.us/messages",
+			want: "120363151317289139@g.us",
+		},
+		{
+			name: "percent-encoded user JID",
+			path: "/chat/6289685028129%40s.whatsapp.net/messages",
+			want: "6289685028129@s.whatsapp.net",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := fiber.New()
+			var got string
+			app.Get("/chat/:chat_jid/messages", func(c fiber.Ctx) error {
+				jid, err := chatJIDParam(c)
+				require.NoError(t, err)
+				got = jid
+				return c.SendStatus(fiber.StatusOK)
+			})
+
+			resp, err := app.Test(httptest.NewRequest("GET", tt.path, nil))
+			require.NoError(t, err)
+			require.Equal(t, fiber.StatusOK, resp.StatusCode)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestChatJIDParamRejectsMalformedEscape(t *testing.T) {
+	app := fiber.New()
+	app.Get("/chat/:chat_jid/messages", func(c fiber.Ctx) error {
+		_, err := chatJIDParam(c)
+		return err
+	})
+
+	req := httptest.NewRequest("GET", "/chat/placeholder/messages", nil)
+	// httptest.NewRequest rejects invalid escapes up front, so smuggle the
+	// malformed URI past net/url via the Opaque field.
+	req.URL.Opaque = "/chat/%zz/messages"
+
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
+}


### PR DESCRIPTION
## Symptom

`GET /chat/120363151317289139%40g.us/messages` returns `data: [], total: 0` and a synthesized `chat_info` that echoes the still-encoded JID with empty timestamps — even though the chat and its messages exist in chatstorage. Same for pin / disappearing / archive. This is what gowa-ui hits on every chat, since it (correctly) percent-encodes the JID path segment.

## Root cause

Fiber does not URL-decode path params (`UnescapePath` defaults to false), and the four chat handlers used `c.Params("chat_jid")` raw. The storage lookup then searched for a chat literally named `...%40g.us`. The old embedded UI happened to send a raw `@` (legal in a path segment), which masked this since day one; any client that URL-encodes path segments — gowa-ui, Python `requests` with quoted paths, most HTTP client libraries — misses every lookup.

## Fix

- New `chatJIDParam` helper: `url.PathUnescape` on the param (raw-`@` URLs are a no-op, so existing clients are unaffected), `strings.Clone` to detach the passthrough case from fiber's reusable param buffer, 400 on malformed escapes.
- Applied in all four handlers: `GetChatMessages`, `PinChat`, `SetDisappearingTimer`, `ArchiveChat`.
- `X-Device-Id` already gets `url.QueryUnescape` in the device middleware, so this closes the last undecoded-identifier gap; `message_id`/`device_id` path params are alphanumeric-safe and need no decoding.
- OpenAPI: note on `chat_jid` that percent-encoded values are accepted.

## Tests

- `TestChatJIDParamDecodesPercentEncoding`: `%40g.us` → `@g.us`, raw `@` passthrough, encoded user JID.
- `TestChatJIDParamRejectsMalformedEscape`: `%zz` → 400.
- Full `go test ./...` + `go vet` green.

Independent of #765/#766/#767 — can merge in any order.