### PR TITLE
feat(chatwoot): render InteractiveMessage (native CTA buttons) as text

### DIFF
--- a/src/infrastructure/whatsapp/chatwoot_content_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_content_test.go
@@ -532,6 +532,45 @@ func TestBuildChatwootMessageContent(t *testing.T) {
 			t.Fatalf("expected 3 attachments, got %v", atts)
 		}
 	})
+
+	t.Run("interactive_media []string yields one attachment per carousel card", func(t *testing.T) {
+		// Live path shape: collectInteractiveMedia (event_message.go) returns
+		// []string directly. Must NOT collide with the singular mediaFields —
+		// a carousel can have media on every card, which the singular
+		// "image"/"video"/"document" keys can't represent without one
+		// overwriting another.
+		content, atts := buildChatwootMessageContent(map[string]any{
+			"interactive":      "Check our products",
+			"interactive_media": []string{"/tmp/wa/card1.jpg", "/tmp/wa/card2.jpg"},
+		}, false, "")
+		if content != "Check our products" {
+			t.Fatalf("expected interactive text passthrough, got %q", content)
+		}
+		if len(atts) != 2 || atts[0] != "/tmp/wa/card1.jpg" || atts[1] != "/tmp/wa/card2.jpg" {
+			t.Fatalf("expected 2 attachments in card order, got %v", atts)
+		}
+	})
+
+	t.Run("interactive_media []any (post-retry JSON shape) yields attachments", func(t *testing.T) {
+		// A failed live forward is re-marshaled through JSON for the retry
+		// queue (enqueueChatwootForwardRetry/replayChatwootForwardEvent),
+		// which turns []string into []any of strings — must still work.
+		_, atts := buildChatwootMessageContent(map[string]any{
+			"interactive_media": []any{"/tmp/wa/card1.jpg", "/tmp/wa/card2.jpg"},
+		}, false, "")
+		if len(atts) != 2 || atts[0] != "/tmp/wa/card1.jpg" || atts[1] != "/tmp/wa/card2.jpg" {
+			t.Fatalf("expected 2 attachments, got %v", atts)
+		}
+	})
+
+	t.Run("interactive_media empty slice yields no attachments", func(t *testing.T) {
+		_, atts := buildChatwootMessageContent(map[string]any{
+			"interactive_media": []string{},
+		}, false, "")
+		if len(atts) != 0 {
+			t.Fatalf("expected no attachments, got %v", atts)
+		}
+	})
 }
 
 // TestExtractStructuredMessageContentVariants drives every non-text branch of the
@@ -1122,6 +1161,21 @@ func TestFormatInteractiveMessageSummary(t *testing.T) {
 			},
 		}
 		want := "Promo\nOnly this week"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("header image caption is included, since it never reaches payload body", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			Header: &waE2E.InteractiveMessage_Header{
+				Title: proto.String("Summer sale"),
+				Media: &waE2E.InteractiveMessage_Header_ImageMessage{
+					ImageMessage: &waE2E.ImageMessage{Caption: proto.String("New arrivals, 20% off")},
+				},
+			},
+		}
+		want := "Summer sale\nNew arrivals, 20% off"
 		if got := formatInteractiveMessageSummary(im); got != want {
 			t.Fatalf("got %q, want %q", got, want)
 		}

--- a/src/infrastructure/whatsapp/chatwoot_content_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_content_test.go
@@ -1095,6 +1095,87 @@ func TestFormatInteractiveMessageSummary(t *testing.T) {
 		}
 	})
 
