### PR TITLE
fix: keep the request port in generated URLs (#779)

### DIFF
--- a/src/ui/rest/app.go
+++ b/src/ui/rest/app.go
@@ -68,7 +68,7 @@ func (handler *App) Login(c fiber.Ctx) error {
 		Message: "Login success",
 		Results: map[string]any{
 			"device_id":   device.ID(),
-			"qr_link":     fmt.Sprintf("%s://%s%s/%s", c.Scheme(), c.Hostname(), config.AppBasePath, response.ImagePath),
+			"qr_link":     fmt.Sprintf("%s://%s%s/%s", c.Scheme(), c.Host(), config.AppBasePath, response.ImagePath),
 			"qr_duration": response.Duration,
 		},
 	})

--- a/src/ui/rest/device.go
+++ b/src/ui/rest/device.go
@@ -136,7 +136,7 @@ func (handler *Device) LoginDevice(c fiber.Ctx) error {
 		Message: "Login success",
 		Results: map[string]any{
 			"device_id":   deviceID,
-			"qr_link":     fmt.Sprintf("%s://%s%s/%s", c.Scheme(), c.Hostname(), config.AppBasePath, response.ImagePath),
+			"qr_link":     fmt.Sprintf("%s://%s%s/%s", c.Scheme(), c.Host(), config.AppBasePath, response.ImagePath),
 			"qr_duration": response.Duration,
 		},
 	})

--- a/src/ui/rest/device_test.go
+++ b/src/ui/rest/device_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	domainApp "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/app"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
 	domainDevice "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/device"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/ui/rest/middleware"
@@ -28,11 +29,16 @@ func (s *addDeviceStubUsecase) AddDevice(_ context.Context, deviceID string, web
 	return &domainDevice.Device{ID: deviceID}, nil
 }
 
+func (s *addDeviceStubUsecase) LoginDevice(_ context.Context, _ string) (domainApp.LoginResponse, error) {
+	return domainApp.LoginResponse{ImagePath: "statics/qrcode/scan-qr-dev1.png"}, nil
+}
+
 func newAddDeviceTestApp(stub *addDeviceStubUsecase) *fiber.App {
 	app := fiber.New()
 	app.Use(middleware.Recovery())
 	controller := Device{Service: stub}
 	app.Post("/devices", controller.AddDevice)
+	app.Get("/devices/:device_id/login", controller.LoginDevice)
 	return app
 }
 
@@ -111,5 +117,30 @@ func TestAddDevice_NoWebhookFields(t *testing.T) {
 	}
 	if parsed.Results["id"] != "dev2" {
 		t.Fatalf("expected result id dev2, got %v", parsed.Results["id"])
+	}
+}
+
+// TestLoginDevice_QRLinkKeepsRequestPort verifies the QR link points back at the
+// host:port the client connected to, so it stays reachable when the app is
+// served on a non-default port.
+func TestLoginDevice_QRLinkKeepsRequestPort(t *testing.T) {
+	app := newAddDeviceTestApp(&addDeviceStubUsecase{})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "http://172.168.0.101:3000/devices/dev1/login", nil))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var parsed struct {
+		Results map[string]any `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	want := "http://172.168.0.101:3000/statics/qrcode/scan-qr-dev1.png"
+	if parsed.Results["qr_link"] != want {
+		t.Fatalf("expected qr_link %q, got %v", want, parsed.Results["qr_link"])
 	}
 }

--- a/src/ui/rest/message.go
+++ b/src/ui/rest/message.go
@@ -214,7 +214,8 @@ func publicStaticFileURL(c fiber.Ctx, filePath string) string {
 	if staticPath == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s://%s%s%s", c.Scheme(), c.Hostname(), config.AppBasePath, staticPath)
+	// Host() keeps the port, Hostname() drops it.
+	return fmt.Sprintf("%s://%s%s%s", c.Scheme(), c.Host(), config.AppBasePath, staticPath)
 }
 
 func publicStaticPath(filePath string) string {

--- a/src/ui/rest/message_test.go
+++ b/src/ui/rest/message_test.go
@@ -73,3 +73,21 @@ func TestPublicStaticFileURLUsesRequestScheme(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "http://example.com/api/statics/media/photo.jpg", string(body))
 }
+
+// TestPublicStaticFileURLKeepsRequestPort guards against dropping the port the
+// client actually connected to, which makes the returned URL unreachable when
+// the app is served on a non-default port.
+func TestPublicStaticFileURLKeepsRequestPort(t *testing.T) {
+	app := fiber.New()
+	app.Get("/url", func(c fiber.Ctx) error {
+		return c.SendString(publicStaticFileURL(c, "statics/media/photo.jpg"))
+	})
+
+	resp, err := app.Test(httptest.NewRequest("GET", "http://172.168.0.101:3000/url", nil))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "http://172.168.0.101:3000/statics/media/photo.jpg", string(body))
+}


### PR DESCRIPTION
## Context

Fixes #779 — generated absolute URLs lost the configured port (`172.168.0.101:3000` came back as `172.168.0.101`), making them unreachable.

Root cause: the project is on Fiber v3, which split v2's single `Hostname()` into two methods:

| method | returns |
| --- | --- |
| `c.Host()` | `example.com:8080` — host **with** port |
| `c.Hostname()` | `example.com` — port **stripped** |

Three handlers still used `c.Hostname()` to build absolute URLs, so the port was silently discarded:

- `src/ui/rest/app.go` — `qr_link`
- `src/ui/rest/device.go` — `qr_link` (per-device)
- `src/ui/rest/message.go` — `publicStaticFileURL`, used for the downloaded-media `file_url`

Switched all three to `c.Host()`. `Host()` still honours `X-Forwarded-Host` under `TrustProxy` exactly as `Hostname()` did, so reverse-proxy behaviour is unchanged — it just no longer throws the port away.

## Test Results

Added two regression tests (written first, and confirmed to reproduce the exact strings from the issue before the fix was applied):

```
--- FAIL: TestLoginDevice_QRLinkKeepsRequestPort
    expected "http://172.168.0.101:3000/statics/qrcode/scan-qr-dev1.png",
    got      "http://172.168.0.101/statics/qrcode/scan-qr-dev1.png"
--- FAIL: TestPublicStaticFileURLKeepsRequestPort
    expected: "http://172.168.0.101:3000/statics/media/photo.jpg"
    actual  : "http://172.168.0.101/statics/media/photo.jpg"
```

After the fix:

```
$ go test ./ui/rest/ -run "TestPublicStaticFileURL|TestLoginDevice_QRLink" -v
--- PASS: TestLoginDevice_QRLinkKeepsRequestPort (0.00s)
--- PASS: TestPublicStaticFileURLUsesRequestScheme (0.00s)
--- PASS: TestPublicStaticFileURLKeepsRequestPort (0.00s)
ok      github.com/aldinokemal/go-whatsapp-web-multidevice/ui/rest      0.421s
```

Also clean: `go build ./...`, `go vet ./ui/rest/`, `gofmt -l ui/rest/`, and the full `go test ./...` suite.
