### PR TITLE
fix(message): sync deletes to chat storage

### DIFF
--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -694,24 +694,26 @@ func (r *SQLiteRepository) loadMessageReactions(deviceID, chatJID string, messag
 	return nil
 }
 
-// DeleteMessage deletes a specific message
+// DeleteMessage deletes a specific message. Chatwoot links are intentionally
+// preserved so asynchronous revoke/delete forwarding can still resolve them.
 func (r *SQLiteRepository) DeleteMessage(id, chatJID string) error {
 	if _, err := r.db.Exec("DELETE FROM message_reactions WHERE message_id = ? AND chat_jid = ?", id, chatJID); err != nil {
 		return err
 	}
-	if _, err := r.db.Exec("DELETE FROM chatwoot_message_links WHERE wa_message_id = ? AND wa_chat_jid = ?", id, chatJID); err != nil {
+	if _, err := r.db.Exec("DELETE FROM message_edits WHERE original_message_id = ? AND chat_jid = ?", id, chatJID); err != nil {
 		return err
 	}
 	_, err := r.db.Exec("DELETE FROM messages WHERE id = ? AND chat_jid = ?", id, chatJID)
 	return err
 }
 
-// DeleteMessageByDevice deletes a specific message for a specific device
+// DeleteMessageByDevice deletes a specific message for a specific device.
+// Chatwoot links are intentionally preserved for asynchronous delete sync.
 func (r *SQLiteRepository) DeleteMessageByDevice(deviceID, id, chatJID string) error {
 	if _, err := r.db.Exec("DELETE FROM message_reactions WHERE message_id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID); err != nil {
 		return err
 	}
-	if _, err := r.db.Exec("DELETE FROM chatwoot_message_links WHERE wa_message_id = ? AND wa_chat_jid = ? AND device_id = ?", id, chatJID, deviceID); err != nil {
+	if _, err := r.db.Exec("DELETE FROM message_edits WHERE original_message_id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID); err != nil {
 		return err
 	}
 	_, err := r.db.Exec("DELETE FROM messages WHERE id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID)
@@ -1686,6 +1688,10 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 	// Store the full sender JID (user@server) to ensure consistency between received and sent messages
 	sender := normalizedSender.ToNonAD().String()
 
+	if revokedMessageID := extractRevokedMessageID(evt.Message); revokedMessageID != "" {
+		return r.DeleteMessageByDevice(deviceID, revokedMessageID, chatJID)
+	}
+
 	// Get appropriate chat name using pushname if available (device-scoped)
 	chatName := r.GetChatNameWithPushNameByDevice(deviceID, normalizedChatJID, chatJID, normalizedSender.User, evt.Info.PushName)
 
@@ -1781,6 +1787,17 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 
 	// Store the message
 	return r.StoreMessage(message)
+}
+
+func extractRevokedMessageID(msg *waE2E.Message) string {
+	if msg == nil {
+		return ""
+	}
+	protocolMessage := utils.UnwrapMessage(msg).GetProtocolMessage()
+	if protocolMessage == nil || protocolMessage.GetType() != waE2E.ProtocolMessage_REVOKE {
+		return ""
+	}
+	return protocolMessage.GetKey().GetID()
 }
 
 func extractEditedMessage(msg *waE2E.Message) *waE2E.Message {

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -697,27 +697,43 @@ func (r *SQLiteRepository) loadMessageReactions(deviceID, chatJID string, messag
 // DeleteMessage deletes a specific message. Chatwoot links are intentionally
 // preserved so asynchronous revoke/delete forwarding can still resolve them.
 func (r *SQLiteRepository) DeleteMessage(id, chatJID string) error {
-	if _, err := r.db.Exec("DELETE FROM message_reactions WHERE message_id = ? AND chat_jid = ?", id, chatJID); err != nil {
+	tx, err := r.db.Begin()
+	if err != nil {
 		return err
 	}
-	if _, err := r.db.Exec("DELETE FROM message_edits WHERE original_message_id = ? AND chat_jid = ?", id, chatJID); err != nil {
+	defer tx.Rollback()
+
+	if _, err := tx.Exec("DELETE FROM message_reactions WHERE message_id = ? AND chat_jid = ?", id, chatJID); err != nil {
 		return err
 	}
-	_, err := r.db.Exec("DELETE FROM messages WHERE id = ? AND chat_jid = ?", id, chatJID)
-	return err
+	if _, err := tx.Exec("DELETE FROM message_edits WHERE original_message_id = ? AND chat_jid = ?", id, chatJID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec("DELETE FROM messages WHERE id = ? AND chat_jid = ?", id, chatJID); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // DeleteMessageByDevice deletes a specific message for a specific device.
 // Chatwoot links are intentionally preserved for asynchronous delete sync.
 func (r *SQLiteRepository) DeleteMessageByDevice(deviceID, id, chatJID string) error {
-	if _, err := r.db.Exec("DELETE FROM message_reactions WHERE message_id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID); err != nil {
+	tx, err := r.db.Begin()
+	if err != nil {
 		return err
 	}
-	if _, err := r.db.Exec("DELETE FROM message_edits WHERE original_message_id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID); err != nil {
+	defer tx.Rollback()
+
+	if _, err := tx.Exec("DELETE FROM message_reactions WHERE message_id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID); err != nil {
 		return err
 	}
-	_, err := r.db.Exec("DELETE FROM messages WHERE id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID)
-	return err
+	if _, err := tx.Exec("DELETE FROM message_edits WHERE original_message_id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec("DELETE FROM messages WHERE id = ? AND chat_jid = ? AND device_id = ?", id, chatJID, deviceID); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // UpsertChatwootMessageLink records the stable mapping between a WhatsApp

--- a/src/infrastructure/chatstorage/sqlite_repository_delete_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_delete_test.go
@@ -101,3 +101,66 @@ func TestDeleteMessageByDevicePurgesContentButPreservesChatwootLink(t *testing.T
 	require.NotNil(t, link)
 	require.Equal(t, 101, link.ChatwootMessageID)
 }
+
+func TestDeleteMessageRollsBackDependentDeletesWhenMessageDeleteFails(t *testing.T) {
+	tests := []struct {
+		name   string
+		delete func(repo *SQLiteRepository, deviceID, messageID, chatJID string) error
+	}{
+		{
+			name: "unscoped",
+			delete: func(repo *SQLiteRepository, _, messageID, chatJID string) error {
+				return repo.DeleteMessage(messageID, chatJID)
+			},
+		},
+		{
+			name: "device scoped",
+			delete: func(repo *SQLiteRepository, deviceID, messageID, chatJID string) error {
+				return repo.DeleteMessageByDevice(deviceID, messageID, chatJID)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newTestSQLiteRepository(t)
+			deviceID := "device-a@s.whatsapp.net"
+			chatJID := "628123456789@s.whatsapp.net"
+			timestamp := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+
+			seedChatMessage(t, repo, deviceID, chatJID, "message-1", "latest content", timestamp)
+			seedReaction(t, repo, deviceID, chatJID, "message-1", "628111111111@s.whatsapp.net")
+			require.NoError(t, repo.StoreMessageEdit(&domainChatStorage.MessageEdit{
+				OriginalMessageID: "message-1",
+				EditEventID:       "edit-1",
+				ChatJID:           chatJID,
+				DeviceID:          deviceID,
+				Editor:            deviceID,
+				PreviousContent:   "original content",
+				NewContent:        "latest content",
+				EditedAt:          timestamp,
+			}))
+			_, err := repo.db.Exec(`
+				CREATE TRIGGER fail_target_message_delete
+				BEFORE DELETE ON messages
+				WHEN OLD.id = 'message-1'
+				BEGIN
+					SELECT RAISE(ABORT, 'forced message delete failure');
+				END
+			`)
+			require.NoError(t, err)
+
+			err = tc.delete(repo, deviceID, "message-1", chatJID)
+			require.ErrorContains(t, err, "forced message delete failure")
+
+			message, lookupErr := repo.GetMessageByIDAndDevice(deviceID, "message-1")
+			require.NoError(t, lookupErr)
+			require.NotNil(t, message)
+			require.Equal(t, 1, countMessageReactions(t, repo))
+
+			edits, editsErr := repo.GetMessageEdits("message-1", deviceID)
+			require.NoError(t, editsErr)
+			require.Len(t, edits, 1)
+		})
+	}
+}

--- a/src/infrastructure/chatstorage/sqlite_repository_delete_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_delete_test.go
@@ -1,0 +1,103 @@
+package chatstorage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
+	"github.com/stretchr/testify/require"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestCreateMessageRevokeDeletesTargetForActiveDevice(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "device-a@s.whatsapp.net"
+	otherDeviceID := "device-b@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+	timestamp := time.Date(2026, time.August, 22, 9, 0, 0, 0, time.UTC)
+
+	seedChatMessage(t, repo, deviceID, chatJID, "message-1", "remove me", timestamp)
+	seedChatMessage(t, repo, otherDeviceID, chatJID, "message-1", "keep me", timestamp)
+
+	ctx := whatsapp.ContextWithDevice(context.Background(), whatsapp.NewDeviceInstance(deviceID, nil, repo))
+	revoke := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:   types.NewJID("628123456789", types.DefaultUserServer),
+				Sender: types.NewJID("628123456789", types.DefaultUserServer),
+			},
+			ID:        "revoke-event-1",
+			Timestamp: timestamp.Add(time.Minute),
+		},
+		Message: &waE2E.Message{ProtocolMessage: &waE2E.ProtocolMessage{
+			Type: waE2E.ProtocolMessage_REVOKE.Enum(),
+			Key: &waCommon.MessageKey{
+				RemoteJID: proto.String(chatJID),
+				ID:        proto.String("message-1"),
+			},
+		}},
+	}
+
+	require.NoError(t, repo.CreateMessage(ctx, revoke))
+
+	deleted, err := repo.GetMessageByIDAndDevice(deviceID, "message-1")
+	require.NoError(t, err)
+	require.Nil(t, deleted)
+
+	preserved, err := repo.GetMessageByIDAndDevice(otherDeviceID, "message-1")
+	require.NoError(t, err)
+	require.NotNil(t, preserved)
+	require.Equal(t, "keep me", preserved.Content)
+}
+
+func TestDeleteMessageByDevicePurgesContentButPreservesChatwootLink(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "device-a@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+	timestamp := time.Date(2026, time.August, 22, 10, 0, 0, 0, time.UTC)
+
+	seedChatMessage(t, repo, deviceID, chatJID, "message-1", "latest content", timestamp)
+	seedReaction(t, repo, deviceID, chatJID, "message-1", "628111111111@s.whatsapp.net")
+	require.NoError(t, repo.StoreMessageEdit(&domainChatStorage.MessageEdit{
+		OriginalMessageID: "message-1",
+		EditEventID:       "edit-1",
+		ChatJID:           chatJID,
+		DeviceID:          deviceID,
+		Editor:            deviceID,
+		PreviousContent:   "sensitive original content",
+		NewContent:        "latest content",
+		EditedAt:          timestamp,
+	}))
+	require.NoError(t, repo.UpsertChatwootMessageLink(&domainChatStorage.ChatwootMessageLink{
+		DeviceID:               deviceID,
+		WhatsAppMessageID:      "message-1",
+		WhatsAppChatJID:        chatJID,
+		ChatwootMessageID:      101,
+		ChatwootConversationID: 202,
+		ChatwootInboxID:        303,
+		ChatwootConfigID:       404,
+		ChatwootAccountID:      505,
+	}))
+
+	require.NoError(t, repo.DeleteMessageByDevice(deviceID, "message-1", chatJID))
+
+	message, err := repo.GetMessageByIDAndDevice(deviceID, "message-1")
+	require.NoError(t, err)
+	require.Nil(t, message)
+
+	edits, err := repo.GetMessageEdits("message-1", deviceID)
+	require.NoError(t, err)
+	require.Empty(t, edits)
+	require.Zero(t, countMessageReactions(t, repo))
+
+	link, err := repo.GetChatwootMessageLinkByWhatsAppID(deviceID, "message-1")
+	require.NoError(t, err)
+	require.NotNil(t, link)
+	require.Equal(t, 101, link.ChatwootMessageID)
+}

--- a/src/usecase/message.go
+++ b/src/usecase/message.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/validations"
 	"github.com/sirupsen/logrus"
+	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/appstate"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/proto/waSyncAction"
@@ -24,12 +25,53 @@ import (
 
 type serviceMessage struct {
 	chatStorageRepo domainChatStorage.IChatStorageRepository
+	validateJIDFn   func(client *whatsmeow.Client, jid string) (types.JID, error)
+	sendMessageFn   func(ctx context.Context, client *whatsmeow.Client, recipient types.JID, message *waE2E.Message) (whatsmeow.SendResponse, error)
+	sendAppStateFn  func(ctx context.Context, client *whatsmeow.Client, patch appstate.PatchInfo) error
 }
 
 func NewMessageService(chatStorageRepo domainChatStorage.IChatStorageRepository) domainMessage.IMessageUsecase {
 	return &serviceMessage{
 		chatStorageRepo: chatStorageRepo,
 	}
+}
+
+func (service serviceMessage) validateJID(client *whatsmeow.Client, jid string) (types.JID, error) {
+	if service.validateJIDFn != nil {
+		return service.validateJIDFn(client, jid)
+	}
+	return utils.ValidateJidWithLogin(client, jid)
+}
+
+func (service serviceMessage) sendMessage(ctx context.Context, client *whatsmeow.Client, recipient types.JID, message *waE2E.Message) (whatsmeow.SendResponse, error) {
+	if service.sendMessageFn != nil {
+		return service.sendMessageFn(ctx, client, recipient, message)
+	}
+	return client.SendMessage(ctx, recipient, message)
+}
+
+func (service serviceMessage) sendAppState(ctx context.Context, client *whatsmeow.Client, patch appstate.PatchInfo) error {
+	if service.sendAppStateFn != nil {
+		return service.sendAppStateFn(ctx, client, patch)
+	}
+	return client.SendAppState(ctx, patch)
+}
+
+func (service serviceMessage) deleteStoredMessage(ctx context.Context, client *whatsmeow.Client, messageID, chatJID string) error {
+	deviceID := deviceIDFromContext(ctx)
+	if deviceID == "" && client != nil && client.Store != nil && client.Store.ID != nil {
+		deviceID = client.Store.ID.ToNonAD().String()
+	}
+	if deviceID == "" {
+		return fmt.Errorf("WhatsApp action succeeded, but local message %s could not be deleted without a device ID", messageID)
+	}
+	if service.chatStorageRepo == nil {
+		return fmt.Errorf("WhatsApp action succeeded, but local message %s could not be deleted without chat storage", messageID)
+	}
+	if err := service.chatStorageRepo.DeleteMessageByDevice(deviceID, messageID, chatJID); err != nil {
+		return fmt.Errorf("WhatsApp action succeeded, but failed to delete local message %s: %w", messageID, err)
+	}
+	return nil
 }
 
 func (service serviceMessage) MarkAsRead(ctx context.Context, request domainMessage.MarkAsReadRequest) (response domainMessage.GenericResponse, err error) {
@@ -128,7 +170,7 @@ func (service serviceMessage) RevokeMessage(ctx context.Context, request domainM
 		return response, pkgError.ErrWaCLI
 	}
 
-	dataWaRecipient, err := utils.ValidateJidWithLogin(client, request.Phone)
+	dataWaRecipient, err := service.validateJID(client, request.Phone)
 	if err != nil {
 		return response, err
 	}
@@ -154,8 +196,11 @@ func (service serviceMessage) RevokeMessage(ctx context.Context, request domainM
 		}
 	}
 
-	ts, err := client.SendMessage(ctx, dataWaRecipient, client.BuildRevoke(dataWaRecipient, senderJID, request.MessageID))
+	ts, err := service.sendMessage(ctx, client, dataWaRecipient, client.BuildRevoke(dataWaRecipient, senderJID, request.MessageID))
 	if err != nil {
+		return response, err
+	}
+	if err := service.deleteStoredMessage(ctx, client, request.MessageID, dataWaRecipient.ToNonAD().String()); err != nil {
 		return response, err
 	}
 
@@ -174,7 +219,7 @@ func (service serviceMessage) DeleteMessage(ctx context.Context, request domainM
 		return pkgError.ErrWaCLI
 	}
 
-	dataWaRecipient, err := utils.ValidateJidWithLogin(client, request.Phone)
+	dataWaRecipient, err := service.validateJID(client, request.Phone)
 	if err != nil {
 		return err
 	}
@@ -198,10 +243,10 @@ func (service serviceMessage) DeleteMessage(ctx context.Context, request domainM
 		}},
 	}
 
-	if err = client.SendAppState(ctx, patchInfo); err != nil {
+	if err = service.sendAppState(ctx, client, patchInfo); err != nil {
 		return err
 	}
-	return nil
+	return service.deleteStoredMessage(ctx, client, request.MessageID, dataWaRecipient.ToNonAD().String())
 }
 
 func (service serviceMessage) UpdateMessage(ctx context.Context, request domainMessage.UpdateMessageRequest) (response domainMessage.GenericResponse, err error) {

--- a/src/usecase/message_test.go
+++ b/src/usecase/message_test.go
@@ -1,0 +1,157 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	domainMessage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/message"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/chatstorage"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/appstate"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	waStore "go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestMessageActionsDeleteStoredMessageAfterWhatsAppSuccess(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(service serviceMessage, ctx context.Context) error
+	}{
+		{
+			name: "revoke",
+			run: func(service serviceMessage, ctx context.Context) error {
+				_, err := service.RevokeMessage(ctx, domainMessage.RevokeRequest{
+					MessageID: "message-1",
+					Phone:     "628123456789@s.whatsapp.net",
+				})
+				return err
+			},
+		},
+		{
+			name: "delete for me",
+			run: func(service serviceMessage, ctx context.Context) error {
+				return service.DeleteMessage(ctx, domainMessage.DeleteRequest{
+					MessageID: "message-1",
+					Phone:     "628123456789@s.whatsapp.net",
+				})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			service, repo, ctx := newMessageActionTestService(t, nil)
+
+			require.NoError(t, tc.run(service, ctx))
+
+			message, err := repo.GetMessageByIDAndDevice("device-a@s.whatsapp.net", "message-1")
+			require.NoError(t, err)
+			require.Nil(t, message)
+
+			otherDeviceMessage, err := repo.GetMessageByIDAndDevice("device-b@s.whatsapp.net", "message-1")
+			require.NoError(t, err)
+			require.NotNil(t, otherDeviceMessage)
+		})
+	}
+}
+
+func TestMessageActionsKeepStoredMessageWhenWhatsAppFails(t *testing.T) {
+	remoteErr := errors.New("whatsapp unavailable")
+	tests := []struct {
+		name string
+		run  func(service serviceMessage, ctx context.Context) error
+	}{
+		{
+			name: "revoke",
+			run: func(service serviceMessage, ctx context.Context) error {
+				_, err := service.RevokeMessage(ctx, domainMessage.RevokeRequest{
+					MessageID: "message-1",
+					Phone:     "628123456789@s.whatsapp.net",
+				})
+				return err
+			},
+		},
+		{
+			name: "delete for me",
+			run: func(service serviceMessage, ctx context.Context) error {
+				return service.DeleteMessage(ctx, domainMessage.DeleteRequest{
+					MessageID: "message-1",
+					Phone:     "628123456789@s.whatsapp.net",
+				})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			service, repo, ctx := newMessageActionTestService(t, remoteErr)
+
+			err := tc.run(service, ctx)
+			require.ErrorIs(t, err, remoteErr)
+
+			message, lookupErr := repo.GetMessageByIDAndDevice("device-a@s.whatsapp.net", "message-1")
+			require.NoError(t, lookupErr)
+			require.NotNil(t, message)
+		})
+	}
+}
+
+func newMessageActionTestService(t *testing.T, remoteErr error) (serviceMessage, domainChatStorage.IChatStorageRepository, context.Context) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := chatstorage.NewStorageRepository(db)
+	require.NoError(t, repo.InitializeSchema())
+
+	chatJID := "628123456789@s.whatsapp.net"
+	timestamp := time.Date(2026, time.August, 22, 11, 0, 0, 0, time.UTC)
+	for _, deviceID := range []string{"device-a@s.whatsapp.net", "device-b@s.whatsapp.net"} {
+		require.NoError(t, repo.StoreChat(&domainChatStorage.Chat{
+			DeviceID:        deviceID,
+			JID:             chatJID,
+			Name:            chatJID,
+			LastMessageTime: timestamp,
+		}))
+		require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+			ID:        "message-1",
+			ChatJID:   chatJID,
+			DeviceID:  deviceID,
+			Sender:    deviceID,
+			Content:   "stored content",
+			Timestamp: timestamp,
+			IsFromMe:  true,
+		}))
+	}
+
+	deviceJID := types.NewJID("device-a", types.DefaultUserServer)
+	client := &whatsmeow.Client{Store: &waStore.Device{ID: &deviceJID}}
+	instance := whatsapp.NewDeviceInstance("device-a", client, repo)
+	ctx := whatsapp.ContextWithDevice(context.Background(), instance)
+	recipient := types.NewJID("628123456789", types.DefaultUserServer)
+
+	service := serviceMessage{
+		chatStorageRepo: repo,
+		validateJIDFn: func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+			return recipient, nil
+		},
+		sendMessageFn: func(_ context.Context, _ *whatsmeow.Client, _ types.JID, _ *waE2E.Message) (whatsmeow.SendResponse, error) {
+			return whatsmeow.SendResponse{ID: "action-1", Timestamp: timestamp}, remoteErr
+		},
+		sendAppStateFn: func(_ context.Context, _ *whatsmeow.Client, _ appstate.PatchInfo) error {
+			return remoteErr
+		},
+	}
+	return service, repo, ctx
+}


### PR DESCRIPTION
## Context

- Delete the active device's stored message after WhatsApp confirms revoke or delete-for-me.
- Apply incoming REVOKE protocol events to device-scoped chat storage.
- Remove reactions and edit history while retaining Chatwoot correlation for asynchronous delete sync.
- Return an explicit partial-success error if WhatsApp succeeds but local cleanup fails.

Fixes #806

## Test Results

- go test ./... -count=1
- go vet ./...
- go build -o /tmp/gowa-issue806-whatsapp .