### PR TITLE
feat(webhook): forward view-once unavailable placeholder as a message event

### DIFF
--- a/docs/webhook-payload.md
+++ b/docs/webhook-payload.md
@@ -1299,6 +1299,8 @@ notice. It is forwarded as a `message` event with no media/body:
     "chat_id": "628987654321@s.whatsapp.net",
     "from": "628123456789@s.whatsapp.net",
     "from_name": "John Doe",
+    "sender_display_name": "John Doe",
+    "is_from_me": false,
     "timestamp": "2023-10-15T11:41:00Z",
     "view_once": true,
     "unavailable": true
@@ -1311,6 +1313,16 @@ notice. It is forwarded as a `message` event with no media/body:
 - `view_once`: The contact sent a view-once message
 - `unavailable`: The content itself was not delivered to this device (render a
   notice instead of media)
+- `chat_lid` / `from_lid`: present when the account uses LID addressing, same
+  as regular messages
+
+**ID reuse caveat:** the placeholder carries the *original* message ID. The
+library asks the phone to resend the content; today WhatsApp withholds
+view-once from linked devices so the answer normally never comes, but if it
+ever does, a second `message` event arrives with the **same `id`** and no
+`unavailable` flag. Consumers deduplicating by `id` should treat a
+placeholder row as upgradeable: an event with the same `id` without
+`unavailable` carries the real content and should win.
 
 ### Forwarded Message
 

--- a/docs/webhook-payload.md
+++ b/docs/webhook-payload.md
@@ -1284,6 +1284,34 @@ When a message is edited, the webhook includes the original message ID to track 
 }
 ```
 
+**Unavailable placeholder variant:** WhatsApp intentionally withholds view-once
+content from linked devices. Depending on the sender's client, instead of the
+message above the server may deliver only an `unavailable` placeholder — the
+same signal WhatsApp Web turns into its *"You received a view once message"*
+notice. It is forwarded as a `message` event with no media/body:
+
+```json
+{
+  "event": "message",
+  "device_id": "628987654321@s.whatsapp.net",
+  "payload": {
+    "id": "3EB0C127D7BACC83D6B9",
+    "chat_id": "628987654321@s.whatsapp.net",
+    "from": "628123456789@s.whatsapp.net",
+    "from_name": "John Doe",
+    "timestamp": "2023-10-15T11:41:00Z",
+    "view_once": true,
+    "unavailable": true
+  }
+}
+```
+
+**Fields:**
+
+- `view_once`: The contact sent a view-once message
+- `unavailable`: The content itself was not delivered to this device (render a
+  notice instead of media)
+
 ### Forwarded Message
 
 ```json

