### PR TITLE
feat(send): add calendar event messages (/send/event + whatsapp_send_event MCP tool)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1806,6 +1806,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorInternalServer'
+  /send/event:
+    post:
+      operationId: sendEvent
+      tags:
+        - send
+      summary: Send Calendar Event
+      parameters:
+        - $ref: '#/components/parameters/DeviceIdHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                phone:
+                  type: string
+                  description: The WhatsApp phone number to send the event to, including the '@s.whatsapp.net' suffix.
+                  example: '6289685024421@s.whatsapp.net'
+                name:
+                  type: string
+                  description: The name of the event.
+                  example: 'Team Meeting'
+                description:
+                  type: string
+                  description: Optional description of the event.
+                  example: 'Quarterly planning session'
+                start_time:
+                  type: integer
+                  format: int64
+                  description: Event start time as a unix timestamp in seconds.
+                  example: 2063137000
+                end_time:
+                  type: integer
+                  format: int64
+                  description: Optional event end time as a unix timestamp in seconds. Must be after start_time.
+                  example: 2063140600
+                location_name:
+                  type: string
+                  description: Optional location name shown on the event.
+                  example: 'Head Office'
+                extra_guests_allowed:
+                  type: boolean
+                  description: Whether attendees may bring extra guests.
+                  example: false
+                duration:
+                  type: integer
+                  example: 86400
+                  description: "Disappearing message duration in seconds. Allowed values: 0 (no expiry), 86400 (24h), 604800 (7d), 7776000 (90d)."
+              required:
+                - phone
+                - name
+                - start_time
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBadRequest'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInternalServer'
   /send/presence:
     post:
       operationId: sendPresence

--- a/readme.md
+++ b/readme.md
@@ -406,6 +406,7 @@ protocol. Below is the complete list of available tools:
 - `whatsapp_send_document` - Send document/file messages from URLs
 - `whatsapp_send_audio` - Send audio files from URLs, including voice-note mode
 - `whatsapp_send_poll` - Send WhatsApp polls
+- `whatsapp_send_event` - Send WhatsApp calendar events with RSVP
 
 ##### **📋 Chat & Contact Management**
 
@@ -635,6 +636,7 @@ You can fork or edit this source code !
 | ✅       | Send Link                              | POST   | /send/link                          |
 | ✅       | Send Location                          | POST   | /send/location                      |
 | ✅       | Send Poll / Vote                       | POST   | /send/poll                          |
+| ✅       | Send Calendar Event                    | POST   | /send/event                         |
 | ✅       | Send Presence                          | POST   | /send/presence                      |
 | ✅       | Send Chat Presence (Typing Indicator)  | POST   | /send/chat-presence                 |
 | ✅       | Revoke Message                         | POST   | /message/:message_id/revoke         |

--- a/src/domains/send/event.go
+++ b/src/domains/send/event.go
@@ -1,0 +1,11 @@
+package send
+
+type EventRequest struct {
+	BaseRequest
+	Name               string `json:"name" form:"name"`
+	Description        string `json:"description" form:"description"`
+	StartTime          int64  `json:"start_time" form:"start_time"`
+	EndTime            *int64 `json:"end_time" form:"end_time"`
+	LocationName       string `json:"location_name" form:"location_name"`
+	ExtraGuestsAllowed bool   `json:"extra_guests_allowed" form:"extra_guests_allowed"`
+}

--- a/src/domains/send/interfaces.go
+++ b/src/domains/send/interfaces.go
@@ -24,6 +24,7 @@ type IInteractionSender interface {
 	SendLink(ctx context.Context, request LinkRequest) (response GenericResponse, err error)
 	SendLocation(ctx context.Context, request LocationRequest) (response GenericResponse, err error)
 	SendPoll(ctx context.Context, request PollRequest) (response GenericResponse, err error)
+	SendEvent(ctx context.Context, request EventRequest) (response GenericResponse, err error)
 }
 
 // IPresenceSender handles presence-related operations

--- a/src/ui/mcp/send.go
+++ b/src/ui/mcp/send.go
@@ -786,14 +786,19 @@ func (s *SendHandler) handleSendEvent(ctx context.Context, request mcp.CallToolR
 		eventRequest.EndTime = &endTime
 	}
 
