### PR TITLE
fix: retry whatsmeow queries on websocket disconnect

### DIFF
--- a/src/infrastructure/chatwoot/sync.go
+++ b/src/infrastructure/chatwoot/sync.go
@@ -93,7 +93,7 @@ func (g *groupNameResolver) resolve(ctx context.Context, waClient *whatsmeow.Cli
 	}
 	lookupCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	info, err := waClient.GetGroupInfo(lookupCtx, jid)
+	info, err := utils.GetGroupInfoWithRetry(lookupCtx, waClient, jid)
 	if err != nil || info == nil || info.Name == "" {
 		return ""
 	}

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -1282,7 +1282,7 @@ func getGroupName(ctx context.Context, groupJID string) string {
 	defer cancel()
 
 	logrus.Debugf("Chatwoot: Fetching group info for %s", groupJID)
-	groupInfo, err := client.GetGroupInfo(freshCtx, jid)
+	groupInfo, err := utils.GetGroupInfoWithRetry(freshCtx, client, jid)
 	if err != nil {
 		logrus.Warnf("Chatwoot: Failed to get group info for %s: %v", groupJID, err)
 		return ""

--- a/src/pkg/utils/whatsapp.go
+++ b/src/pkg/utils/whatsapp.go
@@ -969,6 +969,24 @@ func ValidateJidWithLogin(client *whatsmeow.Client, jid string) (types.JID, erro
 	return parsedJID, nil
 }
 
+// GetGroupInfoWithRetry calls client.GetGroupInfo and retries once if the
+// websocket was disconnected mid-query (whatsmeow auto-reconnects within ~1s).
+func GetGroupInfoWithRetry(ctx context.Context, client *whatsmeow.Client, jid types.JID) (*types.GroupInfo, error) {
+	info, err := client.GetGroupInfo(ctx, jid)
+	if err == nil {
+		return info, nil
+	}
+	if client.IsConnected() {
+		return info, err
+	}
+	logrus.Debugf("GetGroupInfo failed and client disconnected, waiting for auto-reconnect: %v", err)
+	time.Sleep(2 * time.Second)
+	if !client.IsConnected() {
+		return nil, fmt.Errorf("client still disconnected after retry wait: %w", err)
+	}
+	return client.GetGroupInfo(ctx, jid)
+}
+
 // MustLogin ensures the WhatsApp client is logged in
 func MustLogin(client *whatsmeow.Client) {
 	if client == nil {

--- a/src/pkg/utils/whatsapp.go
+++ b/src/pkg/utils/whatsapp.go
@@ -980,7 +980,13 @@ func GetGroupInfoWithRetry(ctx context.Context, client *whatsmeow.Client, jid ty
 		return info, err
 	}
 	logrus.Debugf("GetGroupInfo failed and client disconnected, waiting for auto-reconnect: %v", err)
-	time.Sleep(2 * time.Second)
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	if !client.IsConnected() {
 		return nil, fmt.Errorf("client still disconnected after retry wait: %w", err)
 	}

--- a/src/usecase/group.go
+++ b/src/usecase/group.go
@@ -180,7 +180,7 @@ func (service serviceGroup) GetGroupParticipants(ctx context.Context, request do
 		return response, err
 	}
 
-	groupInfo, err := client.GetGroupInfo(ctx, groupJID)
+	groupInfo, err := utils.GetGroupInfoWithRetry(ctx, client, groupJID)
 	if err != nil {
 		return response, err
 	}
@@ -451,7 +451,7 @@ func (service serviceGroup) GroupInfo(ctx context.Context, request domainGroup.G
 	}
 
 	// Fetch group information from WhatsApp
-	groupInfo, err := client.GetGroupInfo(ctx, groupJID)
+	groupInfo, err := utils.GetGroupInfoWithRetry(ctx, client, groupJID)
 	if err != nil {
 		return response, err
 	}

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -1441,7 +1441,7 @@ func (service serviceSend) getMentionsFromList(ctx context.Context, mentions []s
 		// Handle @everyone keyword - fetch all group participants
 		if mention == "@everyone" {
 			if recipientJID.Server == types.GroupServer {
-				groupInfo, err := client.GetGroupInfo(ctx, recipientJID)
+				groupInfo, err := utils.GetGroupInfoWithRetry(ctx, client, recipientJID)
 				if err == nil && groupInfo != nil {
 					for _, participant := range groupInfo.Participants {
 						result = append(result, participant.JID.String())


### PR DESCRIPTION
Issues:
The server occasionally throws 500 or 502 errors ("websocket disconnected 
before info query returned response") when fetching group info.

Cause:
WhatsApp's servers routinely close idle websockets. If a GetGroupInfo query 
fires right as the socket drops, it fails immediately. The whatsmeow library 
auto-reconnects within ~1s, but the app code does not retry the failed query.

Proposed Fix:
Added a GetGroupInfoWithRetry helper in utils/whatsapp.go. If GetGroupInfo 
fails and the client is disconnected, it waits 2s for auto-reconnect, then 
retries once. All 5 call sites updated.