--- a/src/domains/chatstorage/chatstorage.go
+++ b/src/domains/chatstorage/chatstorage.go
@@ -55,18 +55,22 @@ type MessageEdit struct {
 // for it. It is device-scoped because the same WhatsApp message ID can appear
 // in independent device stores.
 type ChatwootMessageLink struct {
-	DeviceID                     string    `db:"device_id"`
-	WhatsAppMessageID            string    `db:"wa_message_id"`
-	WhatsAppChatJID              string    `db:"wa_chat_jid"`
-	ChatwootMessageID            int       `db:"chatwoot_message_id"`
-	ChatwootConversationID       int       `db:"chatwoot_conversation_id"`
-	ChatwootInboxID              int       `db:"chatwoot_inbox_id"`
-	ChatwootContactInboxSourceID string    `db:"chatwoot_contact_inbox_source_id"`
-	SourceID                     string    `db:"source_id"`
-	Direction                    string    `db:"direction"`
-	IsRead                       bool      `db:"is_read"`
-	CreatedAt                    time.Time `db:"created_at"`
-	UpdatedAt                    time.Time `db:"updated_at"`
+	DeviceID                     string `db:"device_id"`
+	WhatsAppMessageID            string `db:"wa_message_id"`
+	WhatsAppChatJID              string `db:"wa_chat_jid"`
+	ChatwootMessageID            int    `db:"chatwoot_message_id"`
+	ChatwootConversationID       int    `db:"chatwoot_conversation_id"`
+	ChatwootInboxID              int    `db:"chatwoot_inbox_id"`
+	ChatwootContactInboxSourceID string `db:"chatwoot_contact_inbox_source_id"`
+	SourceID                     string `db:"source_id"`
+	Direction                    string `db:"direction"`
+	IsRead                       bool   `db:"is_read"`
+	// IsViewOncePlaceholder marks a link created from a view-once "unavailable"
+	// placeholder (notice only, no content). A later real delivery with the
+	// same wa_message_id is allowed to re-sync and replace this link.
+	IsViewOncePlaceholder bool      `db:"is_view_once_placeholder"`
+	CreatedAt             time.Time `db:"created_at"`
+	UpdatedAt             time.Time `db:"updated_at"`
 	// ChatwootConfigID is the id of the chatwoot_device_configs row this link
 	// belongs to. 0 means the legacy/env config (single-account). It scopes
 	// reverse routing so conversation/message ids cannot collide across accounts.

--- a/src/domains/chatstorage/chatstorage.go
+++ b/src/domains/chatstorage/chatstorage.go
@@ -2,6 +2,15 @@ package chatstorage
 
 import "time"
 
+// MediaTypeViewOnceUnavailable marks a stored message as the server-side
+// "unavailable" placeholder of a view-once message: WhatsApp withholds the
+// content from linked devices, so the row is a notice, not media. It is a
+// discriminator, NOT a real media type — history importers read it to flag the
+// Chatwoot link as a placeholder (so a later real delivery can upgrade it), and
+// the media filters (GetChats HasMedia / GetMessages MediaOnly) exclude it
+// exactly like the synthetic "call" rows.
+const MediaTypeViewOnceUnavailable = "view_once_unavailable"
+
 // Chat represents a WhatsApp chat/conversation
 type Chat struct {
 	DeviceID            string    `db:"device_id"`

--- a/src/domains/chatstorage/interfaces.go
+++ b/src/domains/chatstorage/interfaces.go
@@ -36,7 +36,21 @@ type IChatStorageRepository interface {
 	StoreSentMessageWithContext(ctx context.Context, messageID string, senderJID string, recipientJID string, content string, timestamp time.Time, msg *waE2E.Message) error
 
 	// Chatwoot correlation operations
+	//
+	// UpsertChatwootMessageLink writes every column of the mapping EXCEPT
+	// is_view_once_placeholder, which is claim state owned by the dedicated
+	// operations below. Ordinary link updates (read receipts, rebinds, import
+	// replays) read a row, mutate one field and write the whole struct back;
+	// carrying the placeholder flag along would resurrect a stale value and
+	// silently release an upgrade claim taken meanwhile. A row created by this
+	// call still records the flag it was born with — there is no claim to
+	// clobber yet.
 	UpsertChatwootMessageLink(link *ChatwootMessageLink) error
+	// SetChatwootLinkViewOncePlaceholder writes the placeholder discriminator on
+	// an existing link. Reserved for callers that actually created or replaced
+	// the Chatwoot message behind the link, the only ones authoritative about
+	// what that message now shows.
+	SetChatwootLinkViewOncePlaceholder(deviceID, waMessageID string, isPlaceholder bool) error
 	GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID string) (*ChatwootMessageLink, error)
 	// ClaimViewOncePlaceholderUpgrade atomically flips is_view_once_placeholder
 	// FALSE→ for (deviceID, waMessageID) and reports whether THIS caller won the
@@ -49,6 +63,12 @@ type IChatStorageRepository interface {
 	// close the placeholder/real-content race, and rolls it back with this when
 	// the forward fails.
 	DeleteChatwootMessageLink(deviceID, waMessageID string) error
+	// DeleteStaleChatwootMessageLinkReservations drops reservation stubs
+	// (chatwoot_message_id == 0) untouched since olderThan. A stub only lives
+	// for the duration of one forward; one that outlives that window belongs to
+	// a process that died mid-forward, and would otherwise mask its message
+	// from Chatwoot forever. Returns how many rows were reclaimed.
+	DeleteStaleChatwootMessageLinkReservations(olderThan time.Time) (int64, error)
 	GetChatwootMessageLinkByChatwootID(deviceID string, chatwootMessageID int) (*ChatwootMessageLink, error)
 	// GetLatestChatwootMessageLinkByConversation resolves a conversation to its
 	// most recent link. Conversation ids are numbered per Chatwoot account, so the

--- a/src/domains/chatstorage/interfaces.go
+++ b/src/domains/chatstorage/interfaces.go
@@ -44,6 +44,11 @@ type IChatStorageRepository interface {
 	// restores the claim after a failed forward so a later delivery can retry.
 	ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID string) (bool, error)
 	ReleaseViewOncePlaceholderUpgrade(deviceID, waMessageID string) error
+	// DeleteChatwootMessageLink removes a single link, identified by its primary
+	// key. The forward path reserves a stub row before its first network call to
+	// close the placeholder/real-content race, and rolls it back with this when
+	// the forward fails.
+	DeleteChatwootMessageLink(deviceID, waMessageID string) error
 	GetChatwootMessageLinkByChatwootID(deviceID string, chatwootMessageID int) (*ChatwootMessageLink, error)
 	// GetLatestChatwootMessageLinkByConversation resolves a conversation to its
 	// most recent link. Conversation ids are numbered per Chatwoot account, so the

--- a/src/domains/chatstorage/interfaces.go
+++ b/src/domains/chatstorage/interfaces.go
@@ -38,6 +38,12 @@ type IChatStorageRepository interface {
 	// Chatwoot correlation operations
 	UpsertChatwootMessageLink(link *ChatwootMessageLink) error
 	GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID string) (*ChatwootMessageLink, error)
+	// ClaimViewOncePlaceholderUpgrade atomically flips is_view_once_placeholder
+	// FALSE→ for (deviceID, waMessageID) and reports whether THIS caller won the
+	// claim — the winner may sync the recovered content; losers skip. Release
+	// restores the claim after a failed forward so a later delivery can retry.
+	ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID string) (bool, error)
+	ReleaseViewOncePlaceholderUpgrade(deviceID, waMessageID string) error
 	GetChatwootMessageLinkByChatwootID(deviceID string, chatwootMessageID int) (*ChatwootMessageLink, error)
 	// GetLatestChatwootMessageLinkByConversation resolves a conversation to its
 	// most recent link. Conversation ids are numbered per Chatwoot account, so the

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -168,7 +168,9 @@ func (r *SQLiteRepository) buildChatFilterQuery(filter *domainChatStorage.ChatFi
 
 	if filter.HasMedia {
 		// EXISTS avoids duplicating chats when a conversation has multiple media messages (JOIN would).
-		conditions = append(conditions, `EXISTS (SELECT 1 FROM messages m WHERE m.chat_jid = c.jid AND m.device_id = c.device_id AND m.media_type NOT IN ('', 'call'))`)
+		// The excluded values are discriminators for synthetic rows that carry no
+		// delivered media: "call" records and view-once "unavailable" placeholders.
+		conditions = append(conditions, `EXISTS (SELECT 1 FROM messages m WHERE m.chat_jid = c.jid AND m.device_id = c.device_id AND m.media_type NOT IN ('', 'call', '`+domainChatStorage.MediaTypeViewOnceUnavailable+`'))`)
 	}
 
 	if filter.DeviceID != "" {
@@ -497,7 +499,9 @@ func (r *SQLiteRepository) GetMessages(filter *domainChatStorage.MessageFilter) 
 	}
 
 	if filter.MediaOnly {
-		conditions = append(conditions, "media_type NOT IN ('', 'call')")
+		// Same exclusion list as GetChats HasMedia: synthetic rows ("call",
+		// view-once placeholder) never carry delivered media.
+		conditions = append(conditions, "media_type NOT IN ('', 'call', '"+domainChatStorage.MediaTypeViewOnceUnavailable+"')")
 	}
 
 	if filter.IsFromMe != nil {
@@ -788,6 +792,17 @@ func (r *SQLiteRepository) ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID
 	return rows == 1, nil
 }
 
+// DeleteChatwootMessageLink removes a single link. Used to roll back the
+// reservation stub written before a forward when that forward ends up failing,
+// so the retry is not mistaken for a concurrent delivery and skipped.
+func (r *SQLiteRepository) DeleteChatwootMessageLink(deviceID, waMessageID string) error {
+	_, err := r.db.Exec(`
+		DELETE FROM chatwoot_message_links
+		WHERE device_id = ? AND wa_message_id = ?
+	`, deviceID, waMessageID)
+	return err
+}
+
 func (r *SQLiteRepository) ReleaseViewOncePlaceholderUpgrade(deviceID, waMessageID string) error {
 	_, err := r.db.Exec(`
 		UPDATE chatwoot_message_links
@@ -888,6 +903,7 @@ func (r *SQLiteRepository) GetLatestUnreadChatwootMessageLinkByChat(deviceID, wa
 			is_view_once_placeholder
 		FROM chatwoot_message_links
 		WHERE device_id = ? AND wa_chat_jid = ? AND direction = 'incoming' AND is_read = 0
+			AND chatwoot_message_id != 0
 		ORDER BY updated_at DESC, created_at DESC
 		LIMIT 1
 	`

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -773,6 +773,30 @@ func (r *SQLiteRepository) UpsertChatwootMessageLink(link *domainChatStorage.Cha
 	return err
 }
 
+// ClaimViewOncePlaceholderUpgrade flips the placeholder flag off atomically;
+// rowsAffected decides the single winner among concurrent recovered deliveries.
+func (r *SQLiteRepository) ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID string) (bool, error) {
+	result, err := r.db.Exec(`
+		UPDATE chatwoot_message_links
+		SET is_view_once_placeholder = FALSE, updated_at = ?
+		WHERE device_id = ? AND wa_message_id = ? AND is_view_once_placeholder = TRUE
+	`, time.Now(), deviceID, waMessageID)
+	if err != nil {
+		return false, err
+	}
+	rows, _ := result.RowsAffected()
+	return rows == 1, nil
+}
+
+func (r *SQLiteRepository) ReleaseViewOncePlaceholderUpgrade(deviceID, waMessageID string) error {
+	_, err := r.db.Exec(`
+		UPDATE chatwoot_message_links
+		SET is_view_once_placeholder = TRUE, updated_at = ?
+		WHERE device_id = ? AND wa_message_id = ?
+	`, time.Now(), deviceID, waMessageID)
+	return err
+}
+
 func (r *SQLiteRepository) GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID string) (*domainChatStorage.ChatwootMessageLink, error) {
 	query := `
 		SELECT device_id, wa_message_id, wa_chat_jid, chatwoot_message_id,

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -724,6 +724,13 @@ func (r *SQLiteRepository) DeleteMessageByDevice(deviceID, id, chatJID string) e
 
 // UpsertChatwootMessageLink records the stable mapping between a WhatsApp
 // message and the Chatwoot row created for it.
+//
+// The UPDATE deliberately leaves is_view_once_placeholder alone: that column is
+// claim state (see ClaimViewOncePlaceholderUpgrade) and every caller here works
+// from a struct read some time earlier, so writing it back could release a
+// claim taken in between and let a second recovered delivery duplicate the
+// message. Only the INSERT records it, where no claim can exist yet;
+// SetChatwootLinkViewOncePlaceholder changes it afterwards.
 func (r *SQLiteRepository) UpsertChatwootMessageLink(link *domainChatStorage.ChatwootMessageLink) error {
 	if link == nil {
 		return fmt.Errorf("chatwoot message link is required")
@@ -746,12 +753,12 @@ func (r *SQLiteRepository) UpsertChatwootMessageLink(link *domainChatStorage.Cha
 		SET wa_chat_jid = ?, chatwoot_message_id = ?, chatwoot_conversation_id = ?,
 		    chatwoot_inbox_id = ?, chatwoot_contact_inbox_source_id = ?, source_id = ?,
 		    direction = ?, is_read = ?, updated_at = ?,
-		    chatwoot_config_id = ?, chatwoot_account_id = ?, is_view_once_placeholder = ?
+		    chatwoot_config_id = ?, chatwoot_account_id = ?
 		WHERE device_id = ? AND wa_message_id = ?
 	`, link.WhatsAppChatJID, link.ChatwootMessageID, link.ChatwootConversationID,
 		link.ChatwootInboxID, link.ChatwootContactInboxSourceID, link.SourceID,
 		link.Direction, link.IsRead, link.UpdatedAt,
-		link.ChatwootConfigID, link.ChatwootAccountID, link.IsViewOncePlaceholder,
+		link.ChatwootConfigID, link.ChatwootAccountID,
 		link.DeviceID, link.WhatsAppMessageID)
 	if err != nil {
 		return err
@@ -775,6 +782,38 @@ func (r *SQLiteRepository) UpsertChatwootMessageLink(link *domainChatStorage.Cha
 			link.IsViewOncePlaceholder)
 	}
 	return err
+}
+
+// SetChatwootLinkViewOncePlaceholder writes the placeholder discriminator on an
+// existing link. Callers that created or replaced the Chatwoot message use it to
+// state what that message now shows; UpsertChatwootMessageLink never does.
+func (r *SQLiteRepository) SetChatwootLinkViewOncePlaceholder(deviceID, waMessageID string, isPlaceholder bool) error {
+	_, err := r.db.Exec(`
+		UPDATE chatwoot_message_links
+		SET is_view_once_placeholder = ?, updated_at = ?
+		WHERE device_id = ? AND wa_message_id = ?
+	`, isPlaceholder, time.Now(), deviceID, waMessageID)
+	return err
+}
+
+// DeleteStaleChatwootMessageLinkReservations reclaims reservation stubs left
+// behind by a process that died mid-forward. A live stub is rolled back on every
+// failure path, so one whose updated_at stopped moving is orphaned: it would
+// keep answering "already in flight" to every redelivery and hide the message
+// from Chatwoot for good.
+func (r *SQLiteRepository) DeleteStaleChatwootMessageLinkReservations(olderThan time.Time) (int64, error) {
+	result, err := r.db.Exec(`
+		DELETE FROM chatwoot_message_links
+		WHERE chatwoot_message_id = 0 AND updated_at < ?
+	`, olderThan)
+	if err != nil {
+		return 0, err
+	}
+	removed, err := result.RowsAffected()
+	if err != nil {
+		return 0, nil
+	}
+	return removed, nil
 }
 
 // ClaimViewOncePlaceholderUpgrade flips the placeholder flag off atomically;

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -742,12 +742,13 @@ func (r *SQLiteRepository) UpsertChatwootMessageLink(link *domainChatStorage.Cha
 		SET wa_chat_jid = ?, chatwoot_message_id = ?, chatwoot_conversation_id = ?,
 		    chatwoot_inbox_id = ?, chatwoot_contact_inbox_source_id = ?, source_id = ?,
 		    direction = ?, is_read = ?, updated_at = ?,
-		    chatwoot_config_id = ?, chatwoot_account_id = ?
+		    chatwoot_config_id = ?, chatwoot_account_id = ?, is_view_once_placeholder = ?
 		WHERE device_id = ? AND wa_message_id = ?
 	`, link.WhatsAppChatJID, link.ChatwootMessageID, link.ChatwootConversationID,
 		link.ChatwootInboxID, link.ChatwootContactInboxSourceID, link.SourceID,
 		link.Direction, link.IsRead, link.UpdatedAt,
-		link.ChatwootConfigID, link.ChatwootAccountID, link.DeviceID, link.WhatsAppMessageID)
+		link.ChatwootConfigID, link.ChatwootAccountID, link.IsViewOncePlaceholder,
+		link.DeviceID, link.WhatsAppMessageID)
 	if err != nil {
 		return err
 	}
@@ -759,13 +760,15 @@ func (r *SQLiteRepository) UpsertChatwootMessageLink(link *domainChatStorage.Cha
 				device_id, wa_message_id, wa_chat_jid, chatwoot_message_id,
 				chatwoot_conversation_id, chatwoot_inbox_id,
 				chatwoot_contact_inbox_source_id, source_id, direction,
-				is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id
+				is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id,
+				is_view_once_placeholder
 			)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, link.DeviceID, link.WhatsAppMessageID, link.WhatsAppChatJID,
 			link.ChatwootMessageID, link.ChatwootConversationID, link.ChatwootInboxID,
 			link.ChatwootContactInboxSourceID, link.SourceID, link.Direction,
-			link.IsRead, link.CreatedAt, link.UpdatedAt, link.ChatwootConfigID, link.ChatwootAccountID)
+			link.IsRead, link.CreatedAt, link.UpdatedAt, link.ChatwootConfigID, link.ChatwootAccountID,
+			link.IsViewOncePlaceholder)
 	}
 	return err
 }
@@ -775,7 +778,8 @@ func (r *SQLiteRepository) GetChatwootMessageLinkByWhatsAppID(deviceID, waMessag
 		SELECT device_id, wa_message_id, wa_chat_jid, chatwoot_message_id,
 			chatwoot_conversation_id, chatwoot_inbox_id,
 			chatwoot_contact_inbox_source_id, source_id, direction,
-			is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id
+			is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id,
+			is_view_once_placeholder
 		FROM chatwoot_message_links
 		WHERE device_id = ? AND wa_message_id = ?
 		LIMIT 1
@@ -793,7 +797,8 @@ func (r *SQLiteRepository) GetChatwootMessageLinkByChatwootID(deviceID string, c
 		SELECT device_id, wa_message_id, wa_chat_jid, chatwoot_message_id,
 			chatwoot_conversation_id, chatwoot_inbox_id,
 			chatwoot_contact_inbox_source_id, source_id, direction,
-			is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id
+			is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id,
+			is_view_once_placeholder
 		FROM chatwoot_message_links
 		WHERE device_id = ? AND chatwoot_message_id = ?
 		LIMIT 1
@@ -816,7 +821,8 @@ func (r *SQLiteRepository) GetLatestChatwootMessageLinkByConversation(conversati
 		SELECT device_id, wa_message_id, wa_chat_jid, chatwoot_message_id,
 			chatwoot_conversation_id, chatwoot_inbox_id,
 			chatwoot_contact_inbox_source_id, source_id, direction,
-			is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id
+			is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id,
+			is_view_once_placeholder
 		FROM chatwoot_message_links
 		WHERE chatwoot_conversation_id = ? AND (chatwoot_account_id = ? OR (? = 1 AND chatwoot_account_id = 0))
 			AND (? = 0 OR chatwoot_config_id = ?)
@@ -854,7 +860,8 @@ func (r *SQLiteRepository) GetLatestUnreadChatwootMessageLinkByChat(deviceID, wa
 		SELECT device_id, wa_message_id, wa_chat_jid, chatwoot_message_id,
 			chatwoot_conversation_id, chatwoot_inbox_id,
 			chatwoot_contact_inbox_source_id, source_id, direction,
-			is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id
+			is_read, created_at, updated_at, chatwoot_config_id, chatwoot_account_id,
+			is_view_once_placeholder
 		FROM chatwoot_message_links
 		WHERE device_id = ? AND wa_chat_jid = ? AND direction = 'incoming' AND is_read = 0
 		ORDER BY updated_at DESC, created_at DESC
@@ -991,6 +998,7 @@ func (r *SQLiteRepository) scanChatwootMessageLink(scanner interface{ Scan(...an
 		&link.ChatwootContactInboxSourceID, &link.SourceID, &link.Direction,
 		&link.IsRead, &link.CreatedAt, &link.UpdatedAt,
 		&link.ChatwootConfigID, &link.ChatwootAccountID,
+		&link.IsViewOncePlaceholder,
 	)
 	return link, err
 }
@@ -2563,5 +2571,9 @@ func (r *SQLiteRepository) getMigrations() []string {
 		`CREATE INDEX IF NOT EXISTS idx_chatwoot_links_conversation_account ON chatwoot_message_links(chatwoot_conversation_id, chatwoot_account_id, updated_at)`,
 		// Migration 43: Count/delete message links by owning config without a full-table scan
 		`CREATE INDEX IF NOT EXISTS idx_chatwoot_links_config ON chatwoot_message_links(chatwoot_config_id)`,
+		// Migration 44: Mark links created from a view-once "unavailable" placeholder,
+		// so a later real delivery with the same wa_message_id can upgrade the
+		// Chatwoot conversation instead of being suppressed by the link dedupe
+		`ALTER TABLE chatwoot_message_links ADD COLUMN is_view_once_placeholder BOOLEAN DEFAULT FALSE`,
 	}
 }

--- a/src/infrastructure/chatstorage/sqlite_repository_reservation_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_reservation_test.go
@@ -1,0 +1,86 @@
+package chatstorage
+
+import (
+	"testing"
+	"time"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A reservation stub (chatwoot_message_id == 0) is rolled back on every failure
+// path of a forward, so one that stops being touched belongs to a process killed
+// mid-forward. Left in place it answers "already in flight" to every redelivery
+// and hides the message from Chatwoot forever, hence the age-based reclaim.
+// Finished links and stubs of forwards still running must survive it.
+func TestDeleteStaleChatwootMessageLinkReservations(t *testing.T) {
+	deviceID := "628987654321@s.whatsapp.net"
+	waID := func(suffix string) string { return "3EB0C127D7BACC83D6" + suffix }
+
+	seed := func(t *testing.T, repo *SQLiteRepository, id string, chatwootMessageID int, updatedAt time.Time) {
+		t.Helper()
+		require.NoError(t, repo.UpsertChatwootMessageLink(&domainChatStorage.ChatwootMessageLink{
+			DeviceID:          deviceID,
+			WhatsAppMessageID: id,
+			WhatsAppChatJID:   "628123456789@s.whatsapp.net",
+			ChatwootMessageID: chatwootMessageID,
+			Direction:         "incoming",
+		}))
+		// updated_at is stamped with time.Now() by the upsert; age the row by hand
+		// so the sweep has something older than its cutoff to find.
+		_, err := repo.db.Exec(`
+			UPDATE chatwoot_message_links SET updated_at = ?
+			WHERE device_id = ? AND wa_message_id = ?
+		`, updatedAt, deviceID, id)
+		require.NoError(t, err)
+	}
+
+	now := time.Now()
+	cases := []struct {
+		name              string
+		chatwootMessageID int
+		updatedAt         time.Time
+		wantReclaimed     bool
+	}{
+		{"orphaned stub is reclaimed", 0, now.Add(-time.Hour), true},
+		{"stub of a forward still running survives", 0, now, false},
+		{"stub exactly at the cutoff survives", 0, now.Add(-30 * time.Minute), false},
+		{"finished link of the same age survives", 4242, now.Add(-time.Hour), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newTestSQLiteRepository(t)
+			seed(t, repo, waID("01"), tc.chatwootMessageID, tc.updatedAt)
+
+			removed, err := repo.DeleteStaleChatwootMessageLinkReservations(now.Add(-30 * time.Minute))
+			require.NoError(t, err)
+
+			link, err := repo.GetChatwootMessageLinkByWhatsAppID(deviceID, waID("01"))
+			require.NoError(t, err)
+			if tc.wantReclaimed {
+				assert.Equal(t, int64(1), removed)
+				assert.Nil(t, link, "the orphaned stub must be gone so a redelivery can reserve again")
+				return
+			}
+			assert.Zero(t, removed)
+			assert.NotNil(t, link)
+		})
+	}
+
+	t.Run("reclaims across devices and reports the count", func(t *testing.T) {
+		repo := newTestSQLiteRepository(t)
+		seed(t, repo, waID("02"), 0, now.Add(-time.Hour))
+		seed(t, repo, waID("03"), 0, now.Add(-2*time.Hour))
+		seed(t, repo, waID("04"), 7, now.Add(-time.Hour))
+
+		removed, err := repo.DeleteStaleChatwootMessageLinkReservations(now.Add(-30 * time.Minute))
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), removed)
+
+		survivor, err := repo.GetChatwootMessageLinkByWhatsAppID(deviceID, waID("04"))
+		require.NoError(t, err)
+		assert.NotNil(t, survivor)
+	})
+}

--- a/src/infrastructure/chatstorage/sqlite_repository_viewonce_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_viewonce_test.go
@@ -1,0 +1,66 @@
+package chatstorage
+
+import (
+	"testing"
+	"time"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+)
+
+// A view-once "unavailable" placeholder carries no delivered media, so it must
+// never surface in media-only results (GetMessages MediaOnly) nor mark its
+// chat as having media (GetChats HasMedia). The placeholder row uses an empty
+// media_type on purpose — this test pins that contract.
+func TestViewOncePlaceholderExcludedFromMediaFilters(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "628987654321@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+
+	if err := repo.StoreChat(&domainChatStorage.Chat{
+		DeviceID:        deviceID,
+		JID:             chatJID,
+		Name:            "John Doe",
+		LastMessageTime: time.Now(),
+	}); err != nil {
+		t.Fatalf("store chat: %v", err)
+	}
+	if err := repo.StoreMessage(&domainChatStorage.Message{
+		ID:        "3EB0C127D7BACC83D6B9",
+		ChatJID:   chatJID,
+		DeviceID:  deviceID,
+		Sender:    chatJID,
+		Content:   "(View once message — for privacy reasons it can only be opened on the phone)",
+		Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("store placeholder: %v", err)
+	}
+
+	mediaOnly, err := repo.GetMessages(&domainChatStorage.MessageFilter{
+		DeviceID: deviceID, ChatJID: chatJID, MediaOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("get messages media-only: %v", err)
+	}
+	if len(mediaOnly) != 0 {
+		t.Fatalf("placeholder leaked into media-only results: %+v", mediaOnly)
+	}
+
+	withMedia, err := repo.GetChats(&domainChatStorage.ChatFilter{
+		DeviceID: deviceID, HasMedia: true,
+	})
+	if err != nil {
+		t.Fatalf("get chats has-media: %v", err)
+	}
+	if len(withMedia) != 0 {
+		t.Fatalf("placeholder marked the chat as having media: %+v", withMedia)
+	}
+
+	// Sanity: the row itself IS persisted and readable.
+	stored, err := repo.GetMessageByIDAndDevice(deviceID, "3EB0C127D7BACC83D6B9")
+	if err != nil || stored == nil {
+		t.Fatalf("placeholder row missing: %v %v", stored, err)
+	}
+	if stored.MediaType != "" {
+		t.Fatalf("placeholder must not carry a media_type, got %q", stored.MediaType)
+	}
+}

--- a/src/infrastructure/chatstorage/sqlite_repository_viewonce_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_viewonce_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A view-once "unavailable" placeholder carries no delivered media, so it must
@@ -62,5 +64,63 @@ func TestViewOncePlaceholderExcludedFromMediaFilters(t *testing.T) {
 	}
 	if stored.MediaType != "" {
 		t.Fatalf("placeholder must not carry a media_type, got %q", stored.MediaType)
+	}
+}
+
+// Lifecycle of ChatwootMessageLink.IsViewOncePlaceholder: persists on upsert,
+// survives the read path, flips via the atomic claim (single winner), is
+// restorable via release, and stays isolated per device_id.
+func TestChatwootLinkViewOncePlaceholderLifecycle(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	waID := "3EB0C127D7BACC83D6C7"
+	link := func(deviceID string, placeholder bool) *domainChatStorage.ChatwootMessageLink {
+		return &domainChatStorage.ChatwootMessageLink{
+			DeviceID: deviceID, WhatsAppMessageID: waID, WhatsAppChatJID: "628123@s.whatsapp.net",
+			ChatwootMessageID: 42, ChatwootConversationID: 7, Direction: "incoming",
+			IsViewOncePlaceholder: placeholder,
+		}
+	}
+	devA, devB := "devA@s.whatsapp.net", "devB@s.whatsapp.net"
+	require.NoError(t, repo.UpsertChatwootMessageLink(link(devA, true)))
+	require.NoError(t, repo.UpsertChatwootMessageLink(link(devB, false)))
+
+	cases := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{"placeholder flag persists per device", func(t *testing.T) {
+			a, err := repo.GetChatwootMessageLinkByWhatsAppID(devA, waID)
+			require.NoError(t, err)
+			assert.True(t, a.IsViewOncePlaceholder)
+			b, err := repo.GetChatwootMessageLinkByWhatsAppID(devB, waID)
+			require.NoError(t, err)
+			assert.False(t, b.IsViewOncePlaceholder, "same wa_message_id on another device must stay isolated")
+		}},
+		{"claim wins exactly once and only touches its device", func(t *testing.T) {
+			won, err := repo.ClaimViewOncePlaceholderUpgrade(devA, waID)
+			require.NoError(t, err)
+			assert.True(t, won)
+			again, err := repo.ClaimViewOncePlaceholderUpgrade(devA, waID)
+			require.NoError(t, err)
+			assert.False(t, again, "second concurrent claim must lose")
+			b, err := repo.GetChatwootMessageLinkByWhatsAppID(devB, waID)
+			require.NoError(t, err)
+			assert.False(t, b.IsViewOncePlaceholder)
+		}},
+		{"release restores the claim", func(t *testing.T) {
+			require.NoError(t, repo.ReleaseViewOncePlaceholderUpgrade(devA, waID))
+			a, err := repo.GetChatwootMessageLinkByWhatsAppID(devA, waID)
+			require.NoError(t, err)
+			assert.True(t, a.IsViewOncePlaceholder)
+		}},
+		{"upsert to false clears the flag", func(t *testing.T) {
+			require.NoError(t, repo.UpsertChatwootMessageLink(link(devA, false)))
+			a, err := repo.GetChatwootMessageLinkByWhatsAppID(devA, waID)
+			require.NoError(t, err)
+			assert.False(t, a.IsViewOncePlaceholder)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, tc.run)
 	}
 }

--- a/src/infrastructure/chatstorage/sqlite_repository_viewonce_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_viewonce_test.go
@@ -10,61 +10,88 @@ import (
 )
 
 // A view-once "unavailable" placeholder carries no delivered media, so it must
-// never surface in media-only results (GetMessages MediaOnly) nor mark its
-// chat as having media (GetChats HasMedia). The placeholder row uses an empty
-// media_type on purpose — this test pins that contract.
+// never surface in media-only results (GetMessages MediaOnly) nor mark its chat
+// as having media (GetChats HasMedia) — even though it DOES carry a media_type.
+// The row is stamped with the view_once_unavailable discriminator so history
+// importers can recognise it; the two media filters exclude that value
+// explicitly, exactly like the synthetic "call" rows. Real media in the same
+// chat must still pass both filters.
 func TestViewOncePlaceholderExcludedFromMediaFilters(t *testing.T) {
-	repo := newTestSQLiteRepository(t)
 	deviceID := "628987654321@s.whatsapp.net"
-	chatJID := "628123456789@s.whatsapp.net"
+	placeholderChat := "628123456789@s.whatsapp.net"
+	mediaChat := "628111222333@s.whatsapp.net"
 
-	if err := repo.StoreChat(&domainChatStorage.Chat{
-		DeviceID:        deviceID,
-		JID:             chatJID,
-		Name:            "John Doe",
-		LastMessageTime: time.Now(),
-	}); err != nil {
-		t.Fatalf("store chat: %v", err)
-	}
-	if err := repo.StoreMessage(&domainChatStorage.Message{
-		ID:        "3EB0C127D7BACC83D6B9",
-		ChatJID:   chatJID,
-		DeviceID:  deviceID,
-		Sender:    chatJID,
-		Content:   "(View once message — for privacy reasons it can only be opened on the phone)",
-		Timestamp: time.Now(),
-	}); err != nil {
-		t.Fatalf("store placeholder: %v", err)
+	newRepo := func(t *testing.T) *SQLiteRepository {
+		repo := newTestSQLiteRepository(t)
+		require.NoError(t, repo.StoreChat(&domainChatStorage.Chat{
+			DeviceID: deviceID, JID: placeholderChat, Name: "John Doe", LastMessageTime: time.Now(),
+		}))
+		require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+			ID:        "3EB0C127D7BACC83D6B9",
+			ChatJID:   placeholderChat,
+			DeviceID:  deviceID,
+			Sender:    placeholderChat,
+			Content:   "(View once message \u2014 for privacy reasons it can only be opened on the phone)",
+			MediaType: domainChatStorage.MediaTypeViewOnceUnavailable,
+			Timestamp: time.Now(),
+		}))
+		return repo
 	}
 
-	mediaOnly, err := repo.GetMessages(&domainChatStorage.MessageFilter{
-		DeviceID: deviceID, ChatJID: chatJID, MediaOnly: true,
+	t.Run("the discriminator is persisted", func(t *testing.T) {
+		repo := newRepo(t)
+		stored, err := repo.GetMessageByIDAndDevice(deviceID, "3EB0C127D7BACC83D6B9")
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.Equal(t, domainChatStorage.MediaTypeViewOnceUnavailable, stored.MediaType,
+			"history importers read this to flag the Chatwoot link as a placeholder")
 	})
-	if err != nil {
-		t.Fatalf("get messages media-only: %v", err)
-	}
-	if len(mediaOnly) != 0 {
-		t.Fatalf("placeholder leaked into media-only results: %+v", mediaOnly)
-	}
 
-	withMedia, err := repo.GetChats(&domainChatStorage.ChatFilter{
-		DeviceID: deviceID, HasMedia: true,
+	t.Run("excluded from GetMessages MediaOnly", func(t *testing.T) {
+		repo := newRepo(t)
+		mediaOnly, err := repo.GetMessages(&domainChatStorage.MessageFilter{
+			DeviceID: deviceID, ChatJID: placeholderChat, MediaOnly: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, mediaOnly, "placeholder leaked into media-only results")
 	})
-	if err != nil {
-		t.Fatalf("get chats has-media: %v", err)
-	}
-	if len(withMedia) != 0 {
-		t.Fatalf("placeholder marked the chat as having media: %+v", withMedia)
-	}
 
-	// Sanity: the row itself IS persisted and readable.
-	stored, err := repo.GetMessageByIDAndDevice(deviceID, "3EB0C127D7BACC83D6B9")
-	if err != nil || stored == nil {
-		t.Fatalf("placeholder row missing: %v %v", stored, err)
-	}
-	if stored.MediaType != "" {
-		t.Fatalf("placeholder must not carry a media_type, got %q", stored.MediaType)
-	}
+	t.Run("excluded from GetChats HasMedia", func(t *testing.T) {
+		repo := newRepo(t)
+		withMedia, err := repo.GetChats(&domainChatStorage.ChatFilter{
+			DeviceID: deviceID, HasMedia: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, withMedia, "placeholder marked its chat as having media")
+	})
+
+	t.Run("real media still passes both filters", func(t *testing.T) {
+		repo := newRepo(t)
+		require.NoError(t, repo.StoreChat(&domainChatStorage.Chat{
+			DeviceID: deviceID, JID: mediaChat, Name: "Jane Doe", LastMessageTime: time.Now(),
+		}))
+		require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+			ID:        "3EB0C127D7BACC83D6BA",
+			ChatJID:   mediaChat,
+			DeviceID:  deviceID,
+			Sender:    mediaChat,
+			MediaType: "image",
+			Timestamp: time.Now(),
+		}))
+
+		mediaOnly, err := repo.GetMessages(&domainChatStorage.MessageFilter{
+			DeviceID: deviceID, ChatJID: mediaChat, MediaOnly: true,
+		})
+		require.NoError(t, err)
+		assert.Len(t, mediaOnly, 1)
+
+		withMedia, err := repo.GetChats(&domainChatStorage.ChatFilter{
+			DeviceID: deviceID, HasMedia: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, withMedia, 1, "only the chat with real media qualifies")
+		assert.Equal(t, mediaChat, withMedia[0].JID)
+	})
 }
 
 // Lifecycle of ChatwootMessageLink.IsViewOncePlaceholder: persists on upsert,
@@ -118,6 +145,15 @@ func TestChatwootLinkViewOncePlaceholderLifecycle(t *testing.T) {
 			a, err := repo.GetChatwootMessageLinkByWhatsAppID(devA, waID)
 			require.NoError(t, err)
 			assert.False(t, a.IsViewOncePlaceholder)
+		}},
+		{"delete removes only its own device row", func(t *testing.T) {
+			require.NoError(t, repo.DeleteChatwootMessageLink(devA, waID))
+			a, err := repo.GetChatwootMessageLinkByWhatsAppID(devA, waID)
+			require.NoError(t, err)
+			assert.Nil(t, a, "the reservation rollback must drop the row entirely")
+			b, err := repo.GetChatwootMessageLinkByWhatsAppID(devB, waID)
+			require.NoError(t, err)
+			assert.NotNil(t, b, "same wa_message_id on another device must survive")
 		}},
 	}
 	for _, tc := range cases {

--- a/src/infrastructure/chatstorage/sqlite_repository_viewonce_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_viewonce_test.go
@@ -140,11 +140,27 @@ func TestChatwootLinkViewOncePlaceholderLifecycle(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, a.IsViewOncePlaceholder)
 		}},
-		{"upsert to false clears the flag", func(t *testing.T) {
+		{"an ordinary upsert never writes the flag back", func(t *testing.T) {
+			// The read-receipt and rebind paths load a link, change one field and
+			// upsert the whole struct. Their copy of the flag is stale by then, so
+			// an upsert that carried it would release a claim taken meanwhile.
 			require.NoError(t, repo.UpsertChatwootMessageLink(link(devA, false)))
 			a, err := repo.GetChatwootMessageLinkByWhatsAppID(devA, waID)
 			require.NoError(t, err)
+			assert.True(t, a.IsViewOncePlaceholder, "a stale upsert must not clear the claim state")
+			require.NoError(t, repo.UpsertChatwootMessageLink(link(devB, true)))
+			b, err := repo.GetChatwootMessageLinkByWhatsAppID(devB, waID)
+			require.NoError(t, err)
+			assert.False(t, b.IsViewOncePlaceholder, "nor set it")
+		}},
+		{"the explicit setter is the only way to change it", func(t *testing.T) {
+			require.NoError(t, repo.SetChatwootLinkViewOncePlaceholder(devA, waID, false))
+			a, err := repo.GetChatwootMessageLinkByWhatsAppID(devA, waID)
+			require.NoError(t, err)
 			assert.False(t, a.IsViewOncePlaceholder)
+			b, err := repo.GetChatwootMessageLinkByWhatsAppID(devB, waID)
+			require.NoError(t, err)
+			assert.False(t, b.IsViewOncePlaceholder, "another device's row is untouched")
 		}},
 		{"delete removes only its own device row", func(t *testing.T) {
 			require.NoError(t, repo.DeleteChatwootMessageLink(devA, waID))

--- a/src/infrastructure/chatwoot/pgimport/writer.go
+++ b/src/infrastructure/chatwoot/pgimport/writer.go
@@ -557,6 +557,10 @@ func (i *Importer) buildMessageLink(msg *domainChatStorage.Message, convID, chat
 		SourceID:                     sourceID,
 		Direction:                    direction,
 		IsRead:                       false,
+		// Carry the view-once discriminator over from chat storage: a link
+		// imported as a plain message would suppress the later delivery of the
+		// recovered content instead of letting it upgrade the placeholder.
+		IsViewOncePlaceholder: msg.MediaType == domainChatStorage.MediaTypeViewOnceUnavailable,
 		// Account scope must be stamped here: pgimport is legacy-only (config id
 		// stays 0) but a zero account id would only match through the legacy-zero
 		// wildcard, which per-device mode disables — and the boot-time backfill

--- a/src/infrastructure/chatwoot/pgimport/writer.go
+++ b/src/infrastructure/chatwoot/pgimport/writer.go
@@ -50,6 +50,12 @@ type ImportResult struct {
 	MessagesSkipped int // already present (idempotent replay)
 	MessagesFailed  int
 	Links           []domainChatStorage.ChatwootMessageLink
+	// WrittenMessageIDs lists the wa_message_ids this run actually wrote into
+	// Chatwoot, as opposed to the idempotent skips of rows already present. Only
+	// for those is the view-once discriminator carried on the link authoritative:
+	// a skip leaves the existing Chatwoot message untouched, so whatever the live
+	// path has since recorded about it must survive the import.
+	WrittenMessageIDs []string
 }
 
 // ImportChat is the single public entry point for writing historical
@@ -127,6 +133,9 @@ func (i *Importer) ImportChat(ctx context.Context, req ImportChatRequest) (*Impo
 			res.MessagesSkipped++
 		default:
 			res.MessagesWrote++
+			if link != nil {
+				res.WrittenMessageIDs = append(res.WrittenMessageIDs, link.WhatsAppMessageID)
+			}
 			if msg.Timestamp.After(lastActivity) {
 				lastActivity = msg.Timestamp
 			}
@@ -560,6 +569,9 @@ func (i *Importer) buildMessageLink(msg *domainChatStorage.Message, convID, chat
 		// Carry the view-once discriminator over from chat storage: a link
 		// imported as a plain message would suppress the later delivery of the
 		// recovered content instead of letting it upgrade the placeholder.
+		// It describes the message this import writes, so it only counts for
+		// links reported in WrittenMessageIDs — on a skip the Chatwoot row is
+		// left as it was and the stored state stays in charge.
 		IsViewOncePlaceholder: msg.MediaType == domainChatStorage.MediaTypeViewOnceUnavailable,
 		// Account scope must be stamped here: pgimport is legacy-only (config id
 		// stays 0) but a zero account id would only match through the legacy-zero

--- a/src/infrastructure/chatwoot/sync.go
+++ b/src/infrastructure/chatwoot/sync.go
@@ -639,6 +639,11 @@ func (s *SyncService) syncMessageWithOptions(
 			SourceID:                     msgOpts.SourceID,
 			Direction:                    messageType,
 			IsRead:                       false,
+			// Carry the view-once discriminator over from chat storage: a link
+			// imported as a plain message would suppress the later delivery of
+			// the recovered content instead of letting it upgrade the
+			// placeholder.
+			IsViewOncePlaceholder: msg.MediaType == domainChatStorage.MediaTypeViewOnceUnavailable,
 			// Scope the link to this service's Chatwoot account/config so reverse
 			// routing stays account-scoped. Without this, a REST history-sync link
 			// would default to account 0 and match the legacy wildcard in

--- a/src/infrastructure/chatwoot/sync.go
+++ b/src/infrastructure/chatwoot/sync.go
@@ -520,10 +520,24 @@ func (s *SyncService) storeChatwootImportLinks(result *pgimport.ImportResult) er
 	if s.chatStorageRepo == nil || result == nil {
 		return nil
 	}
+	written := make(map[string]struct{}, len(result.WrittenMessageIDs))
+	for _, waMessageID := range result.WrittenMessageIDs {
+		written[waMessageID] = struct{}{}
+	}
 	for i := range result.Links {
 		link := result.Links[i]
 		if err := s.chatStorageRepo.UpsertChatwootMessageLink(&link); err != nil {
 			return fmt.Errorf("failed to store chatwoot import link for %s: %w", link.WhatsAppMessageID, err)
+		}
+		// The upsert leaves the view-once discriminator alone, so a skipped row
+		// keeps whatever the live path recorded: the import did not touch that
+		// Chatwoot message and must not restate what it shows. Where the import
+		// really did write the message, it is the authority.
+		if _, ok := written[link.WhatsAppMessageID]; !ok {
+			continue
+		}
+		if err := s.chatStorageRepo.SetChatwootLinkViewOncePlaceholder(link.DeviceID, link.WhatsAppMessageID, link.IsViewOncePlaceholder); err != nil {
+			return fmt.Errorf("failed to store chatwoot import placeholder state for %s: %w", link.WhatsAppMessageID, err)
 		}
 	}
 	return nil
@@ -653,6 +667,13 @@ func (s *SyncService) syncMessageWithOptions(
 			ChatwootAccountID: s.client.AccountID,
 		}); err != nil {
 			return fmt.Errorf("failed to store chatwoot message link: %w", err)
+		}
+		// The upsert keeps its hands off the discriminator (it is claim state for
+		// the live path). This call created the Chatwoot message, so it is the
+		// one entitled to say what that message shows.
+		if err := s.chatStorageRepo.SetChatwootLinkViewOncePlaceholder(msg.DeviceID, msg.ID,
+			msg.MediaType == domainChatStorage.MediaTypeViewOnceUnavailable); err != nil {
+			return fmt.Errorf("failed to store chatwoot message placeholder state: %w", err)
 		}
 	}
 

--- a/src/infrastructure/chatwoot/sync_import_links_test.go
+++ b/src/infrastructure/chatwoot/sync_import_links_test.go
@@ -1,0 +1,115 @@
+package chatwoot
+
+import (
+	"testing"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/chatwoot/pgimport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type importLinkTestRepo struct {
+	domainChatStorage.IChatStorageRepository
+	upserted    []string
+	placeholder map[string]bool
+}
+
+func newImportLinkTestRepo() *importLinkTestRepo {
+	return &importLinkTestRepo{placeholder: make(map[string]bool)}
+}
+
+func (r *importLinkTestRepo) UpsertChatwootMessageLink(link *domainChatStorage.ChatwootMessageLink) error {
+	r.upserted = append(r.upserted, link.WhatsAppMessageID)
+	return nil
+}
+
+func (r *importLinkTestRepo) SetChatwootLinkViewOncePlaceholder(_, waMessageID string, isPlaceholder bool) error {
+	r.placeholder[waMessageID] = isPlaceholder
+	return nil
+}
+
+// The direct importer probes Chatwoot by source_id and returns a link for rows
+// it merely found, without touching the message they describe. Only the links
+// whose content it actually wrote may restate the view-once discriminator: on a
+// skip, the Chatwoot message still shows whatever it showed, and the stored flag
+// is whatever the live path has since claimed for it.
+func TestStoreChatwootImportLinksPreservesPlaceholderOnSkips(t *testing.T) {
+	const deviceID = "628987654321@s.whatsapp.net"
+
+	link := func(waMessageID string, isPlaceholder bool) domainChatStorage.ChatwootMessageLink {
+		return domainChatStorage.ChatwootMessageLink{
+			DeviceID:              deviceID,
+			WhatsAppMessageID:     waMessageID,
+			WhatsAppChatJID:       "628123456789@s.whatsapp.net",
+			ChatwootMessageID:     99,
+			IsViewOncePlaceholder: isPlaceholder,
+		}
+	}
+
+	cases := []struct {
+		name            string
+		result          *pgimport.ImportResult
+		wantUpserted    []string
+		wantPlaceholder map[string]bool
+	}{
+		{
+			name: "written placeholder stamps the discriminator",
+			result: &pgimport.ImportResult{
+				Links:             []domainChatStorage.ChatwootMessageLink{link("wa-written", true)},
+				WrittenMessageIDs: []string{"wa-written"},
+			},
+			wantUpserted:    []string{"wa-written"},
+			wantPlaceholder: map[string]bool{"wa-written": true},
+		},
+		{
+			name: "written content clears it",
+			result: &pgimport.ImportResult{
+				Links:             []domainChatStorage.ChatwootMessageLink{link("wa-written", false)},
+				WrittenMessageIDs: []string{"wa-written"},
+			},
+			wantUpserted:    []string{"wa-written"},
+			wantPlaceholder: map[string]bool{"wa-written": false},
+		},
+		{
+			name: "skipped row keeps the stored state",
+			result: &pgimport.ImportResult{
+				Links: []domainChatStorage.ChatwootMessageLink{link("wa-skipped", false)},
+			},
+			wantUpserted:    []string{"wa-skipped"},
+			wantPlaceholder: map[string]bool{},
+		},
+		{
+			name: "mixed run separates the two",
+			result: &pgimport.ImportResult{
+				Links: []domainChatStorage.ChatwootMessageLink{
+					link("wa-written", true),
+					link("wa-skipped", false),
+				},
+				WrittenMessageIDs: []string{"wa-written"},
+			},
+			wantUpserted:    []string{"wa-written", "wa-skipped"},
+			wantPlaceholder: map[string]bool{"wa-written": true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newImportLinkTestRepo()
+			svc := NewSyncService(&Client{AccountID: 1, InboxID: 2}, repo)
+
+			require.NoError(t, svc.storeChatwootImportLinks(tc.result))
+
+			assert.Equal(t, tc.wantUpserted, repo.upserted, "every link is still mapped")
+			assert.Equal(t, tc.wantPlaceholder, repo.placeholder,
+				"only links this import actually wrote may restate the discriminator")
+		})
+	}
+
+	t.Run("no storage configured is a no-op", func(t *testing.T) {
+		svc := NewSyncService(&Client{AccountID: 1, InboxID: 2}, nil)
+		assert.NoError(t, svc.storeChatwootImportLinks(&pgimport.ImportResult{
+			Links: []domainChatStorage.ChatwootMessageLink{link("wa-written", true)},
+		}))
+	})
+}

--- a/src/infrastructure/chatwoot/sync_links_test.go
+++ b/src/infrastructure/chatwoot/sync_links_test.go
@@ -31,6 +31,15 @@ func (r *chatwootSyncLinkRepo) UpsertChatwootMessageLink(link *domainChatStorage
 	return nil
 }
 
+// The upsert never writes the view-once discriminator, so the fake mirrors the
+// repository: only the explicit setter moves it.
+func (r *chatwootSyncLinkRepo) SetChatwootLinkViewOncePlaceholder(deviceID, waMessageID string, isPlaceholder bool) error {
+	if link := r.links[chatwootSyncLinkKey(deviceID, waMessageID)]; link != nil {
+		link.IsViewOncePlaceholder = isPlaceholder
+	}
+	return nil
+}
+
 func (r *chatwootSyncLinkRepo) GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID string) (*domainChatStorage.ChatwootMessageLink, error) {
 	link := r.links[chatwootSyncLinkKey(deviceID, waMessageID)]
 	if link == nil {

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -77,6 +77,9 @@ func (r *deviceChatStorage) DeleteChatByDevice(deviceID, jid string) error {
 }
 
 func (r *deviceChatStorage) StoreMessage(message *domainChatStorage.Message) error {
+	if message != nil && message.DeviceID == "" {
+		message.DeviceID = r.deviceID
+	}
 	return r.base.StoreMessage(message)
 }
 

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -144,6 +144,20 @@ func (r *deviceChatStorage) UpsertChatwootMessageLink(link *domainChatStorage.Ch
 	return r.base.UpsertChatwootMessageLink(link)
 }
 
+func (r *deviceChatStorage) ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID string) (bool, error) {
+	if deviceID == "" {
+		deviceID = r.deviceID
+	}
+	return r.base.ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID)
+}
+
+func (r *deviceChatStorage) ReleaseViewOncePlaceholderUpgrade(deviceID, waMessageID string) error {
+	if deviceID == "" {
+		deviceID = r.deviceID
+	}
+	return r.base.ReleaseViewOncePlaceholderUpgrade(deviceID, waMessageID)
+}
+
 func (r *deviceChatStorage) GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID string) (*domainChatStorage.ChatwootMessageLink, error) {
 	targetDeviceID := deviceID
 	if targetDeviceID == "" {

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -144,6 +144,19 @@ func (r *deviceChatStorage) UpsertChatwootMessageLink(link *domainChatStorage.Ch
 	return r.base.UpsertChatwootMessageLink(link)
 }
 
+func (r *deviceChatStorage) SetChatwootLinkViewOncePlaceholder(deviceID, waMessageID string, isPlaceholder bool) error {
+	if deviceID == "" {
+		deviceID = r.deviceID
+	}
+	return r.base.SetChatwootLinkViewOncePlaceholder(deviceID, waMessageID, isPlaceholder)
+}
+
+// DeleteStaleChatwootMessageLinkReservations is intentionally not device-scoped:
+// orphaned stubs are reclaimed for every device the shared store holds.
+func (r *deviceChatStorage) DeleteStaleChatwootMessageLinkReservations(olderThan time.Time) (int64, error) {
+	return r.base.DeleteStaleChatwootMessageLinkReservations(olderThan)
+}
+
 func (r *deviceChatStorage) ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID string) (bool, error) {
 	if deviceID == "" {
 		deviceID = r.deviceID

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -158,6 +158,13 @@ func (r *deviceChatStorage) ReleaseViewOncePlaceholderUpgrade(deviceID, waMessag
 	return r.base.ReleaseViewOncePlaceholderUpgrade(deviceID, waMessageID)
 }
 
+func (r *deviceChatStorage) DeleteChatwootMessageLink(deviceID, waMessageID string) error {
+	if deviceID == "" {
+		deviceID = r.deviceID
+	}
+	return r.base.DeleteChatwootMessageLink(deviceID, waMessageID)
+}
+
 func (r *deviceChatStorage) GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID string) (*domainChatStorage.ChatwootMessageLink, error) {
 	targetDeviceID := deviceID
 	if targetDeviceID == "" {

--- a/src/infrastructure/whatsapp/chatwoot_content_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_content_test.go
@@ -481,6 +481,38 @@ func TestBuildChatwootMessageContent(t *testing.T) {
 		}
 	})
 
+	t.Run("view-once unavailable placeholder yields notice", func(t *testing.T) {
+		content, atts := buildChatwootMessageContent(map[string]any{
+			"view_once": true, "unavailable": true,
+		}, false, "")
+		if content != viewOncePlaceholderNotice {
+			t.Fatalf("expected view-once notice, got %q", content)
+		}
+		if len(atts) != 0 {
+			t.Fatalf("expected no attachments, got %v", atts)
+		}
+	})
+
+	t.Run("group view-once placeholder credits the sender", func(t *testing.T) {
+		content, _ := buildChatwootMessageContent(map[string]any{
+			"view_once": true, "unavailable": true,
+		}, true, "Jane")
+		if content != "Jane: "+viewOncePlaceholderNotice {
+			t.Fatalf("expected sender-prefixed notice, got %q", content)
+		}
+	})
+
+	t.Run("view_once WITHOUT unavailable keeps the generic fallback", func(t *testing.T) {
+		// A delivered view-once whose media extraction failed must not
+		// masquerade as a privacy withholding.
+		content, _ := buildChatwootMessageContent(map[string]any{
+			"view_once": true,
+		}, false, "")
+		if content != "(Unsupported message type)" {
+			t.Fatalf("expected generic placeholder, got %q", content)
+		}
+	})
+
 	t.Run("no body and no attachments yields placeholder", func(t *testing.T) {
 		content, atts := buildChatwootMessageContent(map[string]any{}, false, "")
 		if content != "(Unsupported message type)" {

--- a/src/infrastructure/whatsapp/chatwoot_content_test.go
+++ b/src/infrastructure/whatsapp/chatwoot_content_test.go
@@ -572,7 +572,7 @@ func TestBuildChatwootMessageContent(t *testing.T) {
 		// "image"/"video"/"document" keys can't represent without one
 		// overwriting another.
 		content, atts := buildChatwootMessageContent(map[string]any{
-			"interactive":      "Check our products",
+			"interactive":       "Check our products",
 			"interactive_media": []string{"/tmp/wa/card1.jpg", "/tmp/wa/card2.jpg"},
 		}, false, "")
 		if content != "Check our products" {

--- a/src/infrastructure/whatsapp/event_handler.go
+++ b/src/infrastructure/whatsapp/event_handler.go
@@ -150,20 +150,38 @@ func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMe
 	}()
 }
 
+// placeholderDeviceID resolves the storage partition key for a view-once
+// placeholder: the logged-in JID from the client store. That is exactly what
+// the regular ingestion path (CreateMessage) and the REST chat queries use,
+// so it is the only value that puts the placeholder where the rest of the
+// system will look for it — the device-scoped wrapper may still carry the
+// alias supplied at registration time, which would land the row in a
+// partition nothing reads.
+//
+// Returns "" when the client is not available or not logged in; the caller
+// then skips persistence rather than guessing a partition.
+func placeholderDeviceID(client *whatsmeow.Client) string {
+	if client == nil || client.Store == nil || client.Store.ID == nil {
+		return ""
+	}
+	return client.Store.ID.ToNonAD().String()
+}
+
 // persistViewOncePlaceholder upserts the chat row and stores the placeholder
 // as a notice-only message, so chat listing, ordering and /chat/:jid/messages
 // stay consistent with what webhook and Chatwoot consumers see. Best-effort:
 // failures are logged, never block the forward.
 //
-// Both writes go through the device-scoped wrapper with an EMPTY DeviceID so
-// the wrapper injects its own partition key — chat and message always land in
-// the same partition (a bare client.Store.ID here could diverge from the
-// wrapper's alias on multi-device setups). MediaType stays empty on purpose:
-// no media was delivered, and a synthetic media_type would surface the
-// placeholder in media-only filters (GetChats HasMedia / GetMessages
-// MediaOnly).
+// Both writes carry an EXPLICIT DeviceID (see placeholderDeviceID) instead of
+// letting the device-scoped wrapper inject its own key, and the chat lookups
+// use the *ByDevice variants with that same id. MediaType is the
+// view_once_unavailable discriminator: it is what lets the history importers
+// recognise the row as a placeholder and flag the Chatwoot link so a later
+// real delivery can upgrade it. It is not a real media type, and the media
+// filters exclude it explicitly.
 func persistViewOncePlaceholder(ctx context.Context, evt *events.UndecryptableMessage, repo domainChatStorage.IChatStorageRepository, client *whatsmeow.Client) {
-	if repo == nil {
+	deviceID := placeholderDeviceID(client)
+	if repo == nil || deviceID == "" {
 		return
 	}
 	normalizedChat := NormalizeJIDFromLID(ctx, evt.Info.Chat, client)
@@ -171,15 +189,16 @@ func persistViewOncePlaceholder(ctx context.Context, evt *events.UndecryptableMe
 	normalizedSender := NormalizeJIDFromLID(ctx, evt.Info.Sender, client)
 
 	chat := &domainChatStorage.Chat{
-		JID: chatJID,
+		DeviceID: deviceID,
+		JID:      chatJID,
 		// Same device-scoped resolution the regular ingestion path uses:
 		// correct group names, and never a participant PushName as the name
 		// of a group chat.
-		Name:            repo.GetChatNameWithPushName(normalizedChat, chatJID, normalizedSender.User, evt.Info.PushName),
+		Name:            repo.GetChatNameWithPushNameByDevice(deviceID, normalizedChat, chatJID, normalizedSender.User, evt.Info.PushName),
 		LastMessageTime: evt.Info.Timestamp,
 	}
 	// StoreChat overwrites: preserve what an existing row already knows.
-	if existing, err := repo.GetChat(chatJID); err == nil && existing != nil {
+	if existing, err := repo.GetChatByDevice(deviceID, chatJID); err == nil && existing != nil {
 		chat.EphemeralExpiration = existing.EphemeralExpiration
 		chat.Archived = existing.Archived
 		if existing.LastMessageTime.After(chat.LastMessageTime) {
@@ -194,10 +213,12 @@ func persistViewOncePlaceholder(ctx context.Context, evt *events.UndecryptableMe
 	message := &domainChatStorage.Message{
 		ID:        evt.Info.ID,
 		ChatJID:   chatJID,
+		DeviceID:  deviceID,
 		Sender:    normalizedSender.ToNonAD().String(),
 		Content:   viewOncePlaceholderNotice,
 		Timestamp: evt.Info.Timestamp,
 		IsFromMe:  evt.Info.IsFromMe,
+		MediaType: domainChatStorage.MediaTypeViewOnceUnavailable,
 	}
 	if err := repo.StoreMessage(message); err != nil {
 		log.Warnf("Failed to persist view-once placeholder %s: %v", evt.Info.ID, err)

--- a/src/infrastructure/whatsapp/event_handler.go
+++ b/src/infrastructure/whatsapp/event_handler.go
@@ -54,7 +54,7 @@ func handler(ctx context.Context, instance *DeviceInstance, rawEvt any) {
 	case *events.Message:
 		handleMessage(ctx, evt, chatStorageRepo, client)
 	case *events.UndecryptableMessage:
-		handleUndecryptableMessage(ctx, evt, client)
+		handleUndecryptableMessage(ctx, evt, chatStorageRepo, client)
 	case *events.Receipt:
 		handleReceipt(ctx, evt, instance.JID(), client)
 	case *events.Archive:
@@ -99,7 +99,7 @@ func handler(ctx context.Context, instance *DeviceInstance, rawEvt any) {
 // `message` event with `view_once: true` (and `unavailable: true`, since
 // there is no content) so webhook consumers can render the same notice
 // instead of silently missing the message.
-func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMessage, client *whatsmeow.Client) {
+func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMessage, chatStorageRepo domainChatStorage.IChatStorageRepository, client *whatsmeow.Client) {
 	log.Warnf("Undecryptable message %s from %s (unavailable: %v, type: %q, fail mode: %q).",
 		evt.Info.ID,
 		evt.Info.SourceString(),
@@ -114,6 +114,19 @@ func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMe
 		return
 	}
 
+	// Broadcast/status placeholders are never surfaced — same guard the
+	// regular message path applies in handleWebhookForward.
+	if strings.Contains(evt.Info.SourceString(), "broadcast") {
+		return
+	}
+
+	// Persist a stub in chat storage BEFORE forwarding (mirrors handleMessage's
+	// order and the handleCallOffer precedent for non-Message events): without
+	// it the placeholder would exist for webhook/Chatwoot consumers but be
+	// invisible to GOWA's own /chats API and UI — and a brand-new contact whose
+	// first message is view-once would never get a chat row at all.
+	persistViewOncePlaceholder(ctx, evt, chatStorageRepo, client)
+
 	// Same async pattern as handleWebhookForward: never block the event loop
 	// on webhook delivery, and detach from the incoming context — for devices
 	// created via the HTTP login flow, ctx is the (long-canceled) request
@@ -126,6 +139,54 @@ func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMe
 			log.Warnf("Failed to forward view-once placeholder %s to webhooks: %v", evt.Info.ID, err)
 		}
 	}()
+}
+
+// persistViewOncePlaceholder upserts the chat row and stores the placeholder
+// as a content-less message (media_type "view_once_unavailable"), so chat
+// listing, ordering and /chat/:jid/messages stay consistent with what webhook
+// and Chatwoot consumers see. Best-effort: failures are logged, never block
+// the forward.
+func persistViewOncePlaceholder(ctx context.Context, evt *events.UndecryptableMessage, repo domainChatStorage.IChatStorageRepository, client *whatsmeow.Client) {
+	if repo == nil || client == nil || client.Store == nil || client.Store.ID == nil {
+		return
+	}
+	deviceID := client.Store.ID.ToNonAD().String()
+	chatJID := NormalizeJIDFromLID(ctx, evt.Info.Chat, client).String()
+
+	chat := &domainChatStorage.Chat{
+		JID:             chatJID,
+		Name:            evt.Info.PushName,
+		LastMessageTime: evt.Info.Timestamp,
+	}
+	// StoreChat overwrites: preserve what an existing row already knows.
+	if existing, err := repo.GetChat(chatJID); err == nil && existing != nil {
+		if existing.Name != "" {
+			chat.Name = existing.Name
+		}
+		chat.EphemeralExpiration = existing.EphemeralExpiration
+		chat.Archived = existing.Archived
+		if existing.LastMessageTime.After(chat.LastMessageTime) {
+			chat.LastMessageTime = existing.LastMessageTime
+		}
+	}
+	if err := repo.StoreChat(chat); err != nil {
+		log.Warnf("Failed to persist chat for view-once placeholder %s: %v", evt.Info.ID, err)
+		return
+	}
+
+	message := &domainChatStorage.Message{
+		ID:        evt.Info.ID,
+		ChatJID:   chatJID,
+		DeviceID:  deviceID,
+		Sender:    NormalizeJIDFromLID(ctx, evt.Info.Sender, client).ToNonAD().String(),
+		Content:   viewOncePlaceholderNotice,
+		Timestamp: evt.Info.Timestamp,
+		IsFromMe:  evt.Info.IsFromMe,
+		MediaType: "view_once_unavailable",
+	}
+	if err := repo.StoreMessage(message); err != nil {
+		log.Warnf("Failed to persist view-once placeholder %s: %v", evt.Info.ID, err)
+	}
 }
 
 // buildViewOncePlaceholderEvent builds the webhook envelope for a view-once
@@ -145,9 +206,13 @@ func buildViewOncePlaceholderEvent(ctx context.Context, client *whatsmeow.Client
 		payload["from_name"] = pushname
 	}
 
+	// The key is always present — every regular `message` event carries it
+	// (empty when the client has no store), and schema-strict consumers rely
+	// on that.
 	envelope := map[string]any{
-		"event":   EventTypeMessage,
-		"payload": payload,
+		"event":     EventTypeMessage,
+		"device_id": "",
+		"payload":   payload,
 	}
 	if client != nil && client.Store != nil && client.Store.ID != nil {
 		deviceJID := NormalizeJIDFromLID(ctx, client.Store.ID.ToNonAD(), client)

--- a/src/infrastructure/whatsapp/event_handler.go
+++ b/src/infrastructure/whatsapp/event_handler.go
@@ -125,7 +125,13 @@ func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMe
 	// it the placeholder would exist for webhook/Chatwoot consumers but be
 	// invisible to GOWA's own /chats API and UI — and a brand-new contact whose
 	// first message is view-once would never get a chat row at all.
-	persistViewOncePlaceholder(ctx, evt, chatStorageRepo, client)
+	// The incoming ctx may already be canceled (login-flow request context
+	// captured by the event-handler closure), which would make the LID
+	// lookups inside persistence fail and store raw @lid identifiers —
+	// detach a bounded context for it, same as the webhook forward below.
+	persistCtx, cancelPersist := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	persistViewOncePlaceholder(persistCtx, evt, chatStorageRepo, client)
+	cancelPersist()
 
 	// Same async pattern as handleWebhookForward: never block the event loop
 	// on webhook delivery, and detach from the incoming context — for devices
@@ -134,6 +140,9 @@ func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMe
 	go func() {
 		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
+		// The operator's auto-mark-read setting applies to the placeholder as
+		// it does to any incoming message (original chat/sender JIDs).
+		handleAutoMarkRead(webhookCtx, &evt.Info, client)
 		envelope := buildViewOncePlaceholderEvent(webhookCtx, client, evt)
 		if err := forwardPayloadToConfiguredWebhooks(webhookCtx, envelope, EventTypeMessage); err != nil {
 			log.Warnf("Failed to forward view-once placeholder %s to webhooks: %v", evt.Info.ID, err)
@@ -142,27 +151,35 @@ func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMe
 }
 
 // persistViewOncePlaceholder upserts the chat row and stores the placeholder
-// as a content-less message (media_type "view_once_unavailable"), so chat
-// listing, ordering and /chat/:jid/messages stay consistent with what webhook
-// and Chatwoot consumers see. Best-effort: failures are logged, never block
-// the forward.
+// as a notice-only message, so chat listing, ordering and /chat/:jid/messages
+// stay consistent with what webhook and Chatwoot consumers see. Best-effort:
+// failures are logged, never block the forward.
+//
+// Both writes go through the device-scoped wrapper with an EMPTY DeviceID so
+// the wrapper injects its own partition key — chat and message always land in
+// the same partition (a bare client.Store.ID here could diverge from the
+// wrapper's alias on multi-device setups). MediaType stays empty on purpose:
+// no media was delivered, and a synthetic media_type would surface the
+// placeholder in media-only filters (GetChats HasMedia / GetMessages
+// MediaOnly).
 func persistViewOncePlaceholder(ctx context.Context, evt *events.UndecryptableMessage, repo domainChatStorage.IChatStorageRepository, client *whatsmeow.Client) {
-	if repo == nil || client == nil || client.Store == nil || client.Store.ID == nil {
+	if repo == nil {
 		return
 	}
-	deviceID := client.Store.ID.ToNonAD().String()
-	chatJID := NormalizeJIDFromLID(ctx, evt.Info.Chat, client).String()
+	normalizedChat := NormalizeJIDFromLID(ctx, evt.Info.Chat, client)
+	chatJID := normalizedChat.String()
+	normalizedSender := NormalizeJIDFromLID(ctx, evt.Info.Sender, client)
 
 	chat := &domainChatStorage.Chat{
-		JID:             chatJID,
-		Name:            evt.Info.PushName,
+		JID: chatJID,
+		// Same device-scoped resolution the regular ingestion path uses:
+		// correct group names, and never a participant PushName as the name
+		// of a group chat.
+		Name:            repo.GetChatNameWithPushName(normalizedChat, chatJID, normalizedSender.User, evt.Info.PushName),
 		LastMessageTime: evt.Info.Timestamp,
 	}
 	// StoreChat overwrites: preserve what an existing row already knows.
 	if existing, err := repo.GetChat(chatJID); err == nil && existing != nil {
-		if existing.Name != "" {
-			chat.Name = existing.Name
-		}
 		chat.EphemeralExpiration = existing.EphemeralExpiration
 		chat.Archived = existing.Archived
 		if existing.LastMessageTime.After(chat.LastMessageTime) {
@@ -177,12 +194,10 @@ func persistViewOncePlaceholder(ctx context.Context, evt *events.UndecryptableMe
 	message := &domainChatStorage.Message{
 		ID:        evt.Info.ID,
 		ChatJID:   chatJID,
-		DeviceID:  deviceID,
-		Sender:    NormalizeJIDFromLID(ctx, evt.Info.Sender, client).ToNonAD().String(),
+		Sender:    normalizedSender.ToNonAD().String(),
 		Content:   viewOncePlaceholderNotice,
 		Timestamp: evt.Info.Timestamp,
 		IsFromMe:  evt.Info.IsFromMe,
-		MediaType: "view_once_unavailable",
 	}
 	if err := repo.StoreMessage(message); err != nil {
 		log.Warnf("Failed to persist view-once placeholder %s: %v", evt.Info.ID, err)

--- a/src/infrastructure/whatsapp/event_handler.go
+++ b/src/infrastructure/whatsapp/event_handler.go
@@ -115,10 +115,14 @@ func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMe
 	}
 
 	// Same async pattern as handleWebhookForward: never block the event loop
-	// on webhook delivery.
+	// on webhook delivery, and detach from the incoming context — for devices
+	// created via the HTTP login flow, ctx is the (long-canceled) request
+	// context captured by the event-handler closure.
 	go func() {
-		envelope := buildViewOncePlaceholderEvent(ctx, client, evt)
-		if err := forwardPayloadToConfiguredWebhooks(ctx, envelope, EventTypeMessage); err != nil {
+		webhookCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		envelope := buildViewOncePlaceholderEvent(webhookCtx, client, evt)
+		if err := forwardPayloadToConfiguredWebhooks(webhookCtx, envelope, EventTypeMessage); err != nil {
 			log.Warnf("Failed to forward view-once placeholder %s to webhooks: %v", evt.Info.ID, err)
 		}
 	}()

--- a/src/infrastructure/whatsapp/event_handler.go
+++ b/src/infrastructure/whatsapp/event_handler.go
@@ -54,7 +54,7 @@ func handler(ctx context.Context, instance *DeviceInstance, rawEvt any) {
 	case *events.Message:
 		handleMessage(ctx, evt, chatStorageRepo, client)
 	case *events.UndecryptableMessage:
-		handleUndecryptableMessage(evt)
+		handleUndecryptableMessage(ctx, evt, client)
 	case *events.Receipt:
 		handleReceipt(ctx, evt, instance.JID(), client)
 	case *events.Archive:
@@ -87,17 +87,69 @@ func handler(ctx context.Context, instance *DeviceInstance, rawEvt any) {
 }
 
 // handleUndecryptableMessage surfaces messages that arrived but could not be
-// decrypted. They carry no plaintext, so there is nothing to store or forward,
+// decrypted. Most carry no plaintext, so there is nothing to store or forward,
 // but dropping them without a trace makes the common "messages from this
 // contact never arrive" report impossible to diagnose.
-func handleUndecryptableMessage(evt *events.UndecryptableMessage) {
-	log.Warnf("Undecryptable message %s from %s (unavailable: %v, type: %q, fail mode: %q). No webhook or storage entry is produced for it.",
+//
+// The exception is the server-side "unavailable" placeholder for view-once
+// messages: WhatsApp intentionally withholds view-once content from linked
+// devices, so this placeholder is the ONLY signal a companion device ever
+// receives that the contact sent one — it is exactly what WhatsApp Web turns
+// into its "You received a view once message" notice. Forward it as a
+// `message` event with `view_once: true` (and `unavailable: true`, since
+// there is no content) so webhook consumers can render the same notice
+// instead of silently missing the message.
+func handleUndecryptableMessage(ctx context.Context, evt *events.UndecryptableMessage, client *whatsmeow.Client) {
+	log.Warnf("Undecryptable message %s from %s (unavailable: %v, type: %q, fail mode: %q).",
 		evt.Info.ID,
 		evt.Info.SourceString(),
 		evt.IsUnavailable,
 		evt.UnavailableType,
 		evt.DecryptFailMode,
 	)
+
+	if !evt.IsUnavailable || evt.UnavailableType != events.UnavailableTypeViewOnce {
+		// Genuinely undecryptable (or an unknown unavailable kind): nothing to
+		// store or forward, same as before.
+		return
+	}
+
+	// Same async pattern as handleWebhookForward: never block the event loop
+	// on webhook delivery.
+	go func() {
+		envelope := buildViewOncePlaceholderEvent(ctx, client, evt)
+		if err := forwardPayloadToConfiguredWebhooks(ctx, envelope, EventTypeMessage); err != nil {
+			log.Warnf("Failed to forward view-once placeholder %s to webhooks: %v", evt.Info.ID, err)
+		}
+	}()
+}
+
+// buildViewOncePlaceholderEvent builds the webhook envelope for a view-once
+// "unavailable" placeholder. Mirrors the field names of the regular message
+// path (buildFromFields/from_name) so consumers reuse their existing parsing.
+func buildViewOncePlaceholderEvent(ctx context.Context, client *whatsmeow.Client, evt *events.UndecryptableMessage) map[string]any {
+	payload := map[string]any{
+		"id":          evt.Info.ID,
+		"timestamp":   evt.Info.Timestamp.Format(time.RFC3339),
+		"is_from_me":  evt.Info.IsFromMe,
+		"view_once":   true,
+		"unavailable": true,
+	}
+	buildFromFields(ctx, client, &evt.Info, payload)
+	addSenderDisplayName(ctx, client, payload, evt.Info.IsFromMe, evt.Info.PushName)
+	if pushname := evt.Info.PushName; pushname != "" {
+		payload["from_name"] = pushname
+	}
+
+	envelope := map[string]any{
+		"event":   EventTypeMessage,
+		"payload": payload,
+	}
+	if client != nil && client.Store != nil && client.Store.ID != nil {
+		deviceJID := NormalizeJIDFromLID(ctx, client.Store.ID.ToNonAD(), client)
+		envelope["device_id"] = deviceJID.ToNonAD().String()
+	}
+	return envelope
 }
 
 func handleDeleteForMe(ctx context.Context, evt *events.DeleteForMe, chatStorageRepo domainChatStorage.IChatStorageRepository, deviceID string, client *whatsmeow.Client) {

--- a/src/infrastructure/whatsapp/event_handler_viewonce_test.go
+++ b/src/infrastructure/whatsapp/event_handler_viewonce_test.go
@@ -6,6 +6,10 @@ import (
 	"time"
 
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
@@ -23,6 +27,21 @@ func ensureTestLogger(t *testing.T) {
 	t.Cleanup(func() { log = prev })
 }
 
+// loggedInJID is the device JID the fake client reports as logged in. It
+// deliberately differs from the alias handed to the device-scoped wrapper in
+// these tests: the placeholder must be partitioned by the logged-in JID, which
+// is what CreateMessage and the REST chat queries use.
+const loggedInJID = "628987654321@s.whatsapp.net"
+
+// fakeLoggedInClient builds the minimum client the placeholder path reads: a
+// store carrying the logged-in device JID (with a device suffix, to prove it is
+// stripped).
+func fakeLoggedInClient() *whatsmeow.Client {
+	jid := types.NewJID("628987654321", types.DefaultUserServer)
+	jid.Device = 3
+	return &whatsmeow.Client{Store: &store.Device{ID: &jid}}
+}
+
 // viewOnceFakeRepo overrides only the methods persistViewOncePlaceholder
 // touches; anything else panics via the embedded nil interface.
 type viewOnceFakeRepo struct {
@@ -30,11 +49,16 @@ type viewOnceFakeRepo struct {
 	storedChat    *domainChatStorage.Chat
 	storedMessage *domainChatStorage.Message
 	chatName      string
+	// nameDeviceID / getChatDeviceID record the partition key the resolver and
+	// the existing-chat lookup were asked about.
+	nameDeviceID    string
+	getChatDeviceID string
 }
 
-// The device-scoped wrapper resolves GetChat/name via the *ByDevice variants
-// on its base, injecting its own key — the fake implements those.
+// The placeholder path addresses the repository through the *ByDevice variants
+// with an explicit device id — the fake implements those.
 func (r *viewOnceFakeRepo) GetChatByDevice(deviceID, jid string) (*domainChatStorage.Chat, error) {
+	r.getChatDeviceID = deviceID
 	return nil, nil
 }
 func (r *viewOnceFakeRepo) StoreChat(chat *domainChatStorage.Chat) error {
@@ -46,6 +70,7 @@ func (r *viewOnceFakeRepo) StoreMessage(message *domainChatStorage.Message) erro
 	return nil
 }
 func (r *viewOnceFakeRepo) GetChatNameWithPushNameByDevice(deviceID string, jid types.JID, chatJID string, senderUser string, pushName string) string {
+	r.nameDeviceID = deviceID
 	return r.chatName
 }
 
@@ -72,13 +97,9 @@ func TestBuildViewOncePlaceholderEvent(t *testing.T) {
 
 	envelope := buildViewOncePlaceholderEvent(context.Background(), nil, evt)
 
-	if envelope["event"] != EventTypeMessage {
-		t.Fatalf("event = %v, want %q", envelope["event"], EventTypeMessage)
-	}
+	assert.Equal(t, EventTypeMessage, envelope["event"])
 	payload, ok := envelope["payload"].(map[string]any)
-	if !ok {
-		t.Fatalf("payload is %T, want map[string]any", envelope["payload"])
-	}
+	require.True(t, ok, "payload is %T, want map[string]any", envelope["payload"])
 
 	want := map[string]any{
 		"id":          "3EB0C127D7BACC83D6B9",
@@ -91,13 +112,9 @@ func TestBuildViewOncePlaceholderEvent(t *testing.T) {
 		"from_name":   "John Doe",
 	}
 	for key, expected := range want {
-		if payload[key] != expected {
-			t.Errorf("payload[%q] = %v, want %v", key, payload[key], expected)
-		}
+		assert.Equal(t, expected, payload[key], "payload[%q]", key)
 	}
-	if _, hasBody := payload["body"]; hasBody {
-		t.Errorf("payload must not carry a body: the content was never delivered")
-	}
+	assert.NotContains(t, payload, "body", "the content was never delivered")
 }
 
 func viewOnceEvent() *events.UndecryptableMessage {
@@ -117,31 +134,60 @@ func viewOnceEvent() *events.UndecryptableMessage {
 	}
 }
 
-// Persistence must go through the device-scoped wrapper with an EMPTY
-// DeviceID (the wrapper injects its partition key), leave media_type empty,
-// and resolve the chat name via the shared resolver — never a raw PushName.
+// The partition key is the logged-in JID, never the registration alias the
+// device-scoped wrapper may still carry. Anything short of a logged-in client
+// yields "" so the caller skips persistence instead of guessing.
+func TestPlaceholderDeviceID(t *testing.T) {
+	loggedIn := fakeLoggedInClient()
+	cases := []struct {
+		name   string
+		client *whatsmeow.Client
+		want   string
+	}{
+		{"nil client", nil, ""},
+		{"no store", &whatsmeow.Client{}, ""},
+		{"store without id (not logged in)", &whatsmeow.Client{Store: &store.Device{}}, ""},
+		{"logged in: device suffix stripped", loggedIn, loggedInJID},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, placeholderDeviceID(tc.client))
+		})
+	}
+}
+
+// Persistence must be partitioned by the LOGGED-IN JID (not the wrapper's
+// alias, whose partition nothing queries), carry the view_once_unavailable
+// discriminator so history importers can flag the Chatwoot link, and resolve
+// the chat name via the shared device-scoped resolver — never a raw PushName.
 func TestPersistViewOncePlaceholder(t *testing.T) {
+	fake := &viewOnceFakeRepo{chatName: "resolved-name"}
+	repo := newDeviceChatStorage("device-alias", fake)
+
+	persistViewOncePlaceholder(context.Background(), viewOnceEvent(), repo, fakeLoggedInClient())
+
+	require.NotNil(t, fake.storedChat, "chat not persisted")
+	require.NotNil(t, fake.storedMessage, "message not persisted")
+	assert.Equal(t, loggedInJID, fake.storedChat.DeviceID)
+	assert.Equal(t, loggedInJID, fake.storedMessage.DeviceID)
+	assert.Equal(t, loggedInJID, fake.nameDeviceID, "name resolver must be asked about the logged-in partition")
+	assert.Equal(t, loggedInJID, fake.getChatDeviceID, "existing-chat lookup must read the logged-in partition")
+	assert.Equal(t, "resolved-name", fake.storedChat.Name)
+	assert.Equal(t, domainChatStorage.MediaTypeViewOnceUnavailable, fake.storedMessage.MediaType)
+	assert.Equal(t, viewOncePlaceholderNotice, fake.storedMessage.Content)
+}
+
+// Without a logged-in client there is no trustworthy partition key, so the
+// placeholder is dropped rather than written somewhere nothing reads. The
+// webhook forward still happens; only storage is skipped.
+func TestPersistViewOncePlaceholderWithoutClientIsNoOp(t *testing.T) {
 	fake := &viewOnceFakeRepo{chatName: "resolved-name"}
 	repo := newDeviceChatStorage("device-alias", fake)
 
 	persistViewOncePlaceholder(context.Background(), viewOnceEvent(), repo, nil)
 
-	if fake.storedChat == nil || fake.storedMessage == nil {
-		t.Fatalf("chat/message not persisted: %+v %+v", fake.storedChat, fake.storedMessage)
-	}
-	if fake.storedChat.DeviceID != "device-alias" || fake.storedMessage.DeviceID != "device-alias" {
-		t.Fatalf("partition mismatch: chat=%q message=%q (both must be the wrapper's key)",
-			fake.storedChat.DeviceID, fake.storedMessage.DeviceID)
-	}
-	if fake.storedChat.Name != "resolved-name" {
-		t.Fatalf("chat name must come from the shared resolver, got %q", fake.storedChat.Name)
-	}
-	if fake.storedMessage.MediaType != "" {
-		t.Fatalf("placeholder must not carry a media_type, got %q", fake.storedMessage.MediaType)
-	}
-	if fake.storedMessage.Content != viewOncePlaceholderNotice {
-		t.Fatalf("unexpected content %q", fake.storedMessage.Content)
-	}
+	assert.Nil(t, fake.storedChat)
+	assert.Nil(t, fake.storedMessage)
 }
 
 // The event-handler closure can hold a long-canceled login request context;
@@ -154,9 +200,7 @@ func TestHandleUndecryptableMessagePersistsUnderCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already canceled, like a finished login request
 
-	handleUndecryptableMessage(ctx, viewOnceEvent(), repo, nil)
+	handleUndecryptableMessage(ctx, viewOnceEvent(), repo, fakeLoggedInClient())
 
-	if fake.storedMessage == nil {
-		t.Fatalf("placeholder was not persisted under a canceled parent context")
-	}
+	assert.NotNil(t, fake.storedMessage, "placeholder was not persisted under a canceled parent context")
 }

--- a/src/infrastructure/whatsapp/event_handler_viewonce_test.go
+++ b/src/infrastructure/whatsapp/event_handler_viewonce_test.go
@@ -5,9 +5,45 @@ import (
 	"testing"
 	"time"
 
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
+	waLog "go.mau.fi/whatsmeow/util/log"
 )
+
+// The package logger is only wired up at runtime (database.go); the handler
+// under test logs unconditionally.
+func ensureTestLogger() {
+	if log == nil {
+		log = waLog.Stdout("test", "ERROR", false)
+	}
+}
+
+// viewOnceFakeRepo overrides only the methods persistViewOncePlaceholder
+// touches; anything else panics via the embedded nil interface.
+type viewOnceFakeRepo struct {
+	domainChatStorage.IChatStorageRepository
+	storedChat    *domainChatStorage.Chat
+	storedMessage *domainChatStorage.Message
+	chatName      string
+}
+
+// The device-scoped wrapper resolves GetChat/name via the *ByDevice variants
+// on its base, injecting its own key — the fake implements those.
+func (r *viewOnceFakeRepo) GetChatByDevice(deviceID, jid string) (*domainChatStorage.Chat, error) {
+	return nil, nil
+}
+func (r *viewOnceFakeRepo) StoreChat(chat *domainChatStorage.Chat) error {
+	r.storedChat = chat
+	return nil
+}
+func (r *viewOnceFakeRepo) StoreMessage(message *domainChatStorage.Message) error {
+	r.storedMessage = message
+	return nil
+}
+func (r *viewOnceFakeRepo) GetChatNameWithPushNameByDevice(deviceID string, jid types.JID, chatJID string, senderUser string, pushName string) string {
+	return r.chatName
+}
 
 // A view-once "unavailable" placeholder (WhatsApp withholds view-once content
 // from linked devices) must surface as a `message` event with view_once and
@@ -57,5 +93,66 @@ func TestBuildViewOncePlaceholderEvent(t *testing.T) {
 	}
 	if _, hasBody := payload["body"]; hasBody {
 		t.Errorf("payload must not carry a body: the content was never delivered")
+	}
+}
+
+func viewOnceEvent() *events.UndecryptableMessage {
+	return &events.UndecryptableMessage{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     types.NewJID("628123456789", types.DefaultUserServer),
+				Sender:   types.NewJID("628123456789", types.DefaultUserServer),
+				IsFromMe: false,
+			},
+			ID:        "3EB0C127D7BACC83D6C1",
+			Timestamp: time.Date(2023, 10, 15, 11, 41, 0, 0, time.UTC),
+			PushName:  "John Doe",
+		},
+		IsUnavailable:   true,
+		UnavailableType: events.UnavailableTypeViewOnce,
+	}
+}
+
+// Persistence must go through the device-scoped wrapper with an EMPTY
+// DeviceID (the wrapper injects its partition key), leave media_type empty,
+// and resolve the chat name via the shared resolver — never a raw PushName.
+func TestPersistViewOncePlaceholder(t *testing.T) {
+	fake := &viewOnceFakeRepo{chatName: "resolved-name"}
+	repo := newDeviceChatStorage("device-alias", fake)
+
+	persistViewOncePlaceholder(context.Background(), viewOnceEvent(), repo, nil)
+
+	if fake.storedChat == nil || fake.storedMessage == nil {
+		t.Fatalf("chat/message not persisted: %+v %+v", fake.storedChat, fake.storedMessage)
+	}
+	if fake.storedChat.DeviceID != "device-alias" || fake.storedMessage.DeviceID != "device-alias" {
+		t.Fatalf("partition mismatch: chat=%q message=%q (both must be the wrapper's key)",
+			fake.storedChat.DeviceID, fake.storedMessage.DeviceID)
+	}
+	if fake.storedChat.Name != "resolved-name" {
+		t.Fatalf("chat name must come from the shared resolver, got %q", fake.storedChat.Name)
+	}
+	if fake.storedMessage.MediaType != "" {
+		t.Fatalf("placeholder must not carry a media_type, got %q", fake.storedMessage.MediaType)
+	}
+	if fake.storedMessage.Content != viewOncePlaceholderNotice {
+		t.Fatalf("unexpected content %q", fake.storedMessage.Content)
+	}
+}
+
+// The event-handler closure can hold a long-canceled login request context;
+// persistence must still happen (the handler detaches a bounded context).
+func TestHandleUndecryptableMessagePersistsUnderCanceledContext(t *testing.T) {
+	ensureTestLogger()
+	fake := &viewOnceFakeRepo{chatName: "n"}
+	repo := newDeviceChatStorage("device-alias", fake)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled, like a finished login request
+
+	handleUndecryptableMessage(ctx, viewOnceEvent(), repo, nil)
+
+	if fake.storedMessage == nil {
+		t.Fatalf("placeholder was not persisted under a canceled parent context")
 	}
 }

--- a/src/infrastructure/whatsapp/event_handler_viewonce_test.go
+++ b/src/infrastructure/whatsapp/event_handler_viewonce_test.go
@@ -12,11 +12,15 @@ import (
 )
 
 // The package logger is only wired up at runtime (database.go); the handler
-// under test logs unconditionally.
-func ensureTestLogger() {
+// under test logs unconditionally. Restores the previous value on cleanup so
+// no test state leaks (tests that mutate package globals restore them).
+func ensureTestLogger(t *testing.T) {
+	t.Helper()
+	prev := log
 	if log == nil {
 		log = waLog.Stdout("test", "ERROR", false)
 	}
+	t.Cleanup(func() { log = prev })
 }
 
 // viewOnceFakeRepo overrides only the methods persistViewOncePlaceholder
@@ -143,7 +147,7 @@ func TestPersistViewOncePlaceholder(t *testing.T) {
 // The event-handler closure can hold a long-canceled login request context;
 // persistence must still happen (the handler detaches a bounded context).
 func TestHandleUndecryptableMessagePersistsUnderCanceledContext(t *testing.T) {
-	ensureTestLogger()
+	ensureTestLogger(t)
 	fake := &viewOnceFakeRepo{chatName: "n"}
 	repo := newDeviceChatStorage("device-alias", fake)
 

--- a/src/infrastructure/whatsapp/event_handler_viewonce_test.go
+++ b/src/infrastructure/whatsapp/event_handler_viewonce_test.go
@@ -1,0 +1,61 @@
+package whatsapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// A view-once "unavailable" placeholder (WhatsApp withholds view-once content
+// from linked devices) must surface as a `message` event with view_once and
+// unavailable flags and the regular from/chat_id fields, so consumers can
+// render the same notice WhatsApp Web shows.
+func TestBuildViewOncePlaceholderEvent(t *testing.T) {
+	ts := time.Date(2023, 10, 15, 11, 41, 0, 0, time.UTC)
+	evt := &events.UndecryptableMessage{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     types.NewJID("628123456789", types.DefaultUserServer),
+				Sender:   types.NewJID("628123456789", types.DefaultUserServer),
+				IsFromMe: false,
+			},
+			ID:        "3EB0C127D7BACC83D6B9",
+			Timestamp: ts,
+			PushName:  "John Doe",
+		},
+		IsUnavailable:   true,
+		UnavailableType: events.UnavailableTypeViewOnce,
+	}
+
+	envelope := buildViewOncePlaceholderEvent(context.Background(), nil, evt)
+
+	if envelope["event"] != EventTypeMessage {
+		t.Fatalf("event = %v, want %q", envelope["event"], EventTypeMessage)
+	}
+	payload, ok := envelope["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload is %T, want map[string]any", envelope["payload"])
+	}
+
+	want := map[string]any{
+		"id":          "3EB0C127D7BACC83D6B9",
+		"timestamp":   ts.Format(time.RFC3339),
+		"is_from_me":  false,
+		"view_once":   true,
+		"unavailable": true,
+		"chat_id":     "628123456789@s.whatsapp.net",
+		"from":        "628123456789@s.whatsapp.net",
+		"from_name":   "John Doe",
+	}
+	for key, expected := range want {
+		if payload[key] != expected {
+			t.Errorf("payload[%q] = %v, want %v", key, payload[key], expected)
+		}
+	}
+	if _, hasBody := payload["body"]; hasBody {
+		t.Errorf("payload must not carry a body: the content was never delivered")
+	}
+}

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -100,7 +100,7 @@ func buildEventPayload(ctx context.Context, client *whatsmeow.Client, evt *event
 	payload["is_from_me"] = evt.Info.IsFromMe
 
 	// Build from/from_lid fields
-	buildFromFields(ctx, client, evt, payload)
+	buildFromFields(ctx, client, &evt.Info, payload)
 	addSenderDisplayName(ctx, client, payload, evt.Info.IsFromMe, evt.Info.PushName)
 
 	// Set from_name (pushname)
@@ -252,15 +252,15 @@ func populatedMessageFields(msg *waE2E.Message) []string {
 	return names
 }
 
-func buildFromFields(ctx context.Context, client *whatsmeow.Client, evt *events.Message, payload map[string]any) {
-	chatJID := evt.Info.Chat.ToNonAD()
+func buildFromFields(ctx context.Context, client *whatsmeow.Client, info *types.MessageInfo, payload map[string]any) {
+	chatJID := info.Chat.ToNonAD()
 	if chatJID.Server == "lid" {
 		payload["chat_lid"] = chatJID.String()
 		chatJID = NormalizeJIDFromLID(ctx, chatJID, client).ToNonAD()
 	}
 	payload["chat_id"] = chatJID.String()
 
-	senderJID := evt.Info.Sender
+	senderJID := info.Sender
 	if senderJID.Server == "lid" {
 		payload["from_lid"] = senderJID.ToNonAD().String()
 	}

--- a/src/infrastructure/whatsapp/event_message_handler.go
+++ b/src/infrastructure/whatsapp/event_message_handler.go
@@ -51,7 +51,7 @@ func handleMessage(ctx context.Context, evt *events.Message, chatStorageRepo dom
 	handleImageMessage(ctx, evt, client)
 
 	// Auto-mark message as read if configured
-	handleAutoMarkRead(ctx, evt, client)
+	handleAutoMarkRead(ctx, &evt.Info, client)
 
 	// Handle auto-reply if configured
 	handleAutoReply(ctx, evt, chatStorageRepo, client)
@@ -93,9 +93,12 @@ func handleImageMessage(ctx context.Context, evt *events.Message, client *whatsm
 	}
 }
 
-func handleAutoMarkRead(ctx context.Context, evt *events.Message, client *whatsmeow.Client) {
+// handleAutoMarkRead takes the MessageInfo (not the full event) so non-Message
+// events that still represent an incoming message — e.g. the view-once
+// unavailable placeholder — can honor the operator's auto-mark-read setting.
+func handleAutoMarkRead(ctx context.Context, info *types.MessageInfo, client *whatsmeow.Client) {
 	// Only mark read if auto-mark read is enabled and message is incoming
-	if !config.WhatsappAutoMarkRead || evt.Info.IsFromMe {
+	if !config.WhatsappAutoMarkRead || info.IsFromMe {
 		return
 	}
 
@@ -104,15 +107,15 @@ func handleAutoMarkRead(ctx context.Context, evt *events.Message, client *whatsm
 	}
 
 	// Mark the message as read
-	messageIDs := []types.MessageID{evt.Info.ID}
+	messageIDs := []types.MessageID{info.ID}
 	timestamp := time.Now()
-	chat := evt.Info.Chat
-	sender := evt.Info.Sender
+	chat := info.Chat
+	sender := info.Sender
 
 	if err := client.MarkRead(ctx, messageIDs, timestamp, chat, sender); err != nil {
-		log.Warnf("Failed to mark message %s as read: %v", evt.Info.ID, err)
+		log.Warnf("Failed to mark message %s as read: %v", info.ID, err)
 	} else {
-		log.Debugf("Marked message %s as read", evt.Info.ID)
+		log.Debugf("Marked message %s as read", info.ID)
 	}
 }
 

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -993,6 +993,9 @@ func buildChatwootForwardMessageLink(deviceID string, configID int64, accountID 
 	}
 	chatJID, _ := data["chat_id"].(string)
 
+	viewOnce, _ := data["view_once"].(bool)
+	unavailable, _ := data["unavailable"].(bool)
+
 	return &domainChatStorage.ChatwootMessageLink{
 		DeviceID:                     deviceID,
 		WhatsAppMessageID:            waMessageID,
@@ -1004,9 +1007,26 @@ func buildChatwootForwardMessageLink(deviceID string, configID int64, accountID 
 		SourceID:                     opts.SourceID,
 		Direction:                    chatwootMessageTypeFromPayload(data),
 		IsRead:                       false,
+		IsViewOncePlaceholder:        viewOnce && unavailable,
 		ChatwootConfigID:             configID,
 		ChatwootAccountID:            accountID,
 	}
+}
+
+// chatwootLinkSkipsForward decides whether an existing message link suppresses
+// this forward. Normally yes (dedup), with one exception: a link created from a
+// view-once "unavailable" placeholder may be UPGRADED by a later delivery of
+// the real content (same wa_message_id, no `unavailable` flag) — the recovered
+// media must not be permanently lost behind the notice.
+func chatwootLinkSkipsForward(existing *domainChatStorage.ChatwootMessageLink, data map[string]any) bool {
+	if existing == nil || existing.ChatwootMessageID == 0 {
+		return false
+	}
+	unavailable, _ := data["unavailable"].(bool)
+	if existing.IsViewOncePlaceholder && !unavailable {
+		return false
+	}
+	return true
 }
 
 func extractReceiptMessageIDs(data map[string]any) []string {
@@ -1315,9 +1335,15 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 				logrus.Errorf("Chatwoot: Failed to lookup message link for %s: %v", waMessageID, err)
 				return err
 			}
-			if existing != nil && existing.ChatwootMessageID != 0 {
+			if chatwootLinkSkipsForward(existing, data) {
 				logrus.Debugf("Chatwoot: Skipping already-linked message %s -> %d", waMessageID, existing.ChatwootMessageID)
 				return nil
+			}
+			if existing != nil && existing.ChatwootMessageID != 0 {
+				// Placeholder upgrade: the notice stays in the Chatwoot
+				// conversation; the recovered content lands as a new message
+				// and the link below is re-pointed at it.
+				logrus.Infof("Chatwoot: upgrading view-once placeholder %s with recovered content", waMessageID)
 			}
 		}
 	}

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -552,6 +552,14 @@ func buildChatwootMessageContent(data map[string]any, isGroup bool, fromName str
 		}
 	}
 
+	// View-once "unavailable" placeholder: the content is intentionally
+	// withheld from linked devices, so there is nothing to attach — render the
+	// same notice WhatsApp Web shows instead of "(Unsupported message type)".
+	if viewOnce, _ := data["view_once"].(bool); viewOnce && content == "" && len(attachments) == 0 {
+		content = "(View once message — for privacy reasons it can only be opened on the phone)"
+		logrus.Info("Chatwoot: view-once placeholder, using notice content")
+	}
+
 	// Handle empty content
 	if content == "" && len(attachments) == 0 {
 		content = "(Unsupported message type)"

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -1328,6 +1328,7 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 	info.IsFromMe = chatwootMessageTypeFromPayload(data) == "outgoing"
 
 	// Sync to Chatwoot
+	var upgradeClaimWaID string
 	if eventName == "message" && deviceID != "" && linkRepo != nil {
 		if waMessageID, _ := data["id"].(string); waMessageID != "" {
 			existing, err := linkRepo.GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID)
@@ -1340,9 +1341,22 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 				return nil
 			}
 			if existing != nil && existing.ChatwootMessageID != 0 {
-				// Placeholder upgrade: the notice stays in the Chatwoot
-				// conversation; the recovered content lands as a new message
-				// and the link below is re-pointed at it.
+				// Placeholder upgrade: claim it atomically FIRST — two
+				// concurrent recovered deliveries would otherwise both pass
+				// the check above and create duplicate Chatwoot messages.
+				// The winner syncs; losers are ordinary duplicates. On a
+				// failed forward the claim is released so the retry (or a
+				// later delivery) can upgrade again.
+				claimed, claimErr := linkRepo.ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID)
+				if claimErr != nil {
+					logrus.Errorf("Chatwoot: Failed to claim placeholder upgrade for %s: %v", waMessageID, claimErr)
+					return claimErr
+				}
+				if !claimed {
+					logrus.Debugf("Chatwoot: placeholder %s already claimed by a concurrent upgrade", waMessageID)
+					return nil
+				}
+				upgradeClaimWaID = waMessageID
 				logrus.Infof("Chatwoot: upgrading view-once placeholder %s with recovered content", waMessageID)
 			}
 		}
@@ -1350,6 +1364,11 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 
 	result, err := syncMessageToChatwoot(cw, info, content, attachments, msgOpts)
 	if err != nil {
+		if upgradeClaimWaID != "" {
+			if relErr := linkRepo.ReleaseViewOncePlaceholderUpgrade(deviceID, upgradeClaimWaID); relErr != nil {
+				logrus.Errorf("Chatwoot: Failed to release placeholder claim for %s: %v", upgradeClaimWaID, relErr)
+			}
+		}
 		return err
 	}
 	if eventName == "message" && linkRepo != nil {

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -555,8 +555,18 @@ func buildChatwootMessageContent(data map[string]any, isGroup bool, fromName str
 	// View-once "unavailable" placeholder: the content is intentionally
 	// withheld from linked devices, so there is nothing to attach — render the
 	// same notice WhatsApp Web shows instead of "(Unsupported message type)".
-	if viewOnce, _ := data["view_once"].(bool); viewOnce && content == "" && len(attachments) == 0 {
+	// Gated on BOTH flags: a delivered view-once whose media extraction failed
+	// has view_once without unavailable, and must keep the generic fallback
+	// rather than masquerade as a privacy withholding.
+	viewOnce, _ := data["view_once"].(bool)
+	unavailable, _ := data["unavailable"].(bool)
+	if viewOnce && unavailable && content == "" && len(attachments) == 0 {
 		content = "(View once message — for privacy reasons it can only be opened on the phone)"
+		// The group-prefix block above only runs for non-empty content, so a
+		// group placeholder would otherwise reach Chatwoot anonymous.
+		if prefixGroupSender {
+			content = senderLabel + ": " + content
+		}
 		logrus.Info("Chatwoot: view-once placeholder, using notice content")
 	}
 

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -48,6 +48,13 @@ var (
 // reasonable concurrency (64 shards means max 64 concurrent contact operations).
 const mutexShardCount = 64
 
+// chatwootForwardTimeout bounds the detached Chatwoot forward goroutine. A
+// single forward can chain several Chatwoot calls (contact, conversation,
+// message, attachment uploads), so it is generous compared to the webhook
+// delivery timeout — it exists to stop a wedged request from leaking the
+// goroutine, not to police latency.
+const chatwootForwardTimeout = 60 * time.Second
+
 // contactMutexShards provides sharded locks to prevent race conditions when creating Chatwoot contacts.
 // This approach prevents memory leaks that would occur with a sync.Map that grows indefinitely.
 var contactMutexShards [mutexShardCount]sync.Mutex
@@ -138,7 +145,19 @@ func forwardPayloadToConfiguredWebhooks(ctx context.Context, payload map[string]
 	}
 
 	if chatwootAllowed {
-		go forwardToChatwoot(ctx, payload, eventName)
+		// The Chatwoot forward outlives this function: callers are free to
+		// cancel ctx the moment it returns (the view-once placeholder handler
+		// does exactly that, with a `defer cancel()` around its forward), which
+		// would abort the child's in-flight Chatwoot HTTP calls with "context
+		// canceled" mid-conversation. Give the child a lifetime of its own —
+		// values (device instance, link repository) are preserved, only the
+		// cancelation is dropped — and bound it so a stuck request cannot leak
+		// the goroutine.
+		go func() {
+			chatwootCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), chatwootForwardTimeout)
+			defer cancel()
+			forwardToChatwoot(chatwootCtx, payload, eventName)
+		}()
 	}
 
 	return webhookErr
@@ -562,9 +581,7 @@ func buildChatwootMessageContent(data map[string]any, isGroup bool, fromName str
 	// Gated on BOTH flags: a delivered view-once whose media extraction failed
 	// has view_once without unavailable, and must keep the generic fallback
 	// rather than masquerade as a privacy withholding.
-	viewOnce, _ := data["view_once"].(bool)
-	unavailable, _ := data["unavailable"].(bool)
-	if viewOnce && unavailable && content == "" && len(attachments) == 0 {
+	if isViewOncePlaceholderPayload(data) && content == "" && len(attachments) == 0 {
 		content = viewOncePlaceholderNotice
 		// The group-prefix block above only runs for non-empty content, so a
 		// group placeholder would otherwise reach Chatwoot anonymous.
@@ -993,9 +1010,6 @@ func buildChatwootForwardMessageLink(deviceID string, configID int64, accountID 
 	}
 	chatJID, _ := data["chat_id"].(string)
 
-	viewOnce, _ := data["view_once"].(bool)
-	unavailable, _ := data["unavailable"].(bool)
-
 	return &domainChatStorage.ChatwootMessageLink{
 		DeviceID:                     deviceID,
 		WhatsAppMessageID:            waMessageID,
@@ -1007,26 +1021,71 @@ func buildChatwootForwardMessageLink(deviceID string, configID int64, accountID 
 		SourceID:                     opts.SourceID,
 		Direction:                    chatwootMessageTypeFromPayload(data),
 		IsRead:                       false,
-		IsViewOncePlaceholder:        viewOnce && unavailable,
+		IsViewOncePlaceholder:        isViewOncePlaceholderPayload(data),
 		ChatwootConfigID:             configID,
 		ChatwootAccountID:            accountID,
 	}
 }
 
-// chatwootLinkSkipsForward decides whether an existing message link suppresses
-// this forward. Normally yes (dedup), with one exception: a link created from a
-// view-once "unavailable" placeholder may be UPGRADED by a later delivery of
-// the real content (same wa_message_id, no `unavailable` flag) — the recovered
-// media must not be permanently lost behind the notice.
-func chatwootLinkSkipsForward(existing *domainChatStorage.ChatwootMessageLink, data map[string]any) bool {
-	if existing == nil || existing.ChatwootMessageID == 0 {
-		return false
+// chatwootLinkAction is what the pre-sync inspection of the message link
+// decides for a `message` forward.
+type chatwootLinkAction int
+
+const (
+	// chatwootLinkSkip: an equivalent message is already linked, or already in
+	// flight — drop this forward.
+	chatwootLinkSkip chatwootLinkAction = iota
+	// chatwootLinkReserve: nothing recorded yet — write a stub row claiming
+	// (device_id, wa_message_id) before the first network call, then sync.
+	chatwootLinkReserve
+	// chatwootLinkForward: another delivery of this message is in flight but
+	// this one carries strictly more (the real content over a reserved
+	// placeholder) — sync it too.
+	chatwootLinkForward
+	// chatwootLinkClaimUpgrade: a placeholder is already linked in Chatwoot and
+	// the real content just arrived — claim the upgrade atomically, then sync.
+	chatwootLinkClaimUpgrade
+)
+
+// decideChatwootLinkAction resolves what to do with a `message` forward given
+// the link row currently on file and whether THIS payload is a view-once
+// "unavailable" placeholder (notice only, no content).
+//
+// Two independent deliveries can carry the same wa_message_id: the withheld
+// view-once placeholder and, later, the recovered real content. The placeholder
+// must never permanently mask the content (hence the upgrade), and the two must
+// never race into duplicate Chatwoot messages (hence the reservation stub,
+// recognisable by chatwoot_message_id == 0).
+func decideChatwootLinkAction(existing *domainChatStorage.ChatwootMessageLink, isPlaceholder bool) chatwootLinkAction {
+	if existing == nil {
+		return chatwootLinkReserve
 	}
+	if existing.ChatwootMessageID == 0 {
+		// A reservation stub: the other delivery is mid-flight, no Chatwoot
+		// message exists yet.
+		if existing.IsViewOncePlaceholder && !isPlaceholder {
+			// Real content over a reserved placeholder: it must go through, the
+			// notice alone would lose the message.
+			return chatwootLinkForward
+		}
+		// Either the real content is already in flight (our notice is
+		// redundant) or the very same delivery is — the first caller wins.
+		return chatwootLinkSkip
+	}
+	if existing.IsViewOncePlaceholder && !isPlaceholder {
+		return chatwootLinkClaimUpgrade
+	}
+	return chatwootLinkSkip
+}
+
+// isViewOncePlaceholderPayload reports whether a forward payload is the
+// view-once "unavailable" placeholder. Both flags are required: a delivered
+// view-once whose media extraction failed carries view_once without
+// unavailable and is an ordinary message.
+func isViewOncePlaceholderPayload(data map[string]any) bool {
+	viewOnce, _ := data["view_once"].(bool)
 	unavailable, _ := data["unavailable"].(bool)
-	if existing.IsViewOncePlaceholder && !unavailable {
-		return false
-	}
-	return true
+	return viewOnce && unavailable
 }
 
 func extractReceiptMessageIDs(data map[string]any) []string {
@@ -1327,8 +1386,10 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 	}
 	info.IsFromMe = chatwootMessageTypeFromPayload(data) == "outgoing"
 
-	// Sync to Chatwoot
-	var upgradeClaimWaID string
+	// Sync to Chatwoot.
+	// upgradeClaimWaID: this call holds an atomic placeholder-upgrade claim.
+	// reservedStubWaID: this call wrote the reservation stub and owns rolling it back.
+	var upgradeClaimWaID, reservedStubWaID string
 	if eventName == "message" && deviceID != "" && linkRepo != nil {
 		if waMessageID, _ := data["id"].(string); waMessageID != "" {
 			existing, err := linkRepo.GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID)
@@ -1336,17 +1397,52 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 				logrus.Errorf("Chatwoot: Failed to lookup message link for %s: %v", waMessageID, err)
 				return err
 			}
-			if chatwootLinkSkipsForward(existing, data) {
-				logrus.Debugf("Chatwoot: Skipping already-linked message %s -> %d", waMessageID, existing.ChatwootMessageID)
+			isPlaceholder := isViewOncePlaceholderPayload(data)
+			switch decideChatwootLinkAction(existing, isPlaceholder) {
+			case chatwootLinkSkip:
+				logrus.Debugf("Chatwoot: Skipping already-linked message %s", waMessageID)
 				return nil
-			}
-			if existing != nil && existing.ChatwootMessageID != 0 {
+			case chatwootLinkReserve:
+				// Reserve (device_id, wa_message_id) BEFORE the first network
+				// call. Without it, a view-once placeholder and the recovered
+				// content arriving together would both read "no link yet" and
+				// create two Chatwoot messages. The primary key makes the
+				// second writer lose; it then sees a stub (chatwoot_message_id
+				// == 0) and decides from there. Every failure path below drops
+				// the stub again, so only a hard crash mid-forward can strand
+				// one — the same window in which the pre-existing code would
+				// have created a Chatwoot message with no link at all.
+				chatJID, _ := data["chat_id"].(string)
+				stub := &domainChatStorage.ChatwootMessageLink{
+					DeviceID:                     deviceID,
+					WhatsAppMessageID:            waMessageID,
+					WhatsAppChatJID:              chatJID,
+					ChatwootContactInboxSourceID: chatJID,
+					SourceID:                     msgOpts.SourceID,
+					Direction:                    chatwootMessageTypeFromPayload(data),
+					IsViewOncePlaceholder:        isPlaceholder,
+					ChatwootConfigID:             resolved.ConfigID,
+					ChatwootAccountID:            cw.AccountID,
+				}
+				if err := linkRepo.UpsertChatwootMessageLink(stub); err != nil {
+					logrus.Errorf("Chatwoot: Failed to reserve message link for %s: %v", waMessageID, err)
+					return err
+				}
+				reservedStubWaID = waMessageID
+			case chatwootLinkForward:
+				// The placeholder notice reserved the row and is still being
+				// posted; losing the recovered content is not an option, so
+				// both go out. Whichever finishes last owns the link — if that
+				// is the notice, a later redelivery of the content upgrades it
+				// again. Duplicated notice, never a lost message.
+				logrus.Debugf("Chatwoot: forwarding recovered content over reserved placeholder %s", waMessageID)
+			case chatwootLinkClaimUpgrade:
 				// Placeholder upgrade: claim it atomically FIRST — two
-				// concurrent recovered deliveries would otherwise both pass
-				// the check above and create duplicate Chatwoot messages.
-				// The winner syncs; losers are ordinary duplicates. On a
-				// failed forward the claim is released so the retry (or a
-				// later delivery) can upgrade again.
+				// concurrent recovered deliveries would otherwise both decide
+				// to upgrade and create duplicate Chatwoot messages. The winner
+				// syncs; losers are ordinary duplicates. On a failed forward the
+				// claim is released so the retry (or a later delivery) can
+				// upgrade again.
 				claimed, claimErr := linkRepo.ClaimViewOncePlaceholderUpgrade(deviceID, waMessageID)
 				if claimErr != nil {
 					logrus.Errorf("Chatwoot: Failed to claim placeholder upgrade for %s: %v", waMessageID, claimErr)
@@ -1364,21 +1460,50 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 
 	result, err := syncMessageToChatwoot(cw, info, content, attachments, msgOpts)
 	if err != nil {
-		if upgradeClaimWaID != "" {
-			if relErr := linkRepo.ReleaseViewOncePlaceholderUpgrade(deviceID, upgradeClaimWaID); relErr != nil {
-				logrus.Errorf("Chatwoot: Failed to release placeholder claim for %s: %v", upgradeClaimWaID, relErr)
-			}
-		}
+		releaseChatwootForwardReservation(linkRepo, deviceID, upgradeClaimWaID, reservedStubWaID)
 		return err
 	}
 	if eventName == "message" && linkRepo != nil {
 		if link := buildChatwootForwardMessageLink(deviceID, resolved.ConfigID, cw.AccountID, data, msgOpts, result); link != nil {
 			if err := linkRepo.UpsertChatwootMessageLink(link); err != nil {
 				logrus.Errorf("Chatwoot: Failed to store message link for %s: %v", link.WhatsAppMessageID, err)
+				// The Chatwoot message exists but the link does not describe it.
+				// Left alone, a consumed upgrade claim (or a stub still holding
+				// chatwoot_message_id == 0) makes every future delivery dedupe
+				// against a row that still points at the placeholder notice —
+				// the recovered content would be lost for good. Undo the
+				// reservation and surface the error so the caller enqueues a
+				// retry: an eventual duplicate message in Chatwoot is a far
+				// better outcome than a permanently missing one.
+				if upgradeClaimWaID != "" || reservedStubWaID != "" {
+					releaseChatwootForwardReservation(linkRepo, deviceID, upgradeClaimWaID, reservedStubWaID)
+					return err
+				}
 			}
 		}
 	}
 	return nil
+}
+
+// releaseChatwootForwardReservation undoes whatever this forward reserved
+// before syncing, so a retry is not mistaken for a duplicate and dropped: an
+// upgrade claim goes back to the placeholder state, a reservation stub is
+// removed entirely. Failures are logged only — the caller is already reporting
+// the original error.
+func releaseChatwootForwardReservation(linkRepo domainChatStorage.IChatStorageRepository, deviceID, upgradeClaimWaID, reservedStubWaID string) {
+	if linkRepo == nil {
+		return
+	}
+	if upgradeClaimWaID != "" {
+		if err := linkRepo.ReleaseViewOncePlaceholderUpgrade(deviceID, upgradeClaimWaID); err != nil {
+			logrus.Errorf("Chatwoot: Failed to release placeholder claim for %s: %v", upgradeClaimWaID, err)
+		}
+	}
+	if reservedStubWaID != "" {
+		if err := linkRepo.DeleteChatwootMessageLink(deviceID, reservedStubWaID); err != nil {
+			logrus.Errorf("Chatwoot: Failed to drop reserved message link for %s: %v", reservedStubWaID, err)
+		}
+	}
 }
 
 func forwardToChatwoot(ctx context.Context, payload map[string]any, eventName string) {

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -1389,7 +1389,10 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 	// Sync to Chatwoot.
 	// upgradeClaimWaID: this call holds an atomic placeholder-upgrade claim.
 	// reservedStubWaID: this call wrote the reservation stub and owns rolling it back.
-	var upgradeClaimWaID, reservedStubWaID string
+	// clearPlaceholderWaID: this call carries the recovered content over a stub
+	// another delivery reserved as a placeholder, so on success it owns clearing
+	// that discriminator.
+	var upgradeClaimWaID, reservedStubWaID, clearPlaceholderWaID string
 	if eventName == "message" && deviceID != "" && linkRepo != nil {
 		if waMessageID, _ := data["id"].(string); waMessageID != "" {
 			existing, err := linkRepo.GetChatwootMessageLinkByWhatsAppID(deviceID, waMessageID)
@@ -1436,6 +1439,7 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 				// is the notice, a later redelivery of the content upgrades it
 				// again. Duplicated notice, never a lost message.
 				logrus.Debugf("Chatwoot: forwarding recovered content over reserved placeholder %s", waMessageID)
+				clearPlaceholderWaID = waMessageID
 			case chatwootLinkClaimUpgrade:
 				// Placeholder upgrade: claim it atomically FIRST — two
 				// concurrent recovered deliveries would otherwise both decide
@@ -1479,6 +1483,16 @@ func syncPayloadToChatwoot(ctx context.Context, payload map[string]any, eventNam
 					releaseChatwootForwardReservation(linkRepo, deviceID, upgradeClaimWaID, reservedStubWaID)
 					return err
 				}
+			}
+		}
+		// The upsert above never touches the discriminator — it is claim state.
+		// This forward, though, just put the recovered content into Chatwoot over
+		// a row another delivery had reserved as a placeholder, so it is the one
+		// caller entitled to clear it. Leaving it set would invite the next
+		// redelivery to "upgrade" an already-upgraded message into a duplicate.
+		if clearPlaceholderWaID != "" {
+			if err := linkRepo.SetChatwootLinkViewOncePlaceholder(deviceID, clearPlaceholderWaID, false); err != nil {
+				logrus.Errorf("Chatwoot: Failed to clear placeholder flag for %s: %v", clearPlaceholderWaID, err)
 			}
 		}
 	}
@@ -1560,6 +1574,33 @@ func processDueChatwootForwardRetries(repo domainChatStorage.IChatStorageReposit
 	}
 }
 
+// chatwootForwardReservationTTL is how long a reservation stub may stay
+// unfinished before the sweep reclaims it. A stub lives only for the duration of
+// one forward — every failure path rolls it back — so the window only has to
+// clear the slowest legitimate forward (media download plus the Chatwoot
+// retries), with room to spare.
+const chatwootForwardReservationTTL = 15 * time.Minute
+
+// sweepStaleChatwootForwardReservations reclaims reservation stubs orphaned by a
+// process that died between reserving the row and completing (or rolling back)
+// the forward. In-process rollback cannot cover a crash, and an orphan is
+// permanent damage: decideChatwootLinkAction reads it as "another delivery is in
+// flight" and skips every redelivery, so the message never reaches Chatwoot.
+// Dropping the stub puts the message back in reach of the next delivery.
+func sweepStaleChatwootForwardReservations(repo domainChatStorage.IChatStorageRepository) {
+	if repo == nil {
+		return
+	}
+	removed, err := repo.DeleteStaleChatwootMessageLinkReservations(time.Now().Add(-chatwootForwardReservationTTL))
+	if err != nil {
+		logrus.Errorf("Chatwoot: Failed to reclaim stale forward reservations: %v", err)
+		return
+	}
+	if removed > 0 {
+		logrus.Warnf("Chatwoot: Reclaimed %d stale forward reservation(s) left by an interrupted forward", removed)
+	}
+}
+
 var chatwootForwardRetryWorkerOnce sync.Once
 
 func StartChatwootForwardRetryWorker(repo domainChatStorage.IChatStorageRepository) {
@@ -1571,6 +1612,9 @@ func StartChatwootForwardRetryWorker(repo domainChatStorage.IChatStorageReposito
 			ticker := time.NewTicker(30 * time.Second)
 			defer ticker.Stop()
 			for {
+				// Runs on the first iteration too: startup is exactly when the
+				// stubs of a killed process are waiting to be reclaimed.
+				sweepStaleChatwootForwardReservations(repo)
 				processDueChatwootForwardRetries(repo)
 				<-ticker.C
 			}

--- a/src/infrastructure/whatsapp/webhook_forward.go
+++ b/src/infrastructure/whatsapp/webhook_forward.go
@@ -475,6 +475,10 @@ func extractMediaPath(mediaData any) string {
 	return ""
 }
 
+// viewOncePlaceholderNotice is what both Chatwoot and chat storage render for
+// a view-once "unavailable" placeholder — mirrors WhatsApp Web's notice.
+const viewOncePlaceholderNotice = "(View once message — for privacy reasons it can only be opened on the phone)"
+
 // buildChatwootMessageContent extracts message body and attachments from the payload.
 // For group messages, prepends the sender name to the content.
 func buildChatwootMessageContent(data map[string]any, isGroup bool, fromName string) (content string, attachments []string) {
@@ -561,7 +565,7 @@ func buildChatwootMessageContent(data map[string]any, isGroup bool, fromName str
 	viewOnce, _ := data["view_once"].(bool)
 	unavailable, _ := data["unavailable"].(bool)
 	if viewOnce && unavailable && content == "" && len(attachments) == 0 {
-		content = "(View once message — for privacy reasons it can only be opened on the phone)"
+		content = viewOncePlaceholderNotice
 		// The group-prefix block above only runs for non-empty content, so a
 		// group placeholder would otherwise reach Chatwoot anonymous.
 		if prefixGroupSender {

--- a/src/infrastructure/whatsapp/webhook_forward_reservation_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_reservation_test.go
@@ -1,0 +1,62 @@
+package whatsapp
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reservationSweepTestRepo records the cutoff the sweep asks for, so a test can
+// assert the TTL window without reaching into the database.
+type reservationSweepTestRepo struct {
+	chatstorage.IChatStorageRepository
+	calls   int
+	cutoff  time.Time
+	removed int64
+	err     error
+}
+
+func (r *reservationSweepTestRepo) DeleteStaleChatwootMessageLinkReservations(olderThan time.Time) (int64, error) {
+	r.calls++
+	r.cutoff = olderThan
+	return r.removed, r.err
+}
+
+// The reservation stub is rolled back in-process on every failure path, which a
+// crash bypasses: the row survives with chatwoot_message_id == 0, and from then
+// on decideChatwootLinkAction reads it as a delivery in flight and skips every
+// redelivery. The retry worker sweeps those orphans, starting at boot — the
+// moment the stubs of the killed process are waiting to be reclaimed.
+func TestSweepStaleChatwootForwardReservations(t *testing.T) {
+	cases := []struct {
+		name      string
+		repo      *reservationSweepTestRepo
+		wantCalls int
+	}{
+		{"reclaims orphaned stubs", &reservationSweepTestRepo{removed: 2}, 1},
+		{"nothing to reclaim", &reservationSweepTestRepo{}, 1},
+		{"storage error is contained", &reservationSweepTestRepo{err: errors.New("db is gone")}, 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := time.Now()
+			sweepStaleChatwootForwardReservations(tc.repo)
+			require.Equal(t, tc.wantCalls, tc.repo.calls)
+
+			// Only stubs older than the TTL are orphans: a forward still running
+			// keeps a fresh row and must never be swept out from under itself.
+			assert.WithinDuration(t, before.Add(-chatwootForwardReservationTTL), tc.repo.cutoff, time.Minute)
+			assert.Greater(t, chatwootForwardReservationTTL, time.Minute,
+				"the window has to clear the slowest legitimate forward")
+		})
+	}
+
+	t.Run("no storage configured is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() { sweepStaleChatwootForwardReservations(nil) })
+	})
+}

--- a/src/infrastructure/whatsapp/webhook_forward_viewonce_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_viewonce_test.go
@@ -4,36 +4,102 @@ import (
 	"testing"
 
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/stretchr/testify/assert"
 )
 
-// A link created from a view-once "unavailable" placeholder must NOT suppress
-// a later delivery of the real content (same wa_message_id, no `unavailable`
-// flag) — that delivery upgrades the link. Every other existing link keeps the
-// normal dedupe behavior.
-func TestChatwootLinkSkipsForward(t *testing.T) {
-	placeholderLink := &domainChatStorage.ChatwootMessageLink{
-		ChatwootMessageID:     42,
-		IsViewOncePlaceholder: true,
-	}
-	regularLink := &domainChatStorage.ChatwootMessageLink{ChatwootMessageID: 42}
-	realPayload := map[string]any{"view_once": true}
-	placeholderPayload := map[string]any{"view_once": true, "unavailable": true}
-
+// isViewOncePlaceholderPayload must require BOTH flags: a delivered view-once
+// whose media extraction failed carries view_once alone and is an ordinary
+// message, not a privacy withholding.
+func TestIsViewOncePlaceholderPayload(t *testing.T) {
 	cases := []struct {
-		name     string
-		existing *domainChatStorage.ChatwootMessageLink
-		data     map[string]any
-		want     bool
+		name string
+		data map[string]any
+		want bool
 	}{
-		{"no existing link forwards", nil, realPayload, false},
-		{"zero-id link forwards", &domainChatStorage.ChatwootMessageLink{}, realPayload, false},
-		{"regular duplicate is skipped", regularLink, realPayload, true},
-		{"placeholder + real content upgrades (not skipped)", placeholderLink, realPayload, false},
-		{"placeholder redelivered as placeholder is skipped", placeholderLink, placeholderPayload, true},
+		{"both flags", map[string]any{"view_once": true, "unavailable": true}, true},
+		{"view_once only", map[string]any{"view_once": true}, false},
+		{"unavailable only", map[string]any{"unavailable": true}, false},
+		{"neither", map[string]any{}, false},
+		{"non-bool values", map[string]any{"view_once": "true", "unavailable": 1}, false},
 	}
 	for _, tc := range cases {
-		if got := chatwootLinkSkipsForward(tc.existing, tc.data); got != tc.want {
-			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isViewOncePlaceholderPayload(tc.data))
+		})
+	}
+}
+
+// The same wa_message_id can be delivered twice: once as the view-once
+// "unavailable" placeholder (notice only) and once as the recovered real
+// content. decideChatwootLinkAction has to let the content through — including
+// when it races the placeholder — without ever producing duplicates.
+func TestDecideChatwootLinkAction(t *testing.T) {
+	link := func(chatwootID int, placeholder bool) *domainChatStorage.ChatwootMessageLink {
+		return &domainChatStorage.ChatwootMessageLink{
+			ChatwootMessageID:     chatwootID,
+			IsViewOncePlaceholder: placeholder,
 		}
+	}
+
+	cases := []struct {
+		name          string
+		existing      *domainChatStorage.ChatwootMessageLink
+		isPlaceholder bool
+		want          chatwootLinkAction
+	}{
+		{
+			name:     "nothing on file reserves the row first",
+			existing: nil,
+			want:     chatwootLinkReserve,
+		},
+		{
+			name:          "nothing on file reserves for a placeholder too",
+			existing:      nil,
+			isPlaceholder: true,
+			want:          chatwootLinkReserve,
+		},
+		{
+			name:     "regular duplicate is skipped",
+			existing: link(42, false),
+			want:     chatwootLinkSkip,
+		},
+		{
+			name:     "linked placeholder + real content claims the upgrade",
+			existing: link(42, true),
+			want:     chatwootLinkClaimUpgrade,
+		},
+		{
+			name:          "linked placeholder redelivered as placeholder is skipped",
+			existing:      link(42, true),
+			isPlaceholder: true,
+			want:          chatwootLinkSkip,
+		},
+		{
+			name:     "reserved placeholder + real content still forwards",
+			existing: link(0, true),
+			want:     chatwootLinkForward,
+		},
+		{
+			name:          "reserved real content makes the placeholder redundant",
+			existing:      link(0, false),
+			isPlaceholder: true,
+			want:          chatwootLinkSkip,
+		},
+		{
+			name:     "reserved by an identical delivery: first writer wins",
+			existing: link(0, false),
+			want:     chatwootLinkSkip,
+		},
+		{
+			name:          "reserved placeholder redelivered as placeholder is skipped",
+			existing:      link(0, true),
+			isPlaceholder: true,
+			want:          chatwootLinkSkip,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, decideChatwootLinkAction(tc.existing, tc.isPlaceholder))
+		})
 	}
 }

--- a/src/infrastructure/whatsapp/webhook_forward_viewonce_test.go
+++ b/src/infrastructure/whatsapp/webhook_forward_viewonce_test.go
@@ -1,0 +1,39 @@
+package whatsapp
+
+import (
+	"testing"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+)
+
+// A link created from a view-once "unavailable" placeholder must NOT suppress
+// a later delivery of the real content (same wa_message_id, no `unavailable`
+// flag) — that delivery upgrades the link. Every other existing link keeps the
+// normal dedupe behavior.
+func TestChatwootLinkSkipsForward(t *testing.T) {
+	placeholderLink := &domainChatStorage.ChatwootMessageLink{
+		ChatwootMessageID:     42,
+		IsViewOncePlaceholder: true,
+	}
+	regularLink := &domainChatStorage.ChatwootMessageLink{ChatwootMessageID: 42}
+	realPayload := map[string]any{"view_once": true}
+	placeholderPayload := map[string]any{"view_once": true, "unavailable": true}
+
+	cases := []struct {
+		name     string
+		existing *domainChatStorage.ChatwootMessageLink
+		data     map[string]any
+		want     bool
+	}{
+		{"no existing link forwards", nil, realPayload, false},
+		{"zero-id link forwards", &domainChatStorage.ChatwootMessageLink{}, realPayload, false},
+		{"regular duplicate is skipped", regularLink, realPayload, true},
+		{"placeholder + real content upgrades (not skipped)", placeholderLink, realPayload, false},
+		{"placeholder redelivered as placeholder is skipped", placeholderLink, placeholderPayload, true},
+	}
+	for _, tc := range cases {
+		if got := chatwootLinkSkipsForward(tc.existing, tc.data); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

WhatsApp intentionally withholds view-once content from linked devices. When a contact sends a view-once photo/video, the primary phone receives it, but companion sessions often get only a server-side placeholder stanza — `<unavailable type="view_once">` with no `enc` children. whatsmeow surfaces this as `events.UndecryptableMessage{IsUnavailable: true, UnavailableType: events.UnavailableTypeViewOnce}`, and `handleUndecryptableMessage` currently drops it with a log line ("No webhook or storage entry is produced for it").

The result: webhook consumers never learn the contact sent anything at all — the message silently vanishes. WhatsApp Web uses this exact placeholder to render its *"You received a view once message. For privacy reasons, you can only open it on your phone."* notice, so the signal is meaningful and worth forwarding.

Note that `docs/webhook-payload.md` already documents a `view_once: true` payload, but that variant only covers senders whose client wraps content in a `ViewOnceMessage` that is delivered to companions. Modern clients frequently send the unavailable placeholder instead, which today produces no webhook event whatsoever (observed on a live v9.1.0 deployment: the phone shows the message, the container logs nothing).

## Change

- `handleUndecryptableMessage` now forwards a `message` event when `UnavailableType == view_once`, carrying `view_once: true` and `unavailable: true` plus the usual `id`/`timestamp`/`is_from_me`/`chat_id`/`from`/`from_name` fields — same field names as the regular message path, so consumers reuse their existing parsing. All other undecryptable kinds keep the previous log-only behavior.
- `buildFromFields` now takes `*types.MessageInfo` (its only dependency; single call site updated) so the placeholder path reuses the same chat/sender/LID normalization instead of duplicating it.
- Forwarding runs in a goroutine, mirroring `handleWebhookForward`, so the event loop is never blocked on webhook delivery.
- Docs: the unavailable placeholder variant is documented under *View Once Message*.

## Testing

- New unit test for the payload builder (`TestBuildViewOncePlaceholderEvent`).
- `go test ./infrastructure/whatsapp/` green, `go vet` clean.
- Running on a private deployment (image built from this branch) against a live paired number.