-	if args := request.GetArguments(); args != nil {
-		if _, ok := args["duration"]; ok {
-			duration, err := request.RequireInt("duration")
-			if err != nil {
-				return nil, err
-			}
-			eventRequest.Duration = &duration
+	// duration goes through the same strict integer path as the timestamps:
+	// RequireInt casts float64 to int, so fractional values like 86400.5
+	// would silently truncate onto the duration whitelist.
+	duration64, ok, err := int64Arg(request, "duration")
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		if duration64 < math.MinInt32 || duration64 > math.MaxInt32 {
+			return nil, errors.New("argument \"duration\" is out of range")
 		}
+		duration := int(duration64)
+		eventRequest.Duration = &duration
 	}
 
 	res, err := s.sendService.SendEvent(ctx, eventRequest)

--- a/src/ui/mcp/send.go
+++ b/src/ui/mcp/send.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	domainSend "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/send"
 	mcpHelpers "github.com/aldinokemal/go-whatsapp-web-multidevice/ui/mcp/helpers"
@@ -697,7 +698,40 @@ func (s *SendHandler) toolSendEvent() mcp.Tool {
 		mcp.WithBoolean("extra_guests_allowed",
 			mcp.Description("Whether attendees may bring extra guests (default: false)"),
 		),
+		mcp.WithNumber("duration",
+			mcp.Description("Optional disappearing message duration in seconds (0, 86400, 604800, 7776000)"),
+		),
 	)
+}
+
+// int64Arg reads an MCP number argument as int64 without routing through the
+// platform-sized int helpers, which truncate unix timestamps past 2038 on
+// 32-bit builds (e.g. the armv7 image).
+func int64Arg(request mcp.CallToolRequest, key string) (int64, bool, error) {
+	args := request.GetArguments()
+	if args == nil {
+		return 0, false, nil
+	}
+	val, exists := args[key]
+	if !exists || val == nil {
+		return 0, false, nil
+	}
+	switch v := val.(type) {
+	case float64:
+		return int64(v), true, nil
+	case int64:
+		return v, true, nil
+	case int:
+		return int64(v), true, nil
+	case string:
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, false, fmt.Errorf("argument %q cannot be converted to int64", key)
+		}
+		return parsed, true, nil
+	default:
+		return 0, false, fmt.Errorf("argument %q is not an integer", key)
+	}
 }
 
 func (s *SendHandler) handleSendEvent(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -716,9 +750,12 @@ func (s *SendHandler) handleSendEvent(ctx context.Context, request mcp.CallToolR
 		return nil, err
 	}
 
-	startTime, err := request.RequireInt("start_time")
+	startTime, ok, err := int64Arg(request, "start_time")
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return nil, errors.New("required argument \"start_time\" not found")
 	}
 
 	eventRequest := domainSend.EventRequest{
@@ -727,13 +764,29 @@ func (s *SendHandler) handleSendEvent(ctx context.Context, request mcp.CallToolR
 		},
 		Name:               name,
 		Description:        request.GetString("description", ""),
-		StartTime:          int64(startTime),
+		StartTime:          startTime,
 		LocationName:       request.GetString("location_name", ""),
 		ExtraGuestsAllowed: request.GetBool("extra_guests_allowed", false),
 	}
-	if endTime := request.GetInt("end_time", 0); endTime > 0 {
-		endTime64 := int64(endTime)
-		eventRequest.EndTime = &endTime64
+
+	// An explicitly supplied end_time is always passed through so validation
+	// can reject values that are not after start_time.
+	endTime, ok, err := int64Arg(request, "end_time")
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		eventRequest.EndTime = &endTime
+	}
+
+	if args := request.GetArguments(); args != nil {
+		if _, ok := args["duration"]; ok {
+			duration, err := request.RequireInt("duration")
+			if err != nil {
+				return nil, err
+			}
+			eventRequest.Duration = &duration
+		}
 	}
 
 	res, err := s.sendService.SendEvent(ctx, eventRequest)

