### PR TITLE
fix(chatwoot): drop redundant WhatsApp message id from reaction notes

### DIFF
--- a/src/infrastructure/whatsapp/chatwoot_forward_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_forward_test.go
@@ -389,13 +389,17 @@ func TestBuildReactionChatwootContent(t *testing.T) {
 		expected string
 	}{
 		{
+			// The target id is not repeated in the text: syncPayloadToChatwoot
+			// already threads this note onto the reacted-to message via
+			// in_reply_to_external_id, so Chatwoot nests it under that message's
+			// bubble regardless of whether reacted_message_id is present here.
 			name: "reaction with sender name and target id",
 			payload: map[string]any{
 				"reaction":           "👍",
 				"reacted_message_id": "wamid-123",
 			},
 			fromName: "Alice",
-			expected: "Alice reacted 👍 to message wamid-123",
+			expected: "Alice reacted 👍",
 		},
 		{
 			name: "reaction falls back to phone",
@@ -405,7 +409,7 @@ func TestBuildReactionChatwootContent(t *testing.T) {
 				"from":               "628123456789@s.whatsapp.net",
 			},
 			fromName: "",
-			expected: "628123456789 reacted 🔥 to message wamid-456",
+			expected: "628123456789 reacted 🔥",
 		},
 		{
 			name: "reaction removal",
@@ -414,7 +418,7 @@ func TestBuildReactionChatwootContent(t *testing.T) {
 				"reacted_message_id": "wamid-789",
 			},
 			fromName: "Bob",
-			expected: "Bob removed a reaction from message wamid-789",
+			expected: "Bob removed a reaction",
 		},
 		{
 			name: "reaction falls back to sender jid when pushname missing",
@@ -424,7 +428,7 @@ func TestBuildReactionChatwootContent(t *testing.T) {
 				"from":               "628777000111@s.whatsapp.net",
 			},
 			fromName: "",
-			expected: "628777000111 reacted 😂 to message wamid-999",
+			expected: "628777000111 reacted 😂",
 		},
 		{
 			name: "missing target id still produces readable text",

--- a/src/infrastructure/whatsapp/chatwoot_forward_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_forward_test.go
@@ -389,10 +389,10 @@ func TestBuildReactionChatwootContent(t *testing.T) {
 		expected string
 	}{
 		{
-			// The target id is not repeated in the text: syncPayloadToChatwoot
-			// already threads this note onto the reacted-to message via
-			// in_reply_to_external_id, so Chatwoot nests it under that message's
-			// bubble regardless of whether reacted_message_id is present here.
+			// The target id is not repeated in the text: when reacted_message_id
+			// is present, syncPayloadToChatwoot already threads this note onto
+			// the reacted-to message via in_reply_to_external_id, so Chatwoot
+			// nests it under that message's bubble.
 			name: "reaction with sender name and target id",
 			payload: map[string]any{
 				"reaction":           "👍",

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -602,10 +602,12 @@ func isEventWhitelistedForChatwoot(eventName string) bool {
 }
 
 // buildReactionChatwootContent renders the note posted for a reaction event.
-// It never mentions the WhatsApp message id: syncPayloadToChatwoot already
-// threads this note onto the reacted-to message via
-// ContentAttributes.in_reply_to_external_id, so Chatwoot nests it under that
-// message's bubble - repeating the raw id in the text would just be noise.
+// It never mentions the WhatsApp message id: whenever reacted_message_id is
+// present, syncPayloadToChatwoot already threads this note onto the
+// reacted-to message via ContentAttributes.in_reply_to_external_id, so
+// Chatwoot nests it under that message's bubble - repeating the raw id in
+// the text would just be noise. When reacted_message_id is absent the note
+// is posted standalone, un-threaded, but still readable.
 func buildReactionChatwootContent(data map[string]any, fromName string) string {
 	reaction, _ := data["reaction"].(string)
 

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -601,22 +601,19 @@ func isEventWhitelistedForChatwoot(eventName string) bool {
 	return false
 }
 
+// buildReactionChatwootContent renders the note posted for a reaction event.
+// It never mentions the WhatsApp message id: syncPayloadToChatwoot already
+// threads this note onto the reacted-to message via
+// ContentAttributes.in_reply_to_external_id, so Chatwoot nests it under that
+// message's bubble - repeating the raw id in the text would just be noise.
 func buildReactionChatwootContent(data map[string]any, fromName string) string {
 	reaction, _ := data["reaction"].(string)
-	reactedMessageID, _ := data["reacted_message_id"].(string)
 
 	actor := "Someone"
 	if fromName != "" {
 		actor = fromName
 	} else if from, ok := data["from"].(string); ok && from != "" {
 		actor = utils.ExtractPhoneFromJID(from)
-	}
-
-	if reactedMessageID != "" {
-		if reaction == "" {
-			return fmt.Sprintf("%s removed a reaction from message %s", actor, reactedMessageID)
-		}
-		return fmt.Sprintf("%s reacted %s to message %s", actor, reaction, reactedMessageID)
 	}
 
 	if reaction == "" {


### PR DESCRIPTION
## Problem
Reaction notes forwarded to Chatwoot repeat the raw WhatsApp message id in
the text, e.g. "Alice reacted 👍 to message 3AE2A93DFDB30F3C6CDF". This id
is meaningless to the operator reading the note.

## Root cause
`syncPayloadToChatwoot` already threads the reaction note onto the
reacted-to message via `ContentAttributes.in_reply_to_external_id`, so
Chatwoot nests the note under that message's own bubble. The id printed
in the note text was therefore pure duplication of information the UI
already conveys visually.

## Fix
`buildReactionChatwootContent` no longer includes the WhatsApp message id
in the generated text. The note now simply reads "Alice reacted 👍" /
"Alice removed a reaction", while `reacted_message_id` continues to drive
the threading as before.

## Testing
- `go test ./infrastructure/whatsapp/... -run Reaction -v` (updated
  `TestBuildReactionChatwootContent` expectations)
- Verified live with a self-hosted Chatwoot instance: reaction notes now
  render cleanly nested under the original message without the id.