+	t.Run("cta_copy button", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+				NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+					Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+						{
+							Name:             proto.String("cta_copy"),
+							ButtonParamsJSON: proto.String(`{"display_text":"Copy","copy_code":"SAVE10"}`),
+						},
+					},
+				},
+			},
+		}
+		want := "📋 Copy: SAVE10"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("header subtitle is included alongside title", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			Header: &waE2E.InteractiveMessage_Header{
+				Title:    proto.String("Promo"),
+				Subtitle: proto.String("Only this week"),
+			},
+		}
+		want := "Promo\nOnly this week"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("single_select button falls back to native-flow title when display_text absent", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+				NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+					Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+						{
+							Name:             proto.String("single_select"),
+							ButtonParamsJSON: proto.String(`{"title":"Choose a plan","sections":[]}`),
+						},
+					},
+				},
+			},
+		}
+		want := "[single_select] Choose a plan"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("carousel summarizes each card, skipping empty ones", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			Body: &waE2E.InteractiveMessage_Body{Text: proto.String("Check our products")},
+			InteractiveMessage: &waE2E.InteractiveMessage_CarouselMessage_{
+				CarouselMessage: &waE2E.InteractiveMessage_CarouselMessage{
+					Cards: []*waE2E.InteractiveMessage{
+						{
+							Body: &waE2E.InteractiveMessage_Body{Text: proto.String("Shoes")},
+							InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+								NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+									Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+										{
+											Name:             proto.String("cta_url"),
+											ButtonParamsJSON: proto.String(`{"display_text":"Buy","url":"https://example.com/shoes"}`),
+										},
+									},
+								},
+							},
+						},
+						{}, // empty card: no header/body/footer/buttons, must not add a blank "Card 2: " line
+					},
+				},
+			},
+		}
+		want := "Check our products\nCard 1: Shoes\n🔗 Buy: https://example.com/shoes"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
 	t.Run("no header, body, footer, or buttons yields generic sentinel", func(t *testing.T) {
 		im := &waE2E.InteractiveMessage{}
 		want := "Interactive message"
@@ -1105,24 +1186,33 @@ func TestFormatInteractiveMessageSummary(t *testing.T) {
 }
 
 // TestExtractStructuredMessageContentInteractive covers the data["interactive"]
-// dispatch branch in extractStructuredMessageContent, which — unlike the other
-// structured branches in this file — asserts against the concrete *waE2E.InteractiveMessage
-// type rather than a structural interface, since Header/Body/Footer/NativeFlowMessage
-// are themselves concrete generated types with no shared interface to fake against.
+// dispatch branch in extractStructuredMessageContent. Unlike the other
+// structured branches in this file, buildOtherMessageTypes pre-renders
+// InteractiveMessage to a plain string at construction time (via
+// formatInteractiveMessageSummary) instead of storing the raw proto, so this
+// value survives the JSON round-trip the Chatwoot forward retry queue
+// performs — see the comment at that call site in event_message.go.
 func TestExtractStructuredMessageContentInteractive(t *testing.T) {
-	t.Run("real InteractiveMessage dispatches to the formatter", func(t *testing.T) {
-		im := &waE2E.InteractiveMessage{
-			Body: &waE2E.InteractiveMessage_Body{Text: proto.String("Hello")},
-		}
-		got := extractStructuredMessageContent(map[string]any{"interactive": im})
+	t.Run("pre-rendered string is returned as-is", func(t *testing.T) {
+		got := extractStructuredMessageContent(map[string]any{"interactive": "Hello"})
 		if got != "Hello" {
 			t.Fatalf("got %q", got)
 		}
 	})
 
-	t.Run("non-InteractiveMessage value yields generic sentinel", func(t *testing.T) {
-		got := extractStructuredMessageContent(map[string]any{"interactive": "raw"})
-		if got != "Interactive message" {
+	t.Run("non-string value falls through to empty string", func(t *testing.T) {
+		// Would only happen from a bug elsewhere (buildOtherMessageTypes
+		// always stores a string) — falling through to the caller's own
+		// placeholder logic is safer than guessing at a sentinel here.
+		got := extractStructuredMessageContent(map[string]any{"interactive": 42})
+		if got != "" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("empty string falls through to empty string", func(t *testing.T) {
+		got := extractStructuredMessageContent(map[string]any{"interactive": ""})
+		if got != "" {
 			t.Fatalf("got %q", got)
 		}
 	})

--- a/src/infrastructure/whatsapp/chatwoot_content_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_content_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"google.golang.org/protobuf/proto"
 )
 
 // --- Fakes implementing the structural interfaces extractStructuredMessageContent
@@ -987,6 +989,148 @@ func TestGroupNameCache(t *testing.T) {
 		name, ok := getCachedGroupName(jid)
 		if !ok || name != "" {
 			t.Fatalf("expected ('', true) for empty cached name, got (%q, %v)", name, ok)
+		}
+	})
+}
+
+// TestFormatInteractiveMessageSummary pins the text rendering of
+// InteractiveMessage (business/Cloud API messages with native buttons), which
+// can't be exercised end-to-end without a real Business-API sender — these
+// build the real protobuf type directly instead of relying on a live message.
+func TestFormatInteractiveMessageSummary(t *testing.T) {
+	t.Run("header, body, footer, and cta_url button", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			Header: &waE2E.InteractiveMessage_Header{Title: proto.String("Promo")},
+			Body:   &waE2E.InteractiveMessage_Body{Text: proto.String("Confira nossa oferta")},
+			Footer: &waE2E.InteractiveMessage_Footer{Text: proto.String("Equipe Vendas")},
+			InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+				NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+					Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+						{
+							Name:             proto.String("cta_url"),
+							ButtonParamsJSON: proto.String(`{"display_text":"Visitar site","url":"https://example.com"}`),
+						},
+					},
+				},
+			},
+		}
+		want := "Promo\nConfira nossa oferta\nEquipe Vendas\n🔗 Visitar site: https://example.com"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("cta_call button", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+				NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+					Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+						{
+							Name:             proto.String("cta_call"),
+							ButtonParamsJSON: proto.String(`{"display_text":"Ligar agora","phone_number":"+5511999999999"}`),
+						},
+					},
+				},
+			},
+		}
+		want := "📞 Ligar agora: +5511999999999"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("cta_url button missing url falls back to raw name", func(t *testing.T) {
+		// A cta_url button whose JSON has no url is unusable as a link, so it
+		// must not silently print a broken "🔗 Label: " line.
+		im := &waE2E.InteractiveMessage{
+			InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+				NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+					Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+						{
+							Name:             proto.String("cta_url"),
+							ButtonParamsJSON: proto.String(`{"display_text":"Visitar site"}`),
+						},
+					},
+				},
+			},
+		}
+		want := "[cta_url] Visitar site"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unrecognized button name falls back to raw name and display text", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+				NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+					Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+						{
+							Name:             proto.String("single_select"),
+							ButtonParamsJSON: proto.String(`{"display_text":"Choose an option"}`),
+						},
+					},
+				},
+			},
+		}
+		want := "[single_select] Choose an option"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unrecognized button with no display text falls back to bare name", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			InteractiveMessage: &waE2E.InteractiveMessage_NativeFlowMessage_{
+				NativeFlowMessage: &waE2E.InteractiveMessage_NativeFlowMessage{
+					Buttons: []*waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton{
+						{Name: proto.String("review_and_pay")},
+					},
+				},
+			},
+		}
+		want := "[review_and_pay]"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no header, body, footer, or buttons yields generic sentinel", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{}
+		want := "Interactive message"
+		if got := formatInteractiveMessageSummary(im); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+}
+
+// TestExtractStructuredMessageContentInteractive covers the data["interactive"]
+// dispatch branch in extractStructuredMessageContent, which — unlike the other
+// structured branches in this file — asserts against the concrete *waE2E.InteractiveMessage
+// type rather than a structural interface, since Header/Body/Footer/NativeFlowMessage
+// are themselves concrete generated types with no shared interface to fake against.
+func TestExtractStructuredMessageContentInteractive(t *testing.T) {
+	t.Run("real InteractiveMessage dispatches to the formatter", func(t *testing.T) {
+		im := &waE2E.InteractiveMessage{
+			Body: &waE2E.InteractiveMessage_Body{Text: proto.String("Hello")},
+		}
+		got := extractStructuredMessageContent(map[string]any{"interactive": im})
+		if got != "Hello" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("non-InteractiveMessage value yields generic sentinel", func(t *testing.T) {
+		got := extractStructuredMessageContent(map[string]any{"interactive": "raw"})
+		if got != "Interactive message" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("nil interactive value falls through to empty string", func(t *testing.T) {
+		got := extractStructuredMessageContent(map[string]any{"interactive": nil})
+		if got != "" {
+			t.Fatalf("got %q", got)
 		}
 	})
 }

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -374,7 +374,71 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 		}
 	}
 
+	buildInteractiveHeaderMedia(ctx, client, msg.GetInteractiveMessage().GetHeader(), payload)
+
 	return nil
+}
+
+// buildInteractiveHeaderMedia extracts the image/video/document that can ride
+// along an InteractiveMessage's header (common for marketing CTA messages: a
+// product photo above the button). Without this, buildMediaFields only looks
+// at the top-level message — which is empty for InteractiveMessage, since
+// it's a distinct oneof case from GetImageMessage()/GetVideoMessage()/
+// GetDocumentMessage() — so header media silently never reached Chatwoot.
+// header.GetLocationMessage()/GetProductMessage()/GetJPEGThumbnail() are not
+// handled: no existing payload field/attachment path covers them here.
+func buildInteractiveHeaderMedia(ctx context.Context, client *whatsmeow.Client, header *waE2E.InteractiveMessage_Header, payload map[string]any) {
+	if header == nil {
+		return
+	}
+
+	if imageMedia := header.GetImageMessage(); imageMedia != nil {
+		if config.WhatsappAutoDownloadMedia {
+			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, imageMedia)
+			if err != nil {
+				logrus.Errorf("Failed to download interactive header image: %v", err)
+			} else {
+				payload["image"] = buildAutoDownloadPayload(extracted)
+			}
+		} else {
+			payload["image"] = map[string]any{
+				"url":     imageMedia.GetURL(),
+				"caption": imageMedia.GetCaption(),
+			}
+		}
+	}
+
+	if videoMedia := header.GetVideoMessage(); videoMedia != nil {
+		if config.WhatsappAutoDownloadMedia {
+			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, videoMedia)
+			if err != nil {
+				logrus.Errorf("Failed to download interactive header video: %v", err)
+			} else {
+				payload["video"] = buildAutoDownloadPayload(extracted)
+			}
+		} else {
+			payload["video"] = map[string]any{
+				"url":     videoMedia.GetURL(),
+				"caption": videoMedia.GetCaption(),
+			}
+		}
+	}
+
+	if documentMedia := header.GetDocumentMessage(); documentMedia != nil {
+		if config.WhatsappAutoDownloadMedia {
+			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, documentMedia)
+			if err != nil {
+				logrus.Errorf("Failed to download interactive header document: %v", err)
+			} else {
+				payload["document"] = buildAutoDownloadPayload(extracted)
+			}
+		} else {
+			payload["document"] = map[string]any{
+				"url":      documentMedia.GetURL(),
+				"filename": documentMedia.GetFileName(),
+			}
+		}
+	}
 }
 
 // buildAutoDownloadPayload builds the media payload for auto-downloaded media.