--- a/src/ui/mcp/send.go
+++ b/src/ui/mcp/send.go
@@ -32,6 +32,7 @@ func (s *SendHandler) AddSendTools(mcpServer *server.MCPServer) {
 	mcpServer.AddTool(s.toolSendDocument(), s.handleSendDocument)
 	mcpServer.AddTool(s.toolSendAudio(), s.handleSendAudio)
 	mcpServer.AddTool(s.toolSendPoll(), s.handleSendPoll)
+	mcpServer.AddTool(s.toolSendEvent(), s.handleSendEvent)
 	mcpServer.AddTool(s.toolForwardMessage(), s.handleForwardMessage)
 }
 
@@ -663,6 +664,84 @@ func (s *SendHandler) handleSendPoll(ctx context.Context, request mcp.CallToolRe
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf("Poll sent successfully with ID %s", res.MessageID)), nil
+}
+
+func (s *SendHandler) toolSendEvent() mcp.Tool {
+	return mcp.NewTool("whatsapp_send_event",
+		mcp.WithDescription("Send a calendar event to a WhatsApp contact or group. Recipients can RSVP to the event."),
+		mcp.WithTitleAnnotation("Send Event"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithString("phone",
+			mcp.Required(),
+			mcp.Description("Phone number or group ID to send the event to"),
+		),
+		mcp.WithString("name",
+			mcp.Required(),
+			mcp.Description("The event name"),
+		),
+		mcp.WithNumber("start_time",
+			mcp.Required(),
+			mcp.Description("Event start time as a unix timestamp in seconds"),
+		),
+		mcp.WithString("description",
+			mcp.Description("Optional event description"),
+		),
+		mcp.WithNumber("end_time",
+			mcp.Description("Optional event end time as a unix timestamp in seconds"),
+		),
+		mcp.WithString("location_name",
+			mcp.Description("Optional location name shown on the event"),
+		),
+		mcp.WithBoolean("extra_guests_allowed",
+			mcp.Description("Whether attendees may bring extra guests (default: false)"),
+		),
+	)
+}
+
+func (s *SendHandler) handleSendEvent(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	ctx, err := mcpHelpers.ContextWithDefaultDevice(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	phone, err := request.RequireString("phone")
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := request.RequireString("name")
+	if err != nil {
+		return nil, err
+	}
+
+	startTime, err := request.RequireInt("start_time")
+	if err != nil {
+		return nil, err
+	}
+
+	eventRequest := domainSend.EventRequest{
+		BaseRequest: domainSend.BaseRequest{
+			Phone: phone,
+		},
+		Name:               name,
+		Description:        request.GetString("description", ""),
+		StartTime:          int64(startTime),
+		LocationName:       request.GetString("location_name", ""),
+		ExtraGuestsAllowed: request.GetBool("extra_guests_allowed", false),
+	}
+	if endTime := request.GetInt("end_time", 0); endTime > 0 {
+		endTime64 := int64(endTime)
+		eventRequest.EndTime = &endTime64
+	}
+
+	res, err := s.sendService.SendEvent(ctx, eventRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Event sent successfully with ID %s", res.MessageID)), nil
 }
 
 func (s *SendHandler) toolForwardMessage() mcp.Tool {

--- a/src/ui/mcp/send.go
+++ b/src/ui/mcp/send.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 
 	domainSend "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/send"
@@ -718,6 +719,12 @@ func int64Arg(request mcp.CallToolRequest, key string) (int64, bool, error) {
 	}
 	switch v := val.(type) {
 	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) || math.Trunc(v) != v {
+			return 0, false, fmt.Errorf("argument %q must be an integer", key)
+		}
+		if v <= math.MinInt64 || v >= math.MaxInt64 {
+			return 0, false, fmt.Errorf("argument %q is out of range", key)
+		}
 		return int64(v), true, nil
 	case int64:
 		return v, true, nil

--- a/src/ui/rest/send.go
+++ b/src/ui/rest/send.go
@@ -23,6 +23,7 @@ func InitRestSend(app fiber.Router, service domainSend.ISendUsecase) Send {
 	app.Post("/send/location", rest.SendLocation)
 	app.Post("/send/audio", rest.SendAudio)
 	app.Post("/send/poll", rest.SendPoll)
+	app.Post("/send/event", rest.SendEvent)
 	app.Post("/send/presence", rest.SendPresence)
 	app.Post("/send/chat-presence", rest.SendChatPresence)
 	return rest
@@ -225,6 +226,24 @@ func (controller *Send) SendPoll(c fiber.Ctx) error {
 	utils.SanitizePhone(&request.Phone)
 
 	response, err := controller.Service.SendPoll(whatsapp.ContextWithDevice(c.Context(), getDeviceFromCtx(c)), request)
+	utils.PanicIfNeeded(err)
+
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: response.Status,
+		Results: response,
+	})
+}
+
+func (controller *Send) SendEvent(c fiber.Ctx) error {
+	var request domainSend.EventRequest
+	err := c.Bind().Body(&request)
+	utils.PanicIfNeeded(err)
+
+	utils.SanitizePhone(&request.Phone)
+
+	response, err := controller.Service.SendEvent(whatsapp.ContextWithDevice(c.Context(), getDeviceFromCtx(c)), request)
 	utils.PanicIfNeeded(err)
 
 	return c.JSON(utils.ResponseData{

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -1378,10 +1378,16 @@ func (service serviceSend) SendEvent(ctx context.Context, request domainSend.Eve
 		return response, err
 	}
 
+	// Mirror the field set phone clients produce: recipients ignore event
+	// creations missing the explicit lifecycle/reminder fields.
 	eventMessage := &waE2E.EventMessage{
 		Name:               proto.String(request.Name),
 		StartTime:          proto.Int64(request.StartTime),
 		ExtraGuestsAllowed: proto.Bool(request.ExtraGuestsAllowed),
+		IsCanceled:         proto.Bool(false),
+		IsScheduleCall:     proto.Bool(false),
+		HasReminder:        proto.Bool(true),
+		ReminderOffsetSec:  proto.Int64(3600),
 	}
 	if request.Description != "" {
 		eventMessage.Description = proto.String(request.Description)

--- a/src/usecase/send.go
+++ b/src/usecase/send.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"math"
@@ -1351,6 +1352,68 @@ func (service serviceSend) SendPoll(ctx context.Context, request domainSend.Poll
 
 	response.MessageID = ts.ID
 	response.Status = fmt.Sprintf("Send poll success %s (server timestamp: %s)", request.BaseRequest.Phone, ts.Timestamp.String())
+	return response, nil
+}
+
+func (service serviceSend) SendEvent(ctx context.Context, request domainSend.EventRequest) (response domainSend.GenericResponse, err error) {
+	err = validations.ValidateSendEvent(ctx, request)
+	if err != nil {
+		return response, err
+	}
+
+	client := whatsapp.ClientFromContext(ctx)
+	if client == nil {
+		return response, pkgError.ErrWaCLI
+	}
+
+	dataWaRecipient, err := utils.ValidateJidWithLogin(client, request.BaseRequest.Phone)
+	if err != nil {
+		return response, err
+	}
+
+	// Recipients encrypt their RSVP responses with the event's message secret
+	// (same mechanism as poll votes), so the creation message must carry one.
+	msgSecret := make([]byte, 32)
+	if _, err = rand.Read(msgSecret); err != nil {
+		return response, err
+	}
+
+	eventMessage := &waE2E.EventMessage{
+		Name:               proto.String(request.Name),
+		StartTime:          proto.Int64(request.StartTime),
+		ExtraGuestsAllowed: proto.Bool(request.ExtraGuestsAllowed),
+	}
+	if request.Description != "" {
+		eventMessage.Description = proto.String(request.Description)
+	}
+	if request.EndTime != nil {
+		eventMessage.EndTime = proto.Int64(*request.EndTime)
+	}
+	if request.LocationName != "" {
+		eventMessage.Location = &waE2E.LocationMessage{
+			Name: proto.String(request.LocationName),
+		}
+	}
+	if request.BaseRequest.Duration != nil && *request.BaseRequest.Duration > 0 {
+		eventMessage.ContextInfo = &waE2E.ContextInfo{
+			Expiration: proto.Uint32(uint32(*request.BaseRequest.Duration)),
+		}
+	}
+
+	msg := &waE2E.Message{
+		EventMessage:       eventMessage,
+		MessageContextInfo: &waE2E.MessageContextInfo{MessageSecret: msgSecret},
+	}
+
+	content := "📅 " + request.Name
+
+	ts, err := service.wrapSendMessage(ctx, client, dataWaRecipient, msg, content)
+	if err != nil {
+		return response, err
+	}
+
+	response.MessageID = ts.ID
+	response.Status = fmt.Sprintf("Send event success %s (server timestamp: %s)", request.BaseRequest.Phone, ts.Timestamp.String())
 	return response, nil
 }
 

--- a/src/validations/send_validation.go
+++ b/src/validations/send_validation.go
@@ -489,6 +489,37 @@ func ValidateSendPoll(ctx context.Context, request domainSend.PollRequest) error
 	return nil
 }
 
+func ValidateSendEvent(ctx context.Context, request domainSend.EventRequest) error {
+	err := validation.ValidateStructWithContext(ctx, &request,
+		validation.Field(&request.Phone, validation.Required),
+		validation.Field(&request.Name, validation.Required),
+		validation.Field(&request.StartTime, validation.Required),
+	)
+
+	if err != nil {
+		return pkgError.ValidationError(err.Error())
+	}
+
+	// Custom validation for phone number format
+	if err := validatePhoneNumber(request.Phone); err != nil {
+		return err
+	}
+
+	if err := validateDuration(request.Duration); err != nil {
+		return err
+	}
+
+	if request.StartTime < 0 {
+		return pkgError.ValidationError("start_time must be a unix timestamp in seconds")
+	}
+
+	if request.EndTime != nil && *request.EndTime <= request.StartTime {
+		return pkgError.ValidationError("end_time must be after start_time")
+	}
+
+	return nil
+}
+
 func ValidateSendPresence(ctx context.Context, request domainSend.PresenceRequest) error {
 	err := validation.ValidateStructWithContext(ctx, &request,
 		validation.Field(&request.Type, validation.In("available", "unavailable")),

--- a/src/validations/send_validation_test.go
+++ b/src/validations/send_validation_test.go
@@ -798,6 +798,7 @@ func TestValidateSendPoll(t *testing.T) {
 func TestValidateSendEvent(t *testing.T) {
 	endTimeValid := int64(2063140600)
 	endTimeBeforeStart := int64(2063130000)
+	endTimeEqualStart := int64(2063137000)
 
 	type args struct {
 		request domainSend.EventRequest
@@ -874,6 +875,29 @@ func TestValidateSendEvent(t *testing.T) {
 				Name:      "Team Meeting",
 				StartTime: 2063137000,
 				EndTime:   &endTimeBeforeStart,
+			}},
+			err: pkgError.ValidationError("end_time must be after start_time"),
+		},
+		{
+			name: "should error with negative start time",
+			args: args{request: domainSend.EventRequest{
+				BaseRequest: domainSend.BaseRequest{
+					Phone: "1728937129312@s.whatsapp.net",
+				},
+				Name:      "Team Meeting",
+				StartTime: -1,
+			}},
+			err: pkgError.ValidationError("start_time must be a unix timestamp in seconds"),
+		},
+		{
+			name: "should error with end time equal to start time",
+			args: args{request: domainSend.EventRequest{
+				BaseRequest: domainSend.BaseRequest{
+					Phone: "1728937129312@s.whatsapp.net",
+				},
+				Name:      "Team Meeting",
+				StartTime: 2063137000,
+				EndTime:   &endTimeEqualStart,
 			}},
 			err: pkgError.ValidationError("end_time must be after start_time"),
 		},

--- a/src/validations/send_validation_test.go
+++ b/src/validations/send_validation_test.go
@@ -795,6 +795,98 @@ func TestValidateSendPoll(t *testing.T) {
 	}
 }
 
+func TestValidateSendEvent(t *testing.T) {
+	endTimeValid := int64(2063140600)
+	endTimeBeforeStart := int64(2063130000)
+
+	type args struct {
+		request domainSend.EventRequest
+	}
+	tests := []struct {
+		name string
+		args args
+		err  any
+	}{
+		{
+			name: "should success with normal condition",
+			args: args{request: domainSend.EventRequest{
+				BaseRequest: domainSend.BaseRequest{
+					Phone: "1728937129312@s.whatsapp.net",
+				},
+				Name:      "Team Meeting",
+				StartTime: 2063137000,
+			}},
+			err: nil,
+		},
+		{
+			name: "should success with all optional fields",
+			args: args{request: domainSend.EventRequest{
+				BaseRequest: domainSend.BaseRequest{
+					Phone: "1728937129312@s.whatsapp.net",
+				},
+				Name:               "Team Meeting",
+				Description:        "Quarterly planning session",
+				StartTime:          2063137000,
+				EndTime:            &endTimeValid,
+				LocationName:       "Head Office",
+				ExtraGuestsAllowed: true,
+			}},
+			err: nil,
+		},
+		{
+			name: "should error with empty phone",
+			args: args{request: domainSend.EventRequest{
+				BaseRequest: domainSend.BaseRequest{
+					Phone: "",
+				},
+				Name:      "Team Meeting",
+				StartTime: 2063137000,
+			}},
+			err: pkgError.ValidationError("phone: cannot be blank."),
+		},
+		{
+			name: "should error with empty name",
+			args: args{request: domainSend.EventRequest{
+				BaseRequest: domainSend.BaseRequest{
+					Phone: "1728937129312@s.whatsapp.net",
+				},
+				Name:      "",
+				StartTime: 2063137000,
+			}},
+			err: pkgError.ValidationError("name: cannot be blank."),
+		},
+		{
+			name: "should error with missing start time",
+			args: args{request: domainSend.EventRequest{
+				BaseRequest: domainSend.BaseRequest{
+					Phone: "1728937129312@s.whatsapp.net",
+				},
+				Name: "Team Meeting",
+			}},
+			err: pkgError.ValidationError("start_time: cannot be blank."),
+		},
+		{
+			name: "should error with end time before start time",
+			args: args{request: domainSend.EventRequest{
+				BaseRequest: domainSend.BaseRequest{
+					Phone: "1728937129312@s.whatsapp.net",
+				},
+				Name:      "Team Meeting",
+				StartTime: 2063137000,
+				EndTime:   &endTimeBeforeStart,
+			}},
+			err: pkgError.ValidationError("end_time must be after start_time"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSendEvent(context.Background(), tt.args.request)
+			assert.Equal(t, tt.err, err)
+		})
+	}
+}
+
 func TestValidateSendPresence(t *testing.T) {
 	type args struct {
 		request domainSend.PresenceRequest


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on tulir/whatsmeow#1214** — event messages must be framed `type="event"` with a `<meta event_type="creation"/>` node or recipient clients silently drop them. Verified end-to-end (renders with working RSVP) on a build with that patch; once it lands upstream, a routine whatsmeow bump here makes this PR fully functional.

## What

Adds WhatsApp **calendar event** sending — the native event message type with RSVP (Attending / Not attending), as seen in group and 1:1 chats.

- `POST /send/event` — REST endpoint
- `whatsapp_send_event` — MCP tool
- OpenAPI spec + readme updated

## Example

```bash
curl -X POST http://localhost:3000/send/event \
  -H 'Content-Type: application/json' \
  -d '{
    "phone": "6289685024421@s.whatsapp.net",
    "name": "Team Meeting",
    "description": "Quarterly planning session",
    "start_time": 2063137000,
    "end_time": 2063140600,
    "location_name": "Head Office",
    "extra_guests_allowed": false
  }'
```

`name` and `start_time` (unix seconds) are required; `description`, `end_time`, `location_name`, `extra_guests_allowed`, and the standard `duration` (disappearing messages) are optional.

## How

Mirrors the existing `SendPoll` flow layer by layer (domain DTO → ozzo validation → usecase → REST/MCP):

- Builds `waE2E.EventMessage` and sends it through the existing `wrapSendMessage` path, so chat storage and error normalization behave like every other send.
- The creation message carries a random 32-byte `MessageSecret` in `MessageContextInfo` — same mechanism as poll creation. This is required: recipients encrypt their RSVP responses with the event's message secret, so without it the event renders but nobody can respond.
- `duration` maps to `ContextInfo.Expiration` like the other message types.
- Location is name-only (`LocationMessage.Name`); coordinates are omitted.

## Validation

- `name`, `start_time`, `phone` required; international phone format check
- `end_time`, when set, must be after `start_time`
- `duration` restricted to the existing disappearing-message whitelist

## Tests

- Table-driven tests for `ValidateSendEvent` (6 cases) in `validations/send_validation_test.go`
- `go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass (11 packages ok)

