### PR TITLE
fix(chat): resolve display names from synced contacts

### DIFF
--- a/src/infrastructure/whatsapp/chat_display_name.go
+++ b/src/infrastructure/whatsapp/chat_display_name.go
@@ -64,6 +64,7 @@ func (r *ChatDisplayNameResolver) Resolve(ctx context.Context, rawJID, storedNam
 		return "Status"
 	}
 
+	originalJID, originalValid := parseChatJID(rawJID)
 	jid, validJID := r.normalizeJID(ctx, rawJID)
 	if validJID {
 		switch jid.Server {
@@ -80,7 +81,7 @@ func (r *ChatDisplayNameResolver) Resolve(ctx context.Context, rawJID, storedNam
 		}
 	}
 
-	if hasDisplayName(storedName) && !isJIDFallbackName(rawJID, jid, validJID, storedName) {
+	if hasDisplayName(storedName) && !isJIDFallbackName(rawJID, originalJID, originalValid, jid, validJID, storedName) {
 		return storedName
 	}
 
@@ -100,12 +101,19 @@ func (r *ChatDisplayNameResolver) Resolve(ctx context.Context, rawJID, storedNam
 	return rawJID
 }
 
-func (r *ChatDisplayNameResolver) normalizeJID(ctx context.Context, rawJID string) (types.JID, bool) {
+func parseChatJID(rawJID string) (types.JID, bool) {
 	jid, err := types.ParseJID(rawJID)
 	if err != nil || jid.IsEmpty() || !hasDisplayName(jid.User) {
 		return types.EmptyJID, false
 	}
-	jid = jid.ToNonAD()
+	return jid.ToNonAD(), true
+}
+
+func (r *ChatDisplayNameResolver) normalizeJID(ctx context.Context, rawJID string) (types.JID, bool) {
+	jid, valid := parseChatJID(rawJID)
+	if !valid {
+		return types.EmptyJID, false
+	}
 	if jid.Server == types.HiddenUserServer && r != nil && r.client != nil && r.client.Store != nil && r.client.Store.LIDs != nil {
 		jid = NormalizeJIDFromLID(ctx, jid, r.client).ToNonAD()
 	}
@@ -163,16 +171,16 @@ func usableContactInfo(contact types.ContactInfo) bool {
 	return contact.Found || hasDisplayName(contact.FullName) || hasDisplayName(contact.PushName) || hasDisplayName(contact.BusinessName)
 }
 
-func isJIDFallbackName(rawJID string, jid types.JID, validJID bool, storedName string) bool {
+func isJIDFallbackName(rawJID string, originalJID types.JID, originalValid bool, normalizedJID types.JID, normalizedValid bool, storedName string) bool {
 	name := strings.TrimSpace(storedName)
-	if name == "" {
+	if name == "" || name == strings.TrimSpace(rawJID) {
 		return true
 	}
-	if name == strings.TrimSpace(rawJID) {
+	if originalValid && (name == originalJID.User || name == originalJID.String()) {
 		return true
 	}
-	if !validJID {
-		return false
+	if normalizedValid && (name == normalizedJID.User || name == normalizedJID.String()) {
+		return true
 	}
-	return name == jid.User || name == jid.String()
+	return false
 }

--- a/src/infrastructure/whatsapp/chat_display_name.go
+++ b/src/infrastructure/whatsapp/chat_display_name.go
@@ -8,43 +8,45 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
-// allContactInfoGetter is the small subset of the WhatsApp contact store needed
-// to resolve chat labels without issuing one contact lookup per chat.
-type allContactInfoGetter interface {
+// chatContactInfoGetter is the subset of the WhatsApp contact store needed to
+// resolve chat labels. GetContact keeps single-chat requests cheap, while
+// GetAllContacts lets list requests collapse repeated lookups into one snapshot.
+type chatContactInfoGetter interface {
+	GetContact(context.Context, types.JID) (types.ContactInfo, error)
 	GetAllContacts(context.Context) (map[types.JID]types.ContactInfo, error)
 }
 
 // ChatDisplayNameResolver resolves a human-readable chat label from the chat
 // metadata already stored by GOWA and the address book synced by whatsmeow.
-// Contacts are snapshotted once when the resolver is created so list endpoints
-// do not turn into N+1 database reads.
+// It starts with point lookups, then switches to a contact snapshot when a
+// second distinct contact is needed. This keeps chat detail requests O(1)
+// without turning chat lists into N+1 database reads.
 type ChatDisplayNameResolver struct {
-	client   *whatsmeow.Client
-	contacts map[types.JID]types.ContactInfo
+	client        *whatsmeow.Client
+	contacts      chatContactInfoGetter
+	contactCache  map[types.JID]types.ContactInfo
+	allContacts   map[types.JID]types.ContactInfo
+	pointLookups  int
+	bulkAttempted bool
 }
 
-// NewChatDisplayNameResolver builds a resolver for one response. A contact-store
-// failure is deliberately non-fatal: callers still receive the existing
+// NewChatDisplayNameResolver builds a resolver scoped to one response. Contact
+// store failures are deliberately non-fatal: callers still receive the existing
 // deterministic JID-derived fallback instead of failing the chat API.
-func NewChatDisplayNameResolver(ctx context.Context, client *whatsmeow.Client) *ChatDisplayNameResolver {
-	var contacts allContactInfoGetter
+func NewChatDisplayNameResolver(_ context.Context, client *whatsmeow.Client) *ChatDisplayNameResolver {
+	var contacts chatContactInfoGetter
 	if client != nil && client.Store != nil {
 		contacts = client.Store.Contacts
 	}
-	return newChatDisplayNameResolver(ctx, contacts, client)
+	return newChatDisplayNameResolver(contacts, client)
 }
 
-func newChatDisplayNameResolver(ctx context.Context, contacts allContactInfoGetter, client *whatsmeow.Client) *ChatDisplayNameResolver {
-	resolver := &ChatDisplayNameResolver{client: client}
-	if contacts == nil {
-		return resolver
+func newChatDisplayNameResolver(contacts chatContactInfoGetter, client *whatsmeow.Client) *ChatDisplayNameResolver {
+	return &ChatDisplayNameResolver{
+		client:       client,
+		contacts:     contacts,
+		contactCache: make(map[types.JID]types.ContactInfo),
 	}
-
-	allContacts, err := contacts.GetAllContacts(ctx)
-	if err == nil {
-		resolver.contacts = allContacts
-	}
-	return resolver
 }
 
 // Resolve applies the shared chat display-name policy:
@@ -83,7 +85,7 @@ func (r *ChatDisplayNameResolver) Resolve(ctx context.Context, rawJID, storedNam
 	}
 
 	if validJID {
-		if contact, ok := r.contactInfo(jid); ok {
+		if contact, ok := r.contactInfo(ctx, jid); ok {
 			if name := PreferredContactDisplayName(contact, ""); name != "" {
 				return name
 			}
@@ -113,15 +115,52 @@ func (r *ChatDisplayNameResolver) normalizeJID(ctx context.Context, rawJID strin
 	return jid, true
 }
 
-func (r *ChatDisplayNameResolver) contactInfo(jid types.JID) (types.ContactInfo, bool) {
+func (r *ChatDisplayNameResolver) contactInfo(ctx context.Context, jid types.JID) (types.ContactInfo, bool) {
 	if r == nil || r.contacts == nil {
 		return types.ContactInfo{}, false
 	}
-	contact, ok := r.contacts[jid.ToNonAD()]
-	if !ok {
+	jid = jid.ToNonAD()
+
+	if contact, ok := r.contactCache[jid]; ok {
+		return contact, usableContactInfo(contact)
+	}
+	if r.allContacts != nil {
+		contact, ok := r.allContacts[jid]
+		if !ok {
+			r.contactCache[jid] = types.ContactInfo{}
+			return types.ContactInfo{}, false
+		}
+		r.contactCache[jid] = contact
+		return contact, usableContactInfo(contact)
+	}
+
+	// A single chat detail only needs one point lookup. When a response asks for
+	// another distinct contact (typical for chat lists), switch to one bulk read
+	// and serve the rest from memory.
+	if r.pointLookups > 0 && !r.bulkAttempted {
+		r.bulkAttempted = true
+		if allContacts, err := r.contacts.GetAllContacts(ctx); err == nil {
+			r.allContacts = allContacts
+			if contact, ok := allContacts[jid]; ok {
+				r.contactCache[jid] = contact
+				return contact, usableContactInfo(contact)
+			}
+			r.contactCache[jid] = types.ContactInfo{}
+			return types.ContactInfo{}, false
+		}
+	}
+
+	contact, err := r.contacts.GetContact(ctx, jid)
+	r.pointLookups++
+	if err != nil {
 		return types.ContactInfo{}, false
 	}
-	return contact, contact.Found || hasDisplayName(contact.FullName) || hasDisplayName(contact.PushName) || hasDisplayName(contact.BusinessName)
+	r.contactCache[jid] = contact
+	return contact, usableContactInfo(contact)
+}
+
+func usableContactInfo(contact types.ContactInfo) bool {
+	return contact.Found || hasDisplayName(contact.FullName) || hasDisplayName(contact.PushName) || hasDisplayName(contact.BusinessName)
 }
 
 func isJIDFallbackName(rawJID string, jid types.JID, validJID bool, storedName string) bool {

--- a/src/infrastructure/whatsapp/chat_display_name.go
+++ b/src/infrastructure/whatsapp/chat_display_name.go
@@ -1,0 +1,139 @@
+package whatsapp
+
+import (
+	"context"
+	"strings"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// allContactInfoGetter is the small subset of the WhatsApp contact store needed
+// to resolve chat labels without issuing one contact lookup per chat.
+type allContactInfoGetter interface {
+	GetAllContacts(context.Context) (map[types.JID]types.ContactInfo, error)
+}
+
+// ChatDisplayNameResolver resolves a human-readable chat label from the chat
+// metadata already stored by GOWA and the address book synced by whatsmeow.
+// Contacts are snapshotted once when the resolver is created so list endpoints
+// do not turn into N+1 database reads.
+type ChatDisplayNameResolver struct {
+	client   *whatsmeow.Client
+	contacts map[types.JID]types.ContactInfo
+}
+
+// NewChatDisplayNameResolver builds a resolver for one response. A contact-store
+// failure is deliberately non-fatal: callers still receive the existing
+// deterministic JID-derived fallback instead of failing the chat API.
+func NewChatDisplayNameResolver(ctx context.Context, client *whatsmeow.Client) *ChatDisplayNameResolver {
+	var contacts allContactInfoGetter
+	if client != nil && client.Store != nil {
+		contacts = client.Store.Contacts
+	}
+	return newChatDisplayNameResolver(ctx, contacts, client)
+}
+
+func newChatDisplayNameResolver(ctx context.Context, contacts allContactInfoGetter, client *whatsmeow.Client) *ChatDisplayNameResolver {
+	resolver := &ChatDisplayNameResolver{client: client}
+	if contacts == nil {
+		return resolver
+	}
+
+	allContacts, err := contacts.GetAllContacts(ctx)
+	if err == nil {
+		resolver.contacts = allContacts
+	}
+	return resolver
+}
+
+// Resolve applies the shared chat display-name policy:
+//   - preserve meaningful stored chat names (group subjects, newsletter names,
+//     or another explicit label),
+//   - for empty/number/JID placeholders use synced FullName,
+//   - then synced PushName and BusinessName,
+//   - finally use the JID-derived label.
+//
+// status@broadcast, groups, and newsletters retain their existing GOWA fallback
+// semantics. LID identifiers are normalized through the active device mapping
+// before contact lookup when possible.
+func (r *ChatDisplayNameResolver) Resolve(ctx context.Context, rawJID, storedName string) string {
+	if rawJID == "status@broadcast" {
+		return "Status"
+	}
+
+	jid, validJID := r.normalizeJID(ctx, rawJID)
+	if validJID {
+		switch jid.Server {
+		case types.GroupServer:
+			if hasDisplayName(storedName) {
+				return storedName
+			}
+			return "Group " + jid.User
+		case types.NewsletterServer:
+			if hasDisplayName(storedName) {
+				return storedName
+			}
+			return "Newsletter " + jid.User
+		}
+	}
+
+	if hasDisplayName(storedName) && !isJIDFallbackName(rawJID, jid, validJID, storedName) {
+		return storedName
+	}
+
+	if validJID {
+		if contact, ok := r.contactInfo(jid); ok {
+			if name := PreferredContactDisplayName(contact, ""); name != "" {
+				return name
+			}
+		if hasDisplayName(jid.User) {
+			return jid.User
+		}
+	}
+
+	if hasDisplayName(storedName) {
+		return storedName
+	}
+	return rawJID
+}
+
+func (r *ChatDisplayNameResolver) normalizeJID(ctx context.Context, rawJID string) (types.JID, bool) {
+	jid, err := types.ParseJID(rawJID)
+	if err != nil || jid.IsEmpty() || !hasDisplayName(jid.User) {
+		return types.EmptyJID, false
+	}
+	jid = jid.ToNonAD()
+	if jid.Server == types.HiddenUserServer && r != nil && r.client != nil && r.client.Store != nil && r.client.Store.LIDs != nil {
+		jid = NormalizeJIDFromLID(ctx, jid, r.client).ToNonAD()
+	}
+	if jid.IsEmpty() || !hasDisplayName(jid.User) {
+		return types.EmptyJID, false
+	}
+	return jid, true
+}
+
+func (r *ChatDisplayNameResolver) contactInfo(jid types.JID) (types.ContactInfo, bool) {
+	if r == nil || r.contacts == nil {
+		return types.ContactInfo{}, false
+	}
+	contact, ok := r.contacts[jid.ToNonAD()]
+	if !ok {
+		return types.ContactInfo{}, false
+	}
+	return contact, contact.Found || hasDisplayName(contact.FullName) || hasDisplayName(contact.PushName) || hasDisplayName(contact.BusinessName)
+}
+
+func isJIDFallbackName(rawJID string, jid types.JID, validJID bool, storedName string) bool {
+	name := strings.TrimSpace(storedName)
+	if name == "" {
+		return true
+	}
+	if name == strings.TrimSpace(rawJID) {
+		return true
+	}
+	if !validJID {
+		return false
+	}
+	return name == jid.User || name == jid.String()
+}

--- a/src/infrastructure/whatsapp/chat_display_name.go
+++ b/src/infrastructure/whatsapp/chat_display_name.go
@@ -90,6 +90,7 @@ func (r *ChatDisplayNameResolver) Resolve(ctx context.Context, rawJID, storedNam
 			if name := PreferredContactDisplayName(contact, ""); name != "" {
 				return name
 			}
+		}
 		if hasDisplayName(jid.User) {
 			return jid.User
 		}

--- a/src/infrastructure/whatsapp/chat_display_name_test.go
+++ b/src/infrastructure/whatsapp/chat_display_name_test.go
@@ -9,14 +9,28 @@ import (
 )
 
 type chatDisplayNameContactStore struct {
-	contacts map[types.JID]types.ContactInfo
-	err      error
-	reads    int
+	contacts  map[types.JID]types.ContactInfo
+	getErr    error
+	allErr    error
+	getReads  int
+	bulkReads int
+}
+
+func (s *chatDisplayNameContactStore) GetContact(_ context.Context, jid types.JID) (types.ContactInfo, error) {
+	s.getReads++
+	if s.getErr != nil {
+		return types.ContactInfo{}, s.getErr
+	}
+	contact, ok := s.contacts[jid.ToNonAD()]
+	if !ok {
+		return types.ContactInfo{}, nil
+	}
+	return contact, nil
 }
 
 func (s *chatDisplayNameContactStore) GetAllContacts(context.Context) (map[types.JID]types.ContactInfo, error) {
-	s.reads++
-	return s.contacts, s.err
+	s.bulkReads++
+	return s.contacts, s.allErr
 }
 
 func TestChatDisplayNameResolverUsesSyncedContactForFallbackChatName(t *testing.T) {
@@ -30,15 +44,18 @@ func TestChatDisplayNameResolverUsesSyncedContactForFallbackChatName(t *testing.
 			BusinessName: "Alice Shop",
 		},
 	}}
-	resolver := newChatDisplayNameResolver(ctx, contacts, nil)
+	resolver := newChatDisplayNameResolver(contacts, nil)
 
 	for _, storedName := range []string{"", jid.User, jid.String()} {
 		if got := resolver.Resolve(ctx, jid.String(), storedName); got != "Saved Alice" {
 			t.Fatalf("Resolve(%q, %q) = %q, want synced full name", jid.String(), storedName, got)
 		}
 	}
-	if contacts.reads != 1 {
-		t.Fatalf("GetAllContacts reads = %d, want 1", contacts.reads)
+	if contacts.getReads != 1 {
+		t.Fatalf("GetContact reads = %d, want 1 cached point lookup", contacts.getReads)
+	}
+	if contacts.bulkReads != 0 {
+		t.Fatalf("GetAllContacts reads = %d, want 0 for one chat", contacts.bulkReads)
 	}
 }
 
@@ -48,10 +65,13 @@ func TestChatDisplayNameResolverPreservesMeaningfulStoredName(t *testing.T) {
 	contacts := &chatDisplayNameContactStore{contacts: map[types.JID]types.ContactInfo{
 		jid: {Found: true, FullName: "Saved Alice"},
 	}}
-	resolver := newChatDisplayNameResolver(ctx, contacts, nil)
+	resolver := newChatDisplayNameResolver(contacts, nil)
 
 	if got := resolver.Resolve(ctx, jid.String(), "Support Queue"); got != "Support Queue" {
 		t.Fatalf("Resolve() = %q, want meaningful stored chat name", got)
+	}
+	if contacts.getReads != 0 || contacts.bulkReads != 0 {
+		t.Fatalf("contact store reads = point:%d bulk:%d, want none for meaningful stored name", contacts.getReads, contacts.bulkReads)
 	}
 }
 
@@ -60,10 +80,11 @@ func TestChatDisplayNameResolverUsesContactFallbackOrder(t *testing.T) {
 	pushJID := types.NewJID("628111111111", types.DefaultUserServer)
 	businessJID := types.NewJID("628222222222", types.DefaultUserServer)
 	phoneJID := types.NewJID("628333333333", types.DefaultUserServer)
-	resolver := newChatDisplayNameResolver(ctx, &chatDisplayNameContactStore{contacts: map[types.JID]types.ContactInfo{
+	contacts := &chatDisplayNameContactStore{contacts: map[types.JID]types.ContactInfo{
 		pushJID:     {Found: true, PushName: "Push Alice", BusinessName: "Alice Shop"},
 		businessJID: {Found: true, BusinessName: "Business Bob"},
-	}}, nil)
+	}}
+	resolver := newChatDisplayNameResolver(contacts, nil)
 
 	cases := []struct {
 		name string
@@ -81,11 +102,15 @@ func TestChatDisplayNameResolverUsesContactFallbackOrder(t *testing.T) {
 			}
 		})
 	}
+	if contacts.getReads != 1 || contacts.bulkReads != 1 {
+		t.Fatalf("contact store reads = point:%d bulk:%d, want one point then one bulk read", contacts.getReads, contacts.bulkReads)
+	}
 }
 
 func TestChatDisplayNameResolverKeepsSpecialChatSemantics(t *testing.T) {
 	ctx := context.Background()
-	resolver := newChatDisplayNameResolver(ctx, &chatDisplayNameContactStore{}, nil)
+	contacts := &chatDisplayNameContactStore{}
+	resolver := newChatDisplayNameResolver(contacts, nil)
 
 	cases := []struct {
 		jid        string
@@ -103,12 +128,15 @@ func TestChatDisplayNameResolverKeepsSpecialChatSemantics(t *testing.T) {
 			t.Fatalf("Resolve(%q, %q) = %q, want %q", tc.jid, tc.storedName, got, tc.want)
 		}
 	}
+	if contacts.getReads != 0 || contacts.bulkReads != 0 {
+		t.Fatalf("contact store reads = point:%d bulk:%d, want none for special chats", contacts.getReads, contacts.bulkReads)
+	}
 }
 
 func TestChatDisplayNameResolverContactReadFailureDoesNotBreakChats(t *testing.T) {
 	ctx := context.Background()
 	jid := types.NewJID("628123456789", types.DefaultUserServer)
-	resolver := newChatDisplayNameResolver(ctx, &chatDisplayNameContactStore{err: errors.New("contact store unavailable")}, nil)
+	resolver := newChatDisplayNameResolver(&chatDisplayNameContactStore{getErr: errors.New("contact store unavailable")}, nil)
 
 	if got := resolver.Resolve(ctx, jid.String(), jid.User); got != jid.User {
 		t.Fatalf("Resolve() = %q, want deterministic phone fallback %q", got, jid.User)

--- a/src/infrastructure/whatsapp/chat_display_name_test.go
+++ b/src/infrastructure/whatsapp/chat_display_name_test.go
@@ -1,0 +1,116 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+type chatDisplayNameContactStore struct {
+	contacts map[types.JID]types.ContactInfo
+	err      error
+	reads    int
+}
+
+func (s *chatDisplayNameContactStore) GetAllContacts(context.Context) (map[types.JID]types.ContactInfo, error) {
+	s.reads++
+	return s.contacts, s.err
+}
+
+func TestChatDisplayNameResolverUsesSyncedContactForFallbackChatName(t *testing.T) {
+	ctx := context.Background()
+	jid := types.NewJID("628123456789", types.DefaultUserServer)
+	contacts := &chatDisplayNameContactStore{contacts: map[types.JID]types.ContactInfo{
+		jid: {
+			Found:        true,
+			FullName:     "Saved Alice",
+			PushName:     "Alice WA",
+			BusinessName: "Alice Shop",
+		},
+	}}
+	resolver := newChatDisplayNameResolver(ctx, contacts, nil)
+
+	for _, storedName := range []string{"", jid.User, jid.String()} {
+		if got := resolver.Resolve(ctx, jid.String(), storedName); got != "Saved Alice" {
+			t.Fatalf("Resolve(%q, %q) = %q, want synced full name", jid.String(), storedName, got)
+		}
+	}
+	if contacts.reads != 1 {
+		t.Fatalf("GetAllContacts reads = %d, want 1", contacts.reads)
+	}
+}
+
+func TestChatDisplayNameResolverPreservesMeaningfulStoredName(t *testing.T) {
+	ctx := context.Background()
+	jid := types.NewJID("628123456789", types.DefaultUserServer)
+	contacts := &chatDisplayNameContactStore{contacts: map[types.JID]types.ContactInfo{
+		jid: {Found: true, FullName: "Saved Alice"},
+	}}
+	resolver := newChatDisplayNameResolver(ctx, contacts, nil)
+
+	if got := resolver.Resolve(ctx, jid.String(), "Support Queue"); got != "Support Queue" {
+		t.Fatalf("Resolve() = %q, want meaningful stored chat name", got)
+	}
+}
+
+func TestChatDisplayNameResolverUsesContactFallbackOrder(t *testing.T) {
+	ctx := context.Background()
+	pushJID := types.NewJID("628111111111", types.DefaultUserServer)
+	businessJID := types.NewJID("628222222222", types.DefaultUserServer)
+	phoneJID := types.NewJID("628333333333", types.DefaultUserServer)
+	resolver := newChatDisplayNameResolver(ctx, &chatDisplayNameContactStore{contacts: map[types.JID]types.ContactInfo{
+		pushJID:     {Found: true, PushName: "Push Alice", BusinessName: "Alice Shop"},
+		businessJID: {Found: true, BusinessName: "Business Bob"},
+	}}, nil)
+
+	cases := []struct {
+		name string
+		jid  types.JID
+		want string
+	}{
+		{name: "push name", jid: pushJID, want: "Push Alice"},
+		{name: "business name", jid: businessJID, want: "Business Bob"},
+		{name: "phone number", jid: phoneJID, want: phoneJID.User},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolver.Resolve(ctx, tc.jid.String(), tc.jid.User); got != tc.want {
+				t.Fatalf("Resolve() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChatDisplayNameResolverKeepsSpecialChatSemantics(t *testing.T) {
+	ctx := context.Background()
+	resolver := newChatDisplayNameResolver(ctx, &chatDisplayNameContactStore{}, nil)
+
+	cases := []struct {
+		jid        string
+		storedName string
+		want       string
+	}{
+		{jid: "status@broadcast", want: "Status"},
+		{jid: "120363999000111@g.us", storedName: "Family", want: "Family"},
+		{jid: "120363999000111@g.us", want: "Group 120363999000111"},
+		{jid: "120363111@newsletter", storedName: "Updates", want: "Updates"},
+		{jid: "120363111@newsletter", want: "Newsletter 120363111"},
+	}
+	for _, tc := range cases {
+		if got := resolver.Resolve(ctx, tc.jid, tc.storedName); got != tc.want {
+			t.Fatalf("Resolve(%q, %q) = %q, want %q", tc.jid, tc.storedName, got, tc.want)
+		}
+	}
+}
+
+func TestChatDisplayNameResolverContactReadFailureDoesNotBreakChats(t *testing.T) {
+	ctx := context.Background()
+	jid := types.NewJID("628123456789", types.DefaultUserServer)
+	resolver := newChatDisplayNameResolver(ctx, &chatDisplayNameContactStore{err: errors.New("contact store unavailable")}, nil)
+
+	if got := resolver.Resolve(ctx, jid.String(), jid.User); got != jid.User {
+		t.Fatalf("Resolve() = %q, want deterministic phone fallback %q", got, jid.User)
+	}
+}

--- a/src/infrastructure/whatsapp/chat_display_name_test.go
+++ b/src/infrastructure/whatsapp/chat_display_name_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -33,6 +35,43 @@ func (s *chatDisplayNameContactStore) GetAllContacts(context.Context) (map[types
 	return s.contacts, s.allErr
 }
 
+type chatDisplayNameLIDStore struct {
+	lid types.JID
+	pn  types.JID
+}
+
+func (s *chatDisplayNameLIDStore) PutManyLIDMappings(context.Context, []store.LIDMapping) error {
+	return nil
+}
+
+func (s *chatDisplayNameLIDStore) PutLIDMapping(context.Context, types.JID, types.JID) error {
+	return nil
+}
+
+func (s *chatDisplayNameLIDStore) GetPNForLID(_ context.Context, lid types.JID) (types.JID, error) {
+	if lid.ToNonAD() == s.lid.ToNonAD() {
+		return s.pn, nil
+	}
+	return types.EmptyJID, nil
+}
+
+func (s *chatDisplayNameLIDStore) GetLIDForPN(_ context.Context, pn types.JID) (types.JID, error) {
+	if pn.ToNonAD() == s.pn.ToNonAD() {
+		return s.lid, nil
+	}
+	return types.EmptyJID, nil
+}
+
+func (s *chatDisplayNameLIDStore) GetManyLIDsForPNs(_ context.Context, pns []types.JID) (map[types.JID]types.JID, error) {
+	result := make(map[types.JID]types.JID)
+	for _, pn := range pns {
+		if pn.ToNonAD() == s.pn.ToNonAD() {
+			result[pn.ToNonAD()] = s.lid.ToNonAD()
+		}
+	}
+	return result, nil
+}
+
 func TestChatDisplayNameResolverUsesSyncedContactForFallbackChatName(t *testing.T) {
 	ctx := context.Background()
 	jid := types.NewJID("628123456789", types.DefaultUserServer)
@@ -56,6 +95,29 @@ func TestChatDisplayNameResolverUsesSyncedContactForFallbackChatName(t *testing.
 	}
 	if contacts.bulkReads != 0 {
 		t.Fatalf("GetAllContacts reads = %d, want 0 for one chat", contacts.bulkReads)
+	}
+}
+
+func TestChatDisplayNameResolverResolvesLateLIDPlaceholderThroughPNContact(t *testing.T) {
+	ctx := context.Background()
+	lid := types.NewJID("123456789012345", types.HiddenUserServer)
+	pn := types.NewJID("628123456789", types.DefaultUserServer)
+	contacts := &chatDisplayNameContactStore{contacts: map[types.JID]types.ContactInfo{
+		pn: {Found: true, FullName: "Saved Alice"},
+	}}
+	client := &whatsmeow.Client{Store: &store.Device{
+		LIDs: &chatDisplayNameLIDStore{lid: lid, pn: pn},
+	}}
+	resolver := newChatDisplayNameResolver(contacts, client)
+
+	// The chat was persisted before LID->PN mapping existed, so its stored name
+	// is the old LID user placeholder. Once the mapping appears, that placeholder
+	// must not outrank the synced PN contact name.
+	if got := resolver.Resolve(ctx, lid.String(), lid.User); got != "Saved Alice" {
+		t.Fatalf("Resolve(%q, %q) = %q, want synced PN contact name", lid.String(), lid.User, got)
+	}
+	if contacts.getReads != 1 {
+		t.Fatalf("GetContact reads = %d, want one PN contact lookup", contacts.getReads)
 	}
 }
 

--- a/src/infrastructure/whatsapp/chat_display_name_test.go
+++ b/src/infrastructure/whatsapp/chat_display_name_test.go
@@ -8,6 +8,7 @@ import (
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
+	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
 type chatDisplayNameContactStore struct {
@@ -99,6 +100,10 @@ func TestChatDisplayNameResolverUsesSyncedContactForFallbackChatName(t *testing.
 }
 
 func TestChatDisplayNameResolverResolvesLateLIDPlaceholderThroughPNContact(t *testing.T) {
+	originalLog := log
+	log = waLog.Noop
+	defer func() { log = originalLog }()
+
 	ctx := context.Background()
 	lid := types.NewJID("123456789012345", types.HiddenUserServer)
 	pn := types.NewJID("628123456789", types.DefaultUserServer)

--- a/src/usecase/chat.go
+++ b/src/usecase/chat.go
@@ -3,7 +3,6 @@ package usecase
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	domainChat "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chat"
@@ -23,33 +22,6 @@ type serviceChat struct {
 func NewChatService(chatStorageRepo domainChatStorage.IChatStorageRepository) domainChat.IChatUsecase {
 	return &serviceChat{
 		chatStorageRepo: chatStorageRepo,
-	}
-}
-
-// chatDisplayName returns a human-readable name for a chat, falling back to a
-// JID-derived label when the stored name is empty. Some chats are persisted
-// before a pushname/group subject is known (or with stale empty names), which
-// otherwise surfaces as a blank "name" in the chat list and makes the sender
-// impossible to identify (issue #675). The fallback mirrors the storage-layer
-// convention in GetChatNameWithPushName: "Status" for status@broadcast, phone
-// number for 1:1, "Group <id>" / "Newsletter <id>" for those address spaces.
-func chatDisplayName(jid, name string) string {
-	if name != "" {
-		return name
-	}
-	// Mirror the storage-layer contract (GetChatNameWithPushNameByDevice):
-	// status@broadcast is always titled "Status", never its lowercase JID local part.
-	if jid == "status@broadcast" {
-		return "Status"
-	}
-	user := utils.ExtractPhoneFromJID(jid)
-	switch {
-	case utils.IsGroupJID(jid):
-		return "Group " + user
-	case strings.HasSuffix(jid, "@newsletter"):
-		return "Newsletter " + user
-	default:
-		return user
 	}
 }
 
@@ -83,12 +55,14 @@ func (service serviceChat) ListChats(ctx context.Context, request domainChat.Lis
 		totalCount = 0
 	}
 
+	chatDisplayNameResolver := whatsapp.NewChatDisplayNameResolver(ctx, whatsapp.ClientFromContext(ctx))
+
 	// Convert entities to domain objects
 	chatInfos := make([]domainChat.ChatInfo, 0, len(chats))
 	for _, chat := range chats {
 		chatInfo := domainChat.ChatInfo{
 			JID:                 chat.JID,
-			Name:                chatDisplayName(chat.JID, chat.Name),
+			Name:                chatDisplayNameResolver.Resolve(ctx, chat.JID, chat.Name),
 			LastMessageTime:     chat.LastMessageTime.Format(time.RFC3339),
 			EphemeralExpiration: chat.EphemeralExpiration,
 			CreatedAt:           chat.CreatedAt.Format(time.RFC3339),
@@ -127,6 +101,9 @@ func (service serviceChat) GetChatMessages(ctx context.Context, request domainCh
 		return response, fmt.Errorf("device identification required")
 	}
 
+	client := whatsapp.ClientFromContext(ctx)
+	chatDisplayNameResolver := whatsapp.NewChatDisplayNameResolver(ctx, client)
+
 	chat, err := service.chatStorageRepo.GetChatByDevice(deviceID, request.ChatJID)
 	if err != nil {
 		logrus.WithError(err).WithField("chat_jid", request.ChatJID).Error("Failed to get chat info")
@@ -148,7 +125,7 @@ func (service serviceChat) GetChatMessages(ctx context.Context, request domainCh
 		}
 		response.ChatInfo = domainChat.ChatInfo{
 			JID:  request.ChatJID,
-			Name: chatDisplayName(request.ChatJID, ""),
+			Name: chatDisplayNameResolver.Resolve(ctx, request.ChatJID, ""),
 		}
 		return response, nil
 	}
@@ -207,7 +184,6 @@ func (service serviceChat) GetChatMessages(ctx context.Context, request domainCh
 	}
 
 	// Convert entities to domain objects
-	client := whatsapp.ClientFromContext(ctx)
 	deviceDisplayName := ""
 	if instance, ok := whatsapp.DeviceFromContext(ctx); ok && instance != nil {
 		deviceDisplayName = instance.DisplayName()
@@ -252,7 +228,7 @@ func (service serviceChat) GetChatMessages(ctx context.Context, request domainCh
 	// Create chat info for response
 	chatInfo := domainChat.ChatInfo{
 		JID:                 chat.JID,
-		Name:                chatDisplayName(chat.JID, chat.Name),
+		Name:                chatDisplayNameResolver.Resolve(ctx, chat.JID, chat.Name),
 		LastMessageTime:     chat.LastMessageTime.Format(time.RFC3339),
 		EphemeralExpiration: chat.EphemeralExpiration,
 		CreatedAt:           chat.CreatedAt.Format(time.RFC3339),

--- a/src/usecase/chat.go
+++ b/src/usecase/chat.go
@@ -30,6 +30,8 @@ func (service serviceChat) ListChats(ctx context.Context, request domainChat.Lis
 		return response, err
 	}
 
+	chatDisplayNameResolver := whatsapp.NewChatDisplayNameResolver(ctx, whatsapp.ClientFromContext(ctx))
+
 	// Create filter from request
 	filter := &domainChatStorage.ChatFilter{
 		DeviceID:   deviceIDFromContext(ctx),
@@ -54,8 +56,6 @@ func (service serviceChat) ListChats(ctx context.Context, request domainChat.Lis
 		// Continue with partial data
 		totalCount = 0
 	}
-
-	chatDisplayNameResolver := whatsapp.NewChatDisplayNameResolver(ctx, whatsapp.ClientFromContext(ctx))
 
 	// Convert entities to domain objects
 	chatInfos := make([]domainChat.ChatInfo, 0, len(chats))

--- a/src/usecase/chat_display_name_test.go
+++ b/src/usecase/chat_display_name_test.go
@@ -1,0 +1,14 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
+)
+
+// chatDisplayName keeps the existing table-driven fallback coverage focused on
+// the production resolver after the local helper moved to infrastructure.
+func chatDisplayName(jid, name string) string {
+	ctx := context.Background()
+	return whatsapp.NewChatDisplayNameResolver(ctx, nil).Resolve(ctx, jid, name)
+}

--- a/src/usecase/chat_display_name_test.go
+++ b/src/usecase/chat_display_name_test.go
@@ -2,8 +2,15 @@ package usecase
 
 import (
 	"context"
+	"testing"
+	"time"
 
+	domainChat "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chat"
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/store"
+	"go.mau.fi/whatsmeow/types"
 )
 
 // chatDisplayName keeps the existing table-driven fallback coverage focused on
@@ -11,4 +18,153 @@ import (
 func chatDisplayName(jid, name string) string {
 	ctx := context.Background()
 	return whatsapp.NewChatDisplayNameResolver(ctx, nil).Resolve(ctx, jid, name)
+}
+
+// chatContactStoreStub serves the synced address book that the chat usecases
+// read through the active device's whatsmeow client. Only the two read paths
+// used by the resolver carry behaviour; the writes are unused here.
+type chatContactStoreStub struct {
+	contacts map[types.JID]types.ContactInfo
+}
+
+func (s *chatContactStoreStub) GetContact(_ context.Context, user types.JID) (types.ContactInfo, error) {
+	return s.contacts[user.ToNonAD()], nil
+}
+
+func (s *chatContactStoreStub) GetAllContacts(context.Context) (map[types.JID]types.ContactInfo, error) {
+	return s.contacts, nil
+}
+
+func (s *chatContactStoreStub) PutPushName(context.Context, types.JID, string) (bool, string, error) {
+	return false, "", nil
+}
+
+func (s *chatContactStoreStub) PutBusinessName(context.Context, types.JID, string) (bool, string, error) {
+	return false, "", nil
+}
+
+func (s *chatContactStoreStub) PutContactName(context.Context, types.JID, string, string) error {
+	return nil
+}
+
+func (s *chatContactStoreStub) PutAllContactNames(context.Context, []store.ContactEntry) error {
+	return nil
+}
+
+func (s *chatContactStoreStub) PutManyRedactedPhones(context.Context, []store.RedactedPhoneEntry) error {
+	return nil
+}
+
+// chatDisplayNameContext mirrors how the REST/MCP layers hand the active device
+// to the usecases, so these tests exercise the real ClientFromContext path.
+func chatDisplayNameContext(accountJID types.JID, contacts map[types.JID]types.ContactInfo) context.Context {
+	client := &whatsmeow.Client{Store: &store.Device{
+		ID:       &accountJID,
+		Contacts: &chatContactStoreStub{contacts: contacts},
+	}}
+	return whatsapp.ContextWithDevice(context.Background(), whatsapp.NewDeviceInstance(accountJID.String(), client, nil))
+}
+
+// TestListChatsResolvesSyncedContactNames pins the ListChats half of issue #805:
+// a stored phone/JID placeholder must be replaced by the synced contact name,
+// while an explicit chat label is still returned verbatim.
+func TestListChatsResolvesSyncedContactNames(t *testing.T) {
+	accountJID := types.NewJID("628999999999", types.DefaultUserServer)
+	alice := types.NewJID("628123456789", types.DefaultUserServer)
+	bob := types.NewJID("628111111111", types.DefaultUserServer)
+	now := time.Date(2026, time.May, 16, 8, 0, 0, 0, time.UTC)
+
+	repo := &chatUsecaseRepoStub{chats: []*domainChatStorage.Chat{
+		{DeviceID: accountJID.String(), JID: alice.String(), Name: alice.User, LastMessageTime: now, CreatedAt: now, UpdatedAt: now},
+		{DeviceID: accountJID.String(), JID: bob.String(), Name: "Support Queue", LastMessageTime: now, CreatedAt: now, UpdatedAt: now},
+	}}
+	ctx := chatDisplayNameContext(accountJID, map[types.JID]types.ContactInfo{
+		alice: {Found: true, FullName: "Saved Alice"},
+		bob:   {Found: true, FullName: "Saved Bob"},
+	})
+
+	response, err := NewChatService(repo).ListChats(ctx, domainChat.ListChatsRequest{})
+	if err != nil {
+		t.Fatalf("list chats: %v", err)
+	}
+	if len(response.Data) != 2 {
+		t.Fatalf("expected two chats, got %d", len(response.Data))
+	}
+	if response.Data[0].Name != "Saved Alice" {
+		t.Fatalf("placeholder chat name = %q, want synced contact name", response.Data[0].Name)
+	}
+	if response.Data[1].Name != "Support Queue" {
+		t.Fatalf("explicit chat name = %q, want it preserved", response.Data[1].Name)
+	}
+}
+
+// TestGetChatMessagesResolvesSyncedContactNameForEmptyChat covers the
+// not-yet-persisted chat response, where chat_info has no stored name at all.
+func TestGetChatMessagesResolvesSyncedContactNameForEmptyChat(t *testing.T) {
+	accountJID := types.NewJID("628999999999", types.DefaultUserServer)
+	alice := types.NewJID("628123456789", types.DefaultUserServer)
+
+	ctx := chatDisplayNameContext(accountJID, map[types.JID]types.ContactInfo{
+		alice: {Found: true, FullName: "Saved Alice"},
+	})
+
+	response, err := NewChatService(&chatUsecaseRepoStub{}).GetChatMessages(ctx, domainChat.GetChatMessagesRequest{
+		ChatJID: alice.String(),
+	})
+	if err != nil {
+		t.Fatalf("get chat messages: %v", err)
+	}
+	if len(response.Data) != 0 {
+		t.Fatalf("expected empty message list, got %d", len(response.Data))
+	}
+	if response.ChatInfo.Name != "Saved Alice" {
+		t.Fatalf("empty chat_info name = %q, want synced contact name", response.ChatInfo.Name)
+	}
+}
+
+// TestGetChatMessagesResolvesSyncedContactNameForLoadedChat covers the stored
+// chat response, where chat_info carries a phone-number placeholder.
+func TestGetChatMessagesResolvesSyncedContactNameForLoadedChat(t *testing.T) {
+	accountJID := types.NewJID("628999999999", types.DefaultUserServer)
+	alice := types.NewJID("628123456789", types.DefaultUserServer)
+	now := time.Date(2026, time.May, 16, 8, 0, 0, 0, time.UTC)
+
+	repo := &chatUsecaseRepoStub{
+		chat: &domainChatStorage.Chat{
+			DeviceID:        accountJID.String(),
+			JID:             alice.String(),
+			Name:            alice.User,
+			LastMessageTime: now,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		},
+		messages: []*domainChatStorage.Message{
+			{
+				ID:        "msg-1",
+				ChatJID:   alice.String(),
+				DeviceID:  accountJID.String(),
+				Sender:    alice.String(),
+				Content:   "hi",
+				Timestamp: now,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+	}
+	ctx := chatDisplayNameContext(accountJID, map[types.JID]types.ContactInfo{
+		alice: {Found: true, FullName: "Saved Alice"},
+	})
+
+	response, err := NewChatService(repo).GetChatMessages(ctx, domainChat.GetChatMessagesRequest{
+		ChatJID: alice.String(),
+	})
+	if err != nil {
+		t.Fatalf("get chat messages: %v", err)
+	}
+	if len(response.Data) != 1 {
+		t.Fatalf("expected one message, got %d", len(response.Data))
+	}
+	if response.ChatInfo.Name != "Saved Alice" {
+		t.Fatalf("loaded chat_info name = %q, want synced contact name", response.ChatInfo.Name)
+	}
 }

--- a/src/usecase/chat_test.go
+++ b/src/usecase/chat_test.go
@@ -372,6 +372,7 @@ func TestChatSenderDisplayNameJSONContract(t *testing.T) {
 type chatUsecaseRepoStub struct {
 	domainChatStorage.IChatStorageRepository
 	chat                *domainChatStorage.Chat
+	chats               []*domainChatStorage.Chat
 	messages            []*domainChatStorage.Message
 	globalMessageCount  int64
 	deviceMessageCounts map[string]int64
@@ -379,6 +380,14 @@ type chatUsecaseRepoStub struct {
 
 func (r *chatUsecaseRepoStub) GetChatByDevice(_, _ string) (*domainChatStorage.Chat, error) {
 	return r.chat, nil
+}
+
+func (r *chatUsecaseRepoStub) GetChats(*domainChatStorage.ChatFilter) ([]*domainChatStorage.Chat, error) {
+	return r.chats, nil
+}
+
+func (r *chatUsecaseRepoStub) GetFilteredChatCount(*domainChatStorage.ChatFilter) (int64, error) {
+	return int64(len(r.chats)), nil
 }
 
 func (r *chatUsecaseRepoStub) GetMessages(*domainChatStorage.MessageFilter) ([]*domainChatStorage.Message, error) {


### PR DESCRIPTION
## Summary

Issue #805 reports that the synced whatsmeow contact store is populated, but chat-facing API responses still expose phone/JID fallbacks in many places.

This PR centralizes chat-level display-name resolution and applies it to both `ListChats` and `GetChatMessages.chat_info`, so REST and MCP callers receive the same resolved name.

### Resolution order

- preserve a meaningful stored chat name (including group/newsletter subjects)
- when the stored value is an empty/number/JID placeholder, use synced `FullName`
- then `PushName`
- then `BusinessName`
- finally keep the existing deterministic JID-derived fallback

`status@broadcast`, groups, newsletters, and LID normalization retain their existing semantics.

### Performance

The resolver is scoped to one response. A single chat detail uses one cached `GetContact` lookup. If a response needs a second distinct contact (typical for chat lists), it switches to one `GetAllContacts` snapshot so pagination does not introduce N+1 contact-store queries.

Contact-store failures remain non-fatal and fall back to the existing number/JID labels.

### Compatibility

- no database migration
- no new WhatsApp network request
- existing `name` response field is preserved
- existing message/reaction `sender_display_name` resolution is left intact

### Tests

Added regression coverage for:

- synced `FullName` replacing number/JID placeholders
- stored-name precedence
- `PushName` / `BusinessName` / number fallback order
- group/newsletter/status behavior
- cached point lookup and adaptive bulk lookup behavior
- contact-store failure fallback

Related to #805. The companion `gowa-ui` PR consumes the already-present `sender_display_name` fields and prefers the resolved `chat_info` returned here.