@@ -419,7 +483,15 @@ func buildOtherMessageTypes(msg *waE2E.Message, payload map[string]any) {
 		// website", cta_call, single/multi-select, etc.) arrive as this type
 		// instead of Conversation/ExtendedTextMessage, so they carried no
 		// body text and rendered as "(Unsupported message type)" in Chatwoot.
-		payload["interactive"] = interactiveMessage
+		//
+		// Rendered to a string here, not stored as the raw proto: a failed
+		// live forward gets re-marshaled through JSON for the retry queue
+		// (see enqueueChatwootForwardRetry/replayChatwootForwardEvent), which
+		// turns *waE2E.InteractiveMessage into a generic map[string]any —
+		// the type assertion in extractStructuredMessageContent would then
+		// miss on retry and silently downgrade to the generic sentinel,
+		// losing the CTA label/URL/phone/code the live path just extracted.
+		payload["interactive"] = formatInteractiveMessageSummary(interactiveMessage)
 	}
 }
 

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -413,6 +413,14 @@ func buildOtherMessageTypes(msg *waE2E.Message, payload map[string]any) {
 	if orderMessage := msg.GetOrderMessage(); orderMessage != nil {
 		payload["order"] = orderMessage
 	}
+
+	if interactiveMessage := msg.GetInteractiveMessage(); interactiveMessage != nil {
+		// Business/Cloud API messages with native buttons (cta_url "visit
+		// website", cta_call, single/multi-select, etc.) arrive as this type
+		// instead of Conversation/ExtendedTextMessage, so they carried no
+		// body text and rendered as "(Unsupported message type)" in Chatwoot.
+		payload["interactive"] = interactiveMessage
+	}
 }
 
 func buildWebhookContactPayload(contact *waE2E.ContactMessage) webhookContactPayload {

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -374,71 +374,74 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 		}
 	}
 
