### PR TITLE
fix(chatwoot): preserve query params in per-device webhook URL

### DIFF
--- a/src/ui/rest/chatwoot_config.go
+++ b/src/ui/rest/chatwoot_config.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
@@ -40,8 +41,11 @@ func maskAPIToken(token string) string {
 // Chatwoot inbox so agent replies route back to this device. Derived from the
 // configured public webhook base, or a relative path when none is set.
 func perDeviceWebhookURL(deviceID string) string {
-	if base := strings.TrimRight(strings.TrimSpace(config.ChatwootWebhookURL), "/"); base != "" {
-		return base + "/" + deviceID
+	if base := strings.TrimSpace(config.ChatwootWebhookURL); base != "" {
+		if webhookURL, err := url.JoinPath(base, deviceID); err == nil {
+			return webhookURL
+		}
+		return strings.TrimRight(base, "/") + "/" + deviceID
 	}
 	return strings.TrimRight(config.AppBasePath, "/") + "/chatwoot/webhook/" + deviceID
 }

--- a/src/ui/rest/chatwoot_config_url_test.go
+++ b/src/ui/rest/chatwoot_config_url_test.go
@@ -1,0 +1,24 @@
+package rest
+
+import (
+	"testing"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+)
+
+func TestPerDeviceWebhookURLPreservesQuery(t *testing.T) {
+	originalWebhookURL := config.ChatwootWebhookURL
+	originalBasePath := config.AppBasePath
+	t.Cleanup(func() {
+		config.ChatwootWebhookURL = originalWebhookURL
+		config.AppBasePath = originalBasePath
+	})
+
+	config.ChatwootWebhookURL = "https://gowa.testdomain.com/chatwoot/webhook?secret=the-web-secret"
+	config.AppBasePath = ""
+
+	const want = "https://gowa.testdomain.com/chatwoot/webhook/the-device-id?secret=the-web-secret"
+	if got := perDeviceWebhookURL("the-device-id"); got != want {
+		t.Fatalf("perDeviceWebhookURL() = %q, want %q", got, want)
+	}
+}

--- a/src/ui/rest/chatwoot_config_url_test.go
+++ b/src/ui/rest/chatwoot_config_url_test.go
@@ -9,10 +9,10 @@ import (
 func TestPerDeviceWebhookURLPreservesQuery(t *testing.T) {
 	originalWebhookURL := config.ChatwootWebhookURL
 	originalBasePath := config.AppBasePath
-	t.Cleanup(func() {
+	defer func() {
 		config.ChatwootWebhookURL = originalWebhookURL
 		config.AppBasePath = originalBasePath
-	})
+	}()
 
 	config.ChatwootWebhookURL = "https://gowa.testdomain.com/chatwoot/webhook?secret=the-web-secret"
 	config.AppBasePath = ""


### PR DESCRIPTION
## Context

- Fix the malformed `webhook_url` returned by `PUT /devices/{device_id}/chatwoot/config` when `CHATWOOT_WEBHOOK_URL` contains query parameters.
- Append the device ID with `net/url.JoinPath`, so it becomes part of the webhook path while existing parameters such as `?secret=...` remain unchanged.
- Keep the existing relative `APP_BASE_PATH` fallback unchanged.
- Add a regression test reproducing the exact URL reported in #800.

Before:

```text
https://gowa.testdomain.com/chatwoot/webhook?secret=the-web-secret/the-device-id
```

After:

```text
https://gowa.testdomain.com/chatwoot/webhook/the-device-id?secret=the-web-secret
```

## Test Results

- Confirmed the regression test fails against the previous string-concatenation implementation with the malformed URL from #800.
- Confirmed the regression test passes after switching to URL-aware path joining.
- Ran `gofmt` on the changed Go files.
- Verified the branch diff against `main`: 2 files changed, limited to the helper and its regression test.

Closes #800