### PR TITLE
Upgrade Go to 1.26 and update infrastructure configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Install cross-compilation toolchains
         run: |
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Branch: fix/chatwoot-postgres
 
 ## OVERVIEW
 
-Go WhatsApp Web Multi-Device is a Go 1.25.5 WhatsApp Web API server. MCP is not a separate mode: the `rest`
+Go WhatsApp Web Multi-Device is a Go 1.26.0 WhatsApp Web API server. MCP is not a separate mode: the `rest`
 command serves it at `/mcp` (streamable HTTP) whenever `config.McpEnabled` is true.
 It uses whatsmeow sessions, Fiber, plain Vue 3 modules, and SQLite-backed chat/session storage by default.
 
@@ -127,7 +127,7 @@ docker compose up --build
 
 ## NOTES
 
-- Docker builds use `docker/golang.Dockerfile`, Go `1.25-alpine3.23`, CGO, and a final non-root `gowauser` process after the entrypoint fixes volume ownership.
+- Docker builds use `docker/golang.Dockerfile`, Go `1.26-alpine3.23`, CGO, and a final non-root `gowauser` process after the entrypoint fixes volume ownership.
 - Docker Compose mounts root-level `./storages` and `./statics` into `/app`; direct local runs from `src/` use `src/storages` and `src/statics`.
 - Docker publish is tag/manual driven. Arch-specific `-amd`, `-arm`, and `-armv7` images are merged into a versioned manifest; `latest` is also promoted by workflows.
 - `release.yml` declares `workflow_dispatch`, but release jobs are still guarded to tag refs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,7 @@ services:
       context: .
       dockerfile: ./docker/golang.Dockerfile
     restart: "on-failure"
-    ports:
-      - "3000:3000"
+    network_mode: "host"
     env_file:
       - src/.env
     volumes:

--- a/docker/golang.Dockerfile
+++ b/docker/golang.Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.25-alpine3.23 AS builder
+FROM golang:1.26-alpine3.23 AS builder
 RUN apk add --no-cache gcc musl-dev gcompat
 WORKDIR /whatsapp
 
@@ -32,7 +32,7 @@ WORKDIR /app
 # Copy compiled from builder.
 COPY --from=builder /app/whatsapp /app/whatsapp
 COPY docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh && chown -R gowauser:gowa /app
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh && chown -R gowauser:gowa /app
 
 # Root only for entrypoint (ownership fix on volumes); process becomes gowauser.
 USER root

--- a/readme.md
+++ b/readme.md
@@ -293,7 +293,7 @@ Note: Command-line flags will override any values set in environment variables o
 
 ### System Requirements
 
-- **Go 1.25.5 or higher** (for building from source)
+- **Go 1.26.0 or higher** (for building from source)
 - **FFmpeg** (for media processing)
 
 ### Platform Support


### PR DESCRIPTION
- Update Go version to 1.26 in workflows, Dockerfiles, and documentation
- Change Docker network mode to host
- Fix potential CRLF issues in entrypoint script

# PR Title

## Context

- Explain briefly the changes about

## Test Results
<!--
- Attach the screenshot of the result or something
-->
- what you have done to test it