-	buildInteractiveHeaderMedia(ctx, client, msg.GetInteractiveMessage().GetHeader(), payload)
+	if mediaPaths := collectInteractiveMedia(ctx, client, msg.GetInteractiveMessage()); len(mediaPaths) > 0 {
+		// Stored separately from the singular image/video/document fields
+		// above (rather than reusing them) because a carousel can carry
+		// media on *every* card: reusing those fields would have each card's
+		// extraction silently overwrite the previous one, dropping all but
+		// the last image. []string (not a proto or map) survives the JSON
+		// round-trip the Chatwoot forward retry queue performs, same
+		// reasoning as the "interactive" field below.
+		payload["interactive_media"] = mediaPaths
+	}
 
 	return nil
 }
 
-// buildInteractiveHeaderMedia extracts the image/video/document that can ride
-// along an InteractiveMessage's header (common for marketing CTA messages: a
-// product photo above the button). Without this, buildMediaFields only looks
-// at the top-level message — which is empty for InteractiveMessage, since
-// it's a distinct oneof case from GetImageMessage()/GetVideoMessage()/
-// GetDocumentMessage() — so header media silently never reached Chatwoot.
+// collectInteractiveMedia extracts every image/video/document reachable from
+// an InteractiveMessage: the root header (common for marketing CTA messages —
+// a product photo above the button) and, recursively, each carousel card's
+// own header (a carousel's cards are themselves full InteractiveMessage
+// values). Without this, buildMediaFields only looks at the top-level
+// message — which is empty for InteractiveMessage, since it's a distinct
+// oneof case from GetImageMessage()/GetVideoMessage()/GetDocumentMessage() —
+// so header media silently never reached Chatwoot. Returns nil when
+// WHATSAPP_AUTO_DOWNLOAD_MEDIA is disabled: as with top-level media, a
+// URL-only reference isn't something Chatwoot can fetch itself, so there's
+// nothing usable to attach (see extractMediaPath in webhook_forward.go).
 // header.GetLocationMessage()/GetProductMessage()/GetJPEGThumbnail() are not
 // handled: no existing payload field/attachment path covers them here.
