### PR TITLE
fix(webhook): propagate device context to async forward goroutines

### DIFF
--- a/src/infrastructure/chatwoot/client.go
+++ b/src/infrastructure/chatwoot/client.go
@@ -866,9 +866,14 @@ func (c *Client) createMessageWithAttachments(endpoint, content, messageType str
 
 		mimeType := mime.TypeByExtension(ext)
 		if mimeType == "" {
-			if ext == ".oga" {
+			switch ext {
+			case ".oga", ".ogg":
+				// The runtime image ships no /etc/mime.types, so
+				// mime.TypeByExtension never resolves these on its own.
+				// WhatsApp voice notes are saved as .ogg (Opus-in-Ogg);
+				// .oga is the alternate extension for the same container.
 				mimeType = "audio/ogg"
-			} else {
+			default:
 				mimeType = "application/octet-stream"
 			}
 		}

--- a/src/infrastructure/whatsapp/event_call.go
+++ b/src/infrastructure/whatsapp/event_call.go
@@ -44,7 +44,7 @@ func handleCallOffer(ctx context.Context, evt *events.CallOffer, chatStorageRepo
 
 	// Forward call event to webhook
 	go func(e *events.CallOffer, c *whatsmeow.Client, rejected bool) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardCallOfferToWebhook(webhookCtx, e, deviceID, c, rejected); err != nil {
 			logrus.Errorf("Failed to forward call event to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_call.go
+++ b/src/infrastructure/whatsapp/event_call.go
@@ -44,7 +44,7 @@ func handleCallOffer(ctx context.Context, evt *events.CallOffer, chatStorageRepo
 
 	// Forward call event to webhook
 	go func(e *events.CallOffer, c *whatsmeow.Client, rejected bool) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardCallOfferToWebhook(webhookCtx, e, deviceID, c, rejected); err != nil {
 			logrus.Errorf("Failed to forward call event to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_chat_presence.go
+++ b/src/infrastructure/whatsapp/event_chat_presence.go
@@ -26,7 +26,7 @@ func handleChatPresence(ctx context.Context, evt *events.ChatPresence, deviceID 
 
 	// Forward chat presence event to webhook
 	go func(e *events.ChatPresence, c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardChatPresenceToWebhook(webhookCtx, e, deviceID, c); err != nil {
 			logrus.Errorf("Failed to forward chat_presence event to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_chat_presence.go
+++ b/src/infrastructure/whatsapp/event_chat_presence.go
@@ -26,7 +26,7 @@ func handleChatPresence(ctx context.Context, evt *events.ChatPresence, deviceID 
 
 	// Forward chat presence event to webhook
 	go func(e *events.ChatPresence, c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardChatPresenceToWebhook(webhookCtx, e, deviceID, c); err != nil {
 			logrus.Errorf("Failed to forward chat_presence event to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_group.go
+++ b/src/infrastructure/whatsapp/event_group.go
@@ -85,7 +85,7 @@ func handleJoinedGroup(ctx context.Context, evt *events.JoinedGroup, deviceID st
 
 	// Forward joined group event to webhook
 	go func(e *events.JoinedGroup, c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardJoinedGroupToWebhook(webhookCtx, e, deviceID, c); err != nil {
 			logrus.Errorf("Failed to forward joined group event to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_group.go
+++ b/src/infrastructure/whatsapp/event_group.go
@@ -85,7 +85,7 @@ func handleJoinedGroup(ctx context.Context, evt *events.JoinedGroup, deviceID st
 
 	// Forward joined group event to webhook
 	go func(e *events.JoinedGroup, c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardJoinedGroupToWebhook(webhookCtx, e, deviceID, c); err != nil {
 			logrus.Errorf("Failed to forward joined group event to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_handler.go
+++ b/src/infrastructure/whatsapp/event_handler.go
@@ -124,7 +124,7 @@ func handleDeleteForMe(ctx context.Context, evt *events.DeleteForMe, chatStorage
 
 	// Send webhook notification for delete event
 	go func(c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardDeleteToWebhook(webhookCtx, evt, message, deviceID, c); err != nil {
 			log.Errorf("Failed to forward delete event to webhook: %v", err)
@@ -322,7 +322,7 @@ func handleReceipt(ctx context.Context, evt *events.Receipt, deviceID string, cl
 	// Note: Receipt events are not rate limited as they are critical for message delivery status
 	if sendReceipt {
 		go func(e *events.Receipt, c *whatsmeow.Client) {
-			webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
 			if err := forwardReceiptToWebhook(webhookCtx, e, deviceID, c); err != nil {
 				logrus.Errorf("Failed to forward ack event to webhook: %v", err)
@@ -348,7 +348,7 @@ func handleAppState(ctx context.Context, evt *events.AppState, deviceID string, 
 
 	if isLabelAppState(evt) {
 		go func(e *events.AppState, c *whatsmeow.Client) {
-			webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer cancel()
 			if err := forwardLabelAppStateToWebhook(webhookCtx, e, deviceID, c); err != nil {
 				logrus.Errorf("Failed to forward label appstate event to webhook: %v", err)
@@ -382,7 +382,7 @@ func handleGroupInfo(ctx context.Context, evt *events.GroupInfo, deviceID string
 
 	// Forward group info event to webhook
 	go func(e *events.GroupInfo, c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardGroupInfoToWebhook(webhookCtx, e, deviceID, c); err != nil {
 			logrus.Errorf("Failed to forward group info event to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_handler.go
+++ b/src/infrastructure/whatsapp/event_handler.go
@@ -124,7 +124,7 @@ func handleDeleteForMe(ctx context.Context, evt *events.DeleteForMe, chatStorage
 
 	// Send webhook notification for delete event
 	go func(c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardDeleteToWebhook(webhookCtx, evt, message, deviceID, c); err != nil {
 			log.Errorf("Failed to forward delete event to webhook: %v", err)
@@ -322,7 +322,7 @@ func handleReceipt(ctx context.Context, evt *events.Receipt, deviceID string, cl
 	// Note: Receipt events are not rate limited as they are critical for message delivery status
 	if sendReceipt {
 		go func(e *events.Receipt, c *whatsmeow.Client) {
-			webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
 			if err := forwardReceiptToWebhook(webhookCtx, e, deviceID, c); err != nil {
 				logrus.Errorf("Failed to forward ack event to webhook: %v", err)
@@ -343,12 +343,12 @@ func handlePresence(_ context.Context, evt *events.Presence) {
 	}
 }
 
-func handleAppState(_ context.Context, evt *events.AppState, deviceID string, client *whatsmeow.Client) {
+func handleAppState(ctx context.Context, evt *events.AppState, deviceID string, client *whatsmeow.Client) {
 	log.Debugf("App state event: %+v / %+v", evt.Index, evt.SyncActionValue)
 
 	if isLabelAppState(evt) {
 		go func(e *events.AppState, c *whatsmeow.Client) {
-			webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
 			if err := forwardLabelAppStateToWebhook(webhookCtx, e, deviceID, c); err != nil {
 				logrus.Errorf("Failed to forward label appstate event to webhook: %v", err)
@@ -382,7 +382,7 @@ func handleGroupInfo(ctx context.Context, evt *events.GroupInfo, deviceID string
 
 	// Forward group info event to webhook
 	go func(e *events.GroupInfo, c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardGroupInfoToWebhook(webhookCtx, e, deviceID, c); err != nil {
 			logrus.Errorf("Failed to forward group info event to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -171,7 +171,36 @@ func buildEventPayload(ctx context.Context, client *whatsmeow.Client, evt *event
 		return "", nil, err
 	}
 
+	if payloadHasNoRenderableContent(payload) {
+		// None of the known text/media/structured fields matched, so this
+		// message type isn't recognized by buildMessageBody/buildOptionalFields
+		// (e.g. templates, interactive/native-flow messages, polls, group
+		// invites, payment requests). Downstream (Chatwoot) will render it as
+		// "(Unsupported message type)" with no way to tell which WhatsApp
+		// message kind caused it; dump the raw proto here so a future
+		// occurrence is diagnosable directly from logs instead of guesswork.
+		logrus.Warnf("Unrecognized message type from %s (id=%s): %s", evt.Info.Sender.String(), evt.Info.ID, msg.String())
+	}
+
 	return EventTypeMessage, payload, nil
+}
+
+// payloadHasNoRenderableContent reports whether none of the fields
+// buildMessageBody/buildOptionalFields/buildMediaFields/buildOtherMessageTypes
+// populate for a recognized message type are present. Kept in sync with the
+// field names those functions write to payload.
+func payloadHasNoRenderableContent(payload map[string]any) bool {
+	renderableKeys := []string{
+		"body",
+		"image", "audio", "video", "video_note", "document", "sticker",
+		"contact", "contacts_array", "list", "live_location", "location", "order",
+	}
+	for _, key := range renderableKeys {
+		if _, ok := payload[key]; ok {
+			return false
+		}
+	}
+	return true
 }
 
 func buildFromFields(ctx context.Context, client *whatsmeow.Client, evt *events.Message, payload map[string]any) {

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 var reMention = regexp.MustCompile(`\B@\w+`)
@@ -171,15 +172,16 @@ func buildEventPayload(ctx context.Context, client *whatsmeow.Client, evt *event
 		return "", nil, err
 	}
 
-	if payloadHasNoRenderableContent(payload) {
-		// None of the known text/media/structured fields matched, so this
-		// message type isn't recognized by buildMessageBody/buildOptionalFields
-		// (e.g. templates, interactive/native-flow messages, polls, group
-		// invites, payment requests). Downstream (Chatwoot) will render it as
-		// "(Unsupported message type)" with no way to tell which WhatsApp
-		// message kind caused it; dump the raw proto here so a future
-		// occurrence is diagnosable directly from logs instead of guesswork.
-		logrus.Warnf("Unrecognized message type from %s (id=%s): %s", evt.Info.Sender.String(), evt.Info.ID, msg.String())
+	if payloadHasNoRenderableContent(payload) && !hasRecognizedMessageType(msg) {
+		// Neither a recognized message type nor any renderable payload field:
+		// this is genuinely an unhandled kind (e.g. templates, interactive/
+		// native-flow messages, polls, group invites, payment requests).
+		// Downstream (Chatwoot) will render it as "(Unsupported message
+		// type)" with no way to tell which WhatsApp message kind caused it.
+		// Log which proto field is populated — never its value, since that
+		// can carry customer message content, media URLs, and decryption
+		// keys — so a future occurrence is diagnosable from logs alone.
+		logrus.Warnf("Unrecognized message type from %s (id=%s): populated proto fields=%v", evt.Info.Sender.String(), evt.Info.ID, populatedMessageFields(msg))
 	}
 
 	return EventTypeMessage, payload, nil
@@ -189,6 +191,12 @@ func buildEventPayload(ctx context.Context, client *whatsmeow.Client, evt *event
 // buildMessageBody/buildOptionalFields/buildMediaFields/buildOtherMessageTypes
 // populate for a recognized message type are present. Kept in sync with the
 // field names those functions write to payload.
+//
+// This alone is not sufficient to conclude the message type is unrecognized:
+// a known media type (image/audio/video/document/sticker/video_note) with a
+// failed/expired download leaves its field unset here too, even though
+// buildMediaFields correctly identified it. Callers must also check
+// hasRecognizedMessageType before treating this as "unhandled type".
 func payloadHasNoRenderableContent(payload map[string]any) bool {
 	renderableKeys := []string{
 		"body",
@@ -201,6 +209,47 @@ func payloadHasNoRenderableContent(payload map[string]any) bool {
 		}
 	}
 	return true
+}
+
+// hasRecognizedMessageType reports whether msg is one of the kinds
+// buildMediaFields/buildOtherMessageTypes know how to handle, independent of
+// whether extraction actually produced payload content (e.g. a media
+// download can fail while the type itself is still recognized). Keep this in
+// sync with the Get*Message() checks in those two functions.
+func hasRecognizedMessageType(msg *waE2E.Message) bool {
+	switch {
+	case msg.GetAudioMessage() != nil,
+		msg.GetDocumentMessage() != nil,
+		msg.GetImageMessage() != nil,
+		msg.GetStickerMessage() != nil,
+		msg.GetVideoMessage() != nil,
+		msg.GetPtvMessage() != nil,
+		msg.GetContactMessage() != nil,
+		msg.GetContactsArrayMessage() != nil,
+		msg.GetListMessage() != nil,
+		msg.GetLiveLocationMessage() != nil,
+		msg.GetLocationMessage() != nil,
+		msg.GetOrderMessage() != nil:
+		return true
+	default:
+		return false
+	}
+}
+
+// populatedMessageFields lists the proto field names set on msg (e.g.
+// "interactiveMessage", "templateMessage"), using reflection purely for
+// field descriptors — never field values — so this is safe to log at warn
+// level even though the message itself may carry customer content.
+func populatedMessageFields(msg *waE2E.Message) []string {
+	if msg == nil {
+		return nil
+	}
+	var names []string
+	msg.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
+		names = append(names, string(fd.Name()))
+		return true
+	})
+	return names
 }
 
 func buildFromFields(ctx context.Context, client *whatsmeow.Client, evt *events.Message, payload map[string]any) {

--- a/src/infrastructure/whatsapp/event_message_handler.go
+++ b/src/infrastructure/whatsapp/event_message_handler.go
@@ -174,7 +174,7 @@ func handleWebhookForward(ctx context.Context, evt *events.Message, client *what
 	// Forward to webhook if any webhook is configured (global or per-device)
 	// The forwardPayloadToConfiguredWebhooks function itself handles the no-op case
 	go func(e *events.Message, c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardMessageToWebhook(webhookCtx, c, e); err != nil {
 			logrus.Error("Failed forward to webhook: ", err)

--- a/src/infrastructure/whatsapp/event_message_handler.go
+++ b/src/infrastructure/whatsapp/event_message_handler.go
@@ -174,7 +174,7 @@ func handleWebhookForward(ctx context.Context, evt *events.Message, client *what
 	// Forward to webhook if any webhook is configured (global or per-device)
 	// The forwardPayloadToConfiguredWebhooks function itself handles the no-op case
 	go func(e *events.Message, c *whatsmeow.Client) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardMessageToWebhook(webhookCtx, c, e); err != nil {
 			logrus.Error("Failed forward to webhook: ", err)

--- a/src/infrastructure/whatsapp/event_newsletter.go
+++ b/src/infrastructure/whatsapp/event_newsletter.go
@@ -14,7 +14,7 @@ func handleNewsletterJoin(ctx context.Context, evt *events.NewsletterJoin, devic
 	log.Infof("Joined newsletter %s", evt.ID)
 
 	go func(e *events.NewsletterJoin) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardNewsletterJoinToWebhook(webhookCtx, e, deviceID); err != nil {
 			logrus.Errorf("Failed to forward newsletter join to webhook: %v", err)
@@ -27,7 +27,7 @@ func handleNewsletterLeave(ctx context.Context, evt *events.NewsletterLeave, dev
 	log.Infof("Left newsletter %s (role: %s)", evt.ID, evt.Role)
 
 	go func(e *events.NewsletterLeave) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardNewsletterLeaveToWebhook(webhookCtx, e, deviceID); err != nil {
 			logrus.Errorf("Failed to forward newsletter leave to webhook: %v", err)
@@ -40,7 +40,7 @@ func handleNewsletterLiveUpdate(ctx context.Context, evt *events.NewsletterLiveU
 	log.Infof("Newsletter %s: %d new message(s)", evt.JID, len(evt.Messages))
 
 	go func(e *events.NewsletterLiveUpdate) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardNewsletterLiveUpdateToWebhook(webhookCtx, e, deviceID); err != nil {
 			logrus.Errorf("Failed to forward newsletter live update to webhook: %v", err)
@@ -53,7 +53,7 @@ func handleNewsletterMuteChange(ctx context.Context, evt *events.NewsletterMuteC
 	log.Infof("Newsletter %s mute changed to: %s", evt.ID, evt.Mute)
 
 	go func(e *events.NewsletterMuteChange) {
-		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := forwardNewsletterMuteChangeToWebhook(webhookCtx, e, deviceID); err != nil {
 			logrus.Errorf("Failed to forward newsletter mute change to webhook: %v", err)

--- a/src/infrastructure/whatsapp/event_newsletter.go
+++ b/src/infrastructure/whatsapp/event_newsletter.go
@@ -14,7 +14,7 @@ func handleNewsletterJoin(ctx context.Context, evt *events.NewsletterJoin, devic
 	log.Infof("Joined newsletter %s", evt.ID)
 
 	go func(e *events.NewsletterJoin) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardNewsletterJoinToWebhook(webhookCtx, e, deviceID); err != nil {
 			logrus.Errorf("Failed to forward newsletter join to webhook: %v", err)
@@ -27,7 +27,7 @@ func handleNewsletterLeave(ctx context.Context, evt *events.NewsletterLeave, dev
 	log.Infof("Left newsletter %s (role: %s)", evt.ID, evt.Role)
 
 	go func(e *events.NewsletterLeave) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardNewsletterLeaveToWebhook(webhookCtx, e, deviceID); err != nil {
 			logrus.Errorf("Failed to forward newsletter leave to webhook: %v", err)
@@ -40,7 +40,7 @@ func handleNewsletterLiveUpdate(ctx context.Context, evt *events.NewsletterLiveU
 	log.Infof("Newsletter %s: %d new message(s)", evt.JID, len(evt.Messages))
 
 	go func(e *events.NewsletterLiveUpdate) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardNewsletterLiveUpdateToWebhook(webhookCtx, e, deviceID); err != nil {
 			logrus.Errorf("Failed to forward newsletter live update to webhook: %v", err)
@@ -53,7 +53,7 @@ func handleNewsletterMuteChange(ctx context.Context, evt *events.NewsletterMuteC
 	log.Infof("Newsletter %s mute changed to: %s", evt.ID, evt.Mute)
 
 	go func(e *events.NewsletterMuteChange) {
-		webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		webhookCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		if err := forwardNewsletterMuteChangeToWebhook(webhookCtx, e, deviceID); err != nil {
 			logrus.Errorf("Failed to forward newsletter mute change to webhook: %v", err)


### PR DESCRIPTION
## Problem

Every webhook/Chatwoot forward goroutine spawned from the WhatsApp event
handlers builds its context from `context.Background()` instead of
deriving it from the `ctx` parameter received by the enclosing function:

    go func(...) {
        webhookCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
        ...
    }(...)

The device instance is attached to `ctx` upstream, in `handler()`
(`ctx = ContextWithDevice(ctx, instance)`), so it's available at the call
site — it's just discarded here.

## Impact

This breaks per-device Chatwoot routing (`PUT /devices/:id/chatwoot/config`,
documented under "Per-Device / Multi-Inbox Routing" in docs/chatwoot.md)
for every live event type: messages, receipts, deletes, group info,
chat presence, call offers, newsletters, and label app-state.

`chatwootLinkStorageFromContext` resolves the device via
`DeviceFromContext(ctx)`; with an empty context it always returns
`deviceID = ""`, so `ClientRegistry.Resolve("")` never matches any
per-device config row. Once at least one per-device config exists,
the registry's env-var fallback is intentionally disabled (see comment
in client_registry.go), so the forward silently no-ops for every device
that isn't the first one, with the deviceID gap logged as:

    Chatwoot: no Chatwoot config for device ; skipping forward

This doesn't affect the common single-tenant setup (global CHATWOOT_*
env vars, no per-device config rows) because the registry's fallback
path doesn't need a device match in that case — which is likely why this
has gone unnoticed despite widespread Chatwoot usage.

## Fix

Derive each goroutine's timeout context from the `ctx` already in scope
instead of `context.Background()`, so `ContextWithDevice` survives into
the async forward call. Also fixes `handleAppState`, whose `ctx` parameter
was discarded at the signature level (`_ context.Context`), so it never
had a context to derive from at all.

Two unrelated `context.Background()` timeouts in webhook_forward.go
(`lookupContactDisplayName`, `getGroupName`) are intentionally left
alone — they already extract what they need from `ctx` (the WhatsApp
client) before intentionally dropping it, since ctx may already be
canceled by the time those run.

## Testing

Reproduced against a real WhatsApp number + Chatwoot account: with a
per-device config registered, live inbound messages returned
`no Chatwoot config for device ; skipping forward` on every attempt.
After the fix, same setup: contact/conversation created and message
synced successfully, confirmed via debug logs.