### PR TITLE
fix: save device webhook config against the generated device ID

### DIFF
--- a/src/usecase/device.go
+++ b/src/usecase/device.go
@@ -60,6 +60,10 @@ func (s *serviceDevice) AddDevice(ctx context.Context, deviceID string, webhook 
 		return nil, err
 	}
 
+	// CreateDevice generates an ID when none was requested; the webhook config
+	// below must be saved against the actual ID, not the (possibly empty) request value.
+	deviceID = inst.ID()
+
 	// Apply the device-specific webhook configuration if provided. Failures are
 	// surfaced instead of logged away: the caller was promised the webhook config,
 	// so a silent partial success would leave the API reporting a webhook that was


### PR DESCRIPTION
## Problem

`POST /devices` with a webhook config but **no** `device_id` fails with:

```
device  created but webhook config could not be saved: device id is required
```

`AddDevice` passes the request's `device_id` to `CreateDevice`, which correctly generates a UUID when it's empty — but the webhook-config save that follows still uses the original empty request value, so `SetDeviceWebhookConfig` rejects it. The device slot is created, the webhook config is lost, and the API reports failure.

## Fix

After `CreateDevice` returns, use the created instance's actual ID for the webhook save.

## Repro

```bash
curl -u user:pass -X POST http://localhost:3000/devices \
  -H 'Content-Type: application/json' \
  -d '{"webhook_url": "https://example.com/hook", "webhook_secret": "s3cret"}'
```

Before: 500 with the error above (device slot still created as a side effect).
After: 200, device created with its webhook config persisted.

Passing an explicit `device_id` was unaffected, which is why this path is easy to miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