-func buildInteractiveHeaderMedia(ctx context.Context, client *whatsmeow.Client, header *waE2E.InteractiveMessage_Header, payload map[string]any) {
+func collectInteractiveMedia(ctx context.Context, client *whatsmeow.Client, im *waE2E.InteractiveMessage) []string {
+	if im == nil || !config.WhatsappAutoDownloadMedia {
+		return nil
+	}
+
+	var paths []string
+	paths = append(paths, extractInteractiveHeaderMediaPaths(ctx, client, im.GetHeader())...)
+	for _, card := range im.GetCarouselMessage().GetCards() {
+		paths = append(paths, collectInteractiveMedia(ctx, client, card)...)
+	}
+	return paths
+}
+
+func extractInteractiveHeaderMediaPaths(ctx context.Context, client *whatsmeow.Client, header *waE2E.InteractiveMessage_Header) []string {
 	if header == nil {
-		return
+		return nil
 	}
 
+	var paths []string
 	if imageMedia := header.GetImageMessage(); imageMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
-			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, imageMedia)
-			if err != nil {
-				logrus.Errorf("Failed to download interactive header image: %v", err)
-			} else {
-				payload["image"] = buildAutoDownloadPayload(extracted)
-			}
+		if extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, imageMedia); err != nil {
+			logrus.Errorf("Failed to download interactive header image: %v", err)
 		} else {
-			payload["image"] = map[string]any{
-				"url":     imageMedia.GetURL(),
-				"caption": imageMedia.GetCaption(),
-			}
+			paths = append(paths, extracted.MediaPath)
 		}
 	}
-
 	if videoMedia := header.GetVideoMessage(); videoMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
-			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, videoMedia)
-			if err != nil {
-				logrus.Errorf("Failed to download interactive header video: %v", err)
-			} else {
-				payload["video"] = buildAutoDownloadPayload(extracted)
-			}
+		if extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, videoMedia); err != nil {
+			logrus.Errorf("Failed to download interactive header video: %v", err)
 		} else {
-			payload["video"] = map[string]any{
-				"url":     videoMedia.GetURL(),
-				"caption": videoMedia.GetCaption(),
-			}
+			paths = append(paths, extracted.MediaPath)
 		}
 	}
-
 	if documentMedia := header.GetDocumentMessage(); documentMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
-			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, documentMedia)
-			if err != nil {
-				logrus.Errorf("Failed to download interactive header document: %v", err)
-			} else {
-				payload["document"] = buildAutoDownloadPayload(extracted)
-			}
+		if extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, documentMedia); err != nil {
+			logrus.Errorf("Failed to download interactive header document: %v", err)
 		} else {
-			payload["document"] = map[string]any{
-				"url":      documentMedia.GetURL(),
-				"filename": documentMedia.GetFileName(),
-			}
+			paths = append(paths, extracted.MediaPath)
 		}
 	}
+	return paths
 }
 
 // buildAutoDownloadPayload builds the media payload for auto-downloaded media.

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -686,11 +686,11 @@ func extractStructuredMessageContent(data map[string]any) string {
 		return "Order message"
 	}
 
-	if interactive, ok := data["interactive"]; ok && interactive != nil {
-		if im, ok := interactive.(*waE2E.InteractiveMessage); ok {
-			return formatInteractiveMessageSummary(im)
-		}
-		return "Interactive message"
+	if interactive, ok := data["interactive"].(string); ok && interactive != "" {
+		// Pre-rendered by buildOtherMessageTypes at construction time (not
+		// stored as the raw proto) so it survives the JSON round-trip on the
+		// Chatwoot forward retry path; see the comment at that call site.
+		return interactive
 	}
 
 	return ""
@@ -710,6 +710,9 @@ func formatInteractiveMessageSummary(im *waE2E.InteractiveMessage) string {
 		if title := header.GetTitle(); title != "" {
 			parts = append(parts, title)
 		}
+		if subtitle := header.GetSubtitle(); subtitle != "" {
+			parts = append(parts, subtitle)
+		}
 	}
 	if body := im.GetBody(); body != nil {
 		if text := body.GetText(); text != "" {
@@ -725,6 +728,17 @@ func formatInteractiveMessageSummary(im *waE2E.InteractiveMessage) string {
 	for _, button := range im.GetNativeFlowMessage().GetButtons() {
 		if line := formatNativeFlowButton(button); line != "" {
 			parts = append(parts, line)
+		}
+	}
+
+	// Carousels put their CTA/quick-reply buttons on each card rather than on
+	// the top-level NativeFlowMessage, so the loop above sees none of them —
+	// summarize each card (itself a full InteractiveMessage) separately.
+	if carousel := im.GetCarouselMessage(); carousel != nil {
+		for i, card := range carousel.GetCards() {
+			if cardSummary := formatInteractiveMessageSummary(card); cardSummary != "" && cardSummary != "Interactive message" {
+				parts = append(parts, fmt.Sprintf("Card %d: %s", i+1, cardSummary))
+			}
 		}
 	}
 
@@ -744,6 +758,10 @@ type nativeFlowButtonParams struct {
 	URL         string `json:"url"`
 	PhoneNumber string `json:"phone_number"`
 	Copy        string `json:"copy_code"`
+	// Title is the visible label field used by picker-style buttons (e.g.
+	// single_select's {"title":...,"sections":...}), which don't set
+	// display_text at all.
+	Title string `json:"title"`
 }
 
 func formatNativeFlowButton(button *waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton) string {
@@ -782,8 +800,12 @@ func formatNativeFlowButton(button *waE2E.InteractiveMessage_NativeFlowMessage_N
 		}
 	}
 
-	if params.DisplayText != "" {
-		return fmt.Sprintf("[%s] %s", name, params.DisplayText)
+	label := params.DisplayText
+	if label == "" {
+		label = params.Title
+	}
+	if label != "" {
+		return fmt.Sprintf("[%s] %s", name, label)
 	}
 	return fmt.Sprintf("[%s]", name)
 }

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/chatwoot"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/sirupsen/logrus"
+	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -685,7 +686,106 @@ func extractStructuredMessageContent(data map[string]any) string {
 		return "Order message"
 	}
 
+	if interactive, ok := data["interactive"]; ok && interactive != nil {
+		if im, ok := interactive.(*waE2E.InteractiveMessage); ok {
+			return formatInteractiveMessageSummary(im)
+		}
+		return "Interactive message"
+	}
+
 	return ""
+}
+
+// formatInteractiveMessageSummary renders an InteractiveMessage (business/
+// Cloud API messages with native buttons: cta_url, cta_call, single/multi
+// select, etc.) as plain text, since Chatwoot has no native concept of a
+// WhatsApp interactive button. Buttons are described in buttonParamsJSON as
+// a per-button-type JSON blob (undocumented, reverse-engineered from
+// traffic), so only the fields relevant to rendering are decoded and
+// anything unrecognized still shows the button's raw name.
+func formatInteractiveMessageSummary(im *waE2E.InteractiveMessage) string {
+	var parts []string
+
+	if header := im.GetHeader(); header != nil {
+		if title := header.GetTitle(); title != "" {
+			parts = append(parts, title)
+		}
+	}
+	if body := im.GetBody(); body != nil {
+		if text := body.GetText(); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	if footer := im.GetFooter(); footer != nil {
+		if text := footer.GetText(); text != "" {
+			parts = append(parts, text)
+		}
+	}
+
+	for _, button := range im.GetNativeFlowMessage().GetButtons() {
+		if line := formatNativeFlowButton(button); line != "" {
+			parts = append(parts, line)
+		}
+	}
+
+	if len(parts) == 0 {
+		return "Interactive message"
+	}
+	return strings.Join(parts, "\n")
+}
+
+// nativeFlowButtonParams covers the fields used by the button types this
+// forwarder renders specially (cta_url, cta_call, cta_copy). Other button
+// names (e.g. single_select, review_and_pay) fall through to displaying the
+// raw button name, since their params carry structured picker/payment data
+// that doesn't reduce to a single line of text.
+type nativeFlowButtonParams struct {
+	DisplayText string `json:"display_text"`
+	URL         string `json:"url"`
+	PhoneNumber string `json:"phone_number"`
+	Copy        string `json:"copy_code"`
+}
+
+func formatNativeFlowButton(button *waE2E.InteractiveMessage_NativeFlowMessage_NativeFlowButton) string {
+	if button == nil {
+		return ""
+	}
+	name := button.GetName()
+
+	var params nativeFlowButtonParams
+	_ = json.Unmarshal([]byte(button.GetButtonParamsJSON()), &params)
+
+	switch name {
+	case "cta_url":
+		label := params.DisplayText
+		if label == "" {
+			label = "Link"
+		}
+		if params.URL != "" {
+			return fmt.Sprintf("🔗 %s: %s", label, params.URL)
+		}
+	case "cta_call":
+		label := params.DisplayText
+		if label == "" {
+			label = "Call"
+		}
+		if params.PhoneNumber != "" {
+			return fmt.Sprintf("📞 %s: %s", label, params.PhoneNumber)
+		}
+	case "cta_copy":
+		label := params.DisplayText
+		if label == "" {
+			label = "Copy code"
+		}
+		if params.Copy != "" {
+			return fmt.Sprintf("📋 %s: %s", label, params.Copy)
+		}
+	}
+
+	if params.DisplayText != "" {
+		return fmt.Sprintf("[%s] %s", name, params.DisplayText)
+	}
+	return fmt.Sprintf("[%s]", name)
 }
 
 func extractContactDetails(contact any) (name string, phone string, ok bool) {

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -528,6 +528,30 @@ func buildChatwootMessageContent(data map[string]any, isGroup bool, fromName str
 		logrus.Infof("Chatwoot: Found %s attachment at %s", field, path)
 	}
 
+	// interactive_media carries zero or more paths collected from an
+	// InteractiveMessage's header and, for carousels, every card's header
+	// (see collectInteractiveMedia in event_message.go) — a plain []string
+	// rather than one of the singular mediaFields above, since a carousel
+	// can have media on more than one card and reusing e.g. "image" would
+	// have each extraction overwrite the last. []any covers the shape after
+	// a JSON round-trip on the Chatwoot forward retry path.
+	switch paths := data["interactive_media"].(type) {
+	case []string:
+		for _, path := range paths {
+			if path != "" {
+				attachments = append(attachments, path)
+				logrus.Infof("Chatwoot: Found interactive media attachment at %s", path)
+			}
+		}
+	case []any:
+		for _, v := range paths {
+			if path, ok := v.(string); ok && path != "" {
+				attachments = append(attachments, path)
+				logrus.Infof("Chatwoot: Found interactive media attachment at %s", path)
+			}
+		}
+	}
+
 	// Handle empty content
 	if content == "" && len(attachments) == 0 {
 		content = "(Unsupported message type)"
@@ -713,6 +737,14 @@ func formatInteractiveMessageSummary(im *waE2E.InteractiveMessage) string {
 		if subtitle := header.GetSubtitle(); subtitle != "" {
 			parts = append(parts, subtitle)
 		}
+		// Media captions on interactive headers never reach payload["body"]
+		// (ExtractMediaCaption only handles top-level Get*Message() cases,
+		// not InteractiveMessage.Header) — surface them here instead of
+		// silently dropping them, since collectInteractiveMedia forwards the
+		// file itself but nothing else carries the caption text.
+		if caption := interactiveHeaderMediaCaption(header); caption != "" {
+			parts = append(parts, caption)
+		}
 	}
 	if body := im.GetBody(); body != nil {
 		if text := body.GetText(); text != "" {
@@ -746,6 +778,25 @@ func formatInteractiveMessageSummary(im *waE2E.InteractiveMessage) string {
 		return "Interactive message"
 	}
 	return strings.Join(parts, "\n")
+}
+
+// interactiveHeaderMediaCaption returns the caption on whichever media type
+// (if any) an InteractiveMessage header carries. Mirrors utils.ExtractMediaCaption's
+// per-type checks, scoped to the Header oneof instead of top-level Get*Message().
+func interactiveHeaderMediaCaption(header *waE2E.InteractiveMessage_Header) string {
+	if header == nil {
+		return ""
+	}
+	if img := header.GetImageMessage(); img != nil {
+		return img.GetCaption()
+	}
+	if vid := header.GetVideoMessage(); vid != nil {
+		return vid.GetCaption()
+	}
+	if doc := header.GetDocumentMessage(); doc != nil {
+		return doc.GetCaption()
+	}
+	return ""
 }
 
 // nativeFlowButtonParams covers the fields used by the button types this

--- a/src/pkg/utils/whatsapp.go
+++ b/src/pkg/utils/whatsapp.go
@@ -699,6 +699,8 @@ func ExtractContextInfo(msg *waE2E.Message) *waE2E.ContextInfo {
 		return msg.GetPtvMessage().GetContextInfo()
 	case msg.GetLiveLocationMessage() != nil:
 		return msg.GetLiveLocationMessage().GetContextInfo()
+	case msg.GetInteractiveMessage() != nil:
+		return msg.GetInteractiveMessage().GetContextInfo()
 	}
 	return nil
 }

--- a/src/pkg/utils/whatsapp_test.go
+++ b/src/pkg/utils/whatsapp_test.go
@@ -773,3 +773,39 @@ func TestFormatJIDStripsDeviceSuffix(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractContextInfoInteractiveMessage pins that quoted/forwarded context
+// on an InteractiveMessage (business/Cloud API CTA buttons) is preserved.
+// Before this case existed, BuildEventMessage/BuildForwarded silently lost
+// replied_to_id/quoted_body and the forwarded flag for these messages, even
+// though every other message type carries them through ExtractContextInfo.
+func TestExtractContextInfoInteractiveMessage(t *testing.T) {
+	t.Run("interactive message with context info", func(t *testing.T) {
+		msg := &waE2E.Message{
+			InteractiveMessage: &waE2E.InteractiveMessage{
+				Body: &waE2E.InteractiveMessage_Body{Text: proto.String("Check this out")},
+				ContextInfo: &waE2E.ContextInfo{
+					StanzaID: proto.String("ABC123"),
+				},
+			},
+		}
+		ci := ExtractContextInfo(msg)
+		if ci == nil {
+			t.Fatal("expected non-nil ContextInfo")
+		}
+		if ci.GetStanzaID() != "ABC123" {
+			t.Fatalf("got StanzaID %q, want %q", ci.GetStanzaID(), "ABC123")
+		}
+	})
+
+	t.Run("interactive message with no context info yields nil", func(t *testing.T) {
+		msg := &waE2E.Message{
+			InteractiveMessage: &waE2E.InteractiveMessage{
+				Body: &waE2E.InteractiveMessage_Body{Text: proto.String("Check this out")},
+			},
+		}
+		if ci := ExtractContextInfo(msg); ci != nil {
+			t.Fatalf("expected nil ContextInfo, got %+v", ci)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Business/Cloud API messages that use native buttons (`cta_url` "visit
website", `cta_call`, `cta_copy`, single/multi-select, etc.) arrive as
`InteractiveMessage` instead of `Conversation`/`ExtendedTextMessage`.
`buildMessageBody` only reads those two, and `buildOtherMessageTypes` had
no case for `InteractiveMessage`, so these messages carried no body text
and no recognized structured field — the Chatwoot forwarder's
empty-content fallback rendered them as `(Unsupported message type)`
with no indication a link/button was even present.

## Fix

Render header/body/footer text plus each native-flow button as plain
text lines, since Chatwoot has no concept of a WhatsApp interactive
button:

- `cta_url`, `cta_call`, and `cta_copy` are decoded specially — label
  plus url/phone/code extracted from the button's `buttonParamsJSON`
  (an undocumented per-button-type JSON blob, reverse-engineered from
  traffic since whatsmeow only exposes it as an opaque string).
- Any other button name falls back to showing its raw name and display
  text, since types like `single_select`/`review_and_pay` carry
  structured picker/payment data that doesn't reduce to one line.

## Testing

This can't be exercised end-to-end without a real Business/Cloud API
sender (I hit it via an inbound marketing message with a "visit our
site" button), so the unit tests build the actual
`*waE2E.InteractiveMessage` protobuf type directly and pin the
formatter's output for `cta_url`, `cta_call`, unrecognized button
names, and the empty/no-content case — see
`TestFormatInteractiveMessageSummary` and
`TestExtractStructuredMessageContentInteractive`.

`gofmt -l`, `go vet ./...`, and `go test ./infrastructure/whatsapp/...
./infrastructure/chatwoot/...` all clean.