### PR TITLE
feat(message): add audio played receipts

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2140,6 +2140,56 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorInternalServer'
+  /message/{message_id}/played:
+    post:
+      operationId: markMessagePlayed
+      tags:
+        - message
+      summary: Mark an audio message as played
+      description: >-
+        Sends WhatsApp's played receipt for an incoming audio message or voice
+        note. The message must exist in the active device's chat storage and
+        belong to the supplied chat.
+      parameters:
+        - $ref: '#/components/parameters/DeviceIdHeader'
+        - in: path
+          name: message_id
+          schema:
+            type: string
+          required: true
+          description: Message ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                phone:
+                  type: string
+                  example: '62819273192397132@s.whatsapp.net'
+                  description: Phone number or group JID containing the audio message
+              required:
+                - phone
+      responses:
+        '200':
+          description: Played receipt sent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBadRequest'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInternalServer'
   /message/{message_id}/star:
     post:
       operationId: starMessage

--- a/src/domains/message/interfaces.go
+++ b/src/domains/message/interfaces.go
@@ -7,6 +7,7 @@ import (
 // IMessageActions handles message action operations
 type IMessageActions interface {
 	MarkAsRead(ctx context.Context, request MarkAsReadRequest) (response GenericResponse, err error)
+	MarkAsPlayed(ctx context.Context, request MarkAsPlayedRequest) (response GenericResponse, err error)
 	ReactMessage(ctx context.Context, request ReactionRequest) (response GenericResponse, err error)
 	RevokeMessage(ctx context.Context, request RevokeRequest) (response GenericResponse, err error)
 	UpdateMessage(ctx context.Context, request UpdateMessageRequest) (response GenericResponse, err error)

--- a/src/domains/message/message.go
+++ b/src/domains/message/message.go
@@ -32,6 +32,10 @@ type MarkAsReadRequest struct {
 	Phone     string `json:"phone" form:"phone"`
 }
 
+// MarkAsPlayedRequest has the same transport fields as a read receipt, but
+// requests WhatsApp's played receipt for an existing voice message.
+type MarkAsPlayedRequest = MarkAsReadRequest
+
 type StarRequest struct {
 	MessageID string `json:"message_id" uri:"message_id"`
 	Phone     string `json:"phone" form:"phone"`

--- a/src/ui/mcp/message.go
+++ b/src/ui/mcp/message.go
@@ -22,7 +22,7 @@ func InitMcpMessage(messageService domainMessage.IMessageUsecase, resolver devic
 
 func (h *MessageHandler) AddMessageTools(mcpServer *server.MCPServer) {
 	tool := mcpg.NewTool("whatsapp_message",
-		mcpg.WithDescription("Operate on an existing WhatsApp message: react, edit, revoke (delete for everyone), delete (for me), mark_read, star, unstar, or download_media."),
+		mcpg.WithDescription("Operate on an existing WhatsApp message: react, edit, revoke (delete for everyone), delete (for me), mark_read, mark_played, star, unstar, or download_media."),
 		mcpg.WithTitleAnnotation("Message Operations"),
 		mcpg.WithReadOnlyHintAnnotation(false),
 		mcpg.WithDestructiveHintAnnotation(true),
@@ -89,6 +89,12 @@ func (h *MessageHandler) handleMessage(ctx context.Context, request mcpg.CallToo
 			return mcpg.NewToolResultError(err.Error()), nil
 		}
 		return mcpg.NewToolResultStructured(resp, fmt.Sprintf("Message marked as read (ID: %s)", resp.MessageID)), nil
+	case "mark_played":
+		resp, err := h.messageService.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{MessageID: messageID, Phone: phone})
+		if err != nil {
+			return mcpg.NewToolResultError(err.Error()), nil
+		}
+		return mcpg.NewToolResultStructured(resp, fmt.Sprintf("Message marked as played (ID: %s)", resp.MessageID)), nil
 	case "star", "unstar":
 		isStarred := action == "star"
 		if err := h.messageService.StarMessage(ctx, domainMessage.StarRequest{

--- a/src/ui/mcp/message_test.go
+++ b/src/ui/mcp/message_test.go
@@ -16,6 +16,7 @@ type stubMessageService struct {
 	revoked    *domainMessage.RevokeRequest
 	deleted    *domainMessage.DeleteRequest
 	marked     *domainMessage.MarkAsReadRequest
+	played     *domainMessage.MarkAsPlayedRequest
 	starred    *domainMessage.StarRequest
 	downloaded *domainMessage.DownloadMediaRequest
 }
@@ -38,6 +39,10 @@ func (s *stubMessageService) DeleteMessage(_ context.Context, r domainMessage.De
 }
 func (s *stubMessageService) MarkAsRead(_ context.Context, r domainMessage.MarkAsReadRequest) (domainMessage.GenericResponse, error) {
 	s.marked = &r
+	return domainMessage.GenericResponse{MessageID: r.MessageID}, nil
+}
+func (s *stubMessageService) MarkAsPlayed(_ context.Context, r domainMessage.MarkAsPlayedRequest) (domainMessage.GenericResponse, error) {
+	s.played = &r
 	return domainMessage.GenericResponse{MessageID: r.MessageID}, nil
 }
 func (s *stubMessageService) StarMessage(_ context.Context, r domainMessage.StarRequest) error {
@@ -102,6 +107,14 @@ func TestHandleMessageDispatch(t *testing.T) {
 		_, err := h.handleMessage(deviceCtx(), callReq(withAction("mark_read", nil)))
 		require.NoError(t, err)
 		require.NotNil(t, svc.marked)
+	})
+
+	t.Run("mark_played", func(t *testing.T) {
+		svc := &stubMessageService{}
+		h := InitMcpMessage(svc, &stubResolver{})
+		_, err := h.handleMessage(deviceCtx(), callReq(withAction("mark_played", nil)))
+		require.NoError(t, err)
+		require.NotNil(t, svc.played)
 	})
 
 	t.Run("star and unstar", func(t *testing.T) {

--- a/src/ui/mcp/schemas.go
+++ b/src/ui/mcp/schemas.go
@@ -57,7 +57,7 @@ const messageSchema = `{
   "type": "object",
   "required": ["action", "phone", "message_id"],
   "properties": {
-    "action": {"type": "string", "enum": ["react","edit","revoke","delete","mark_read","star","unstar","download_media"], "description": "Operation on an existing message. revoke = delete for everyone (destructive); delete = delete for me only; download_media returns the local file path"},
+    "action": {"type": "string", "enum": ["react","edit","revoke","delete","mark_read","mark_played","star","unstar","download_media"], "description": "Operation on an existing message. revoke = delete for everyone (destructive); delete = delete for me only; mark_played sends the played receipt for an incoming audio message; download_media returns the local file path"},
     "phone": {"type": "string", "description": "Phone number or group JID of the chat containing the message"},
     "message_id": {"type": "string", "description": "The WhatsApp message ID"},
     "device_id": {"type": "string", "description": "Act as this device instead of the connection default"},

--- a/src/ui/mcp/schemas_test.go
+++ b/src/ui/mcp/schemas_test.go
@@ -68,6 +68,7 @@ func TestSchemas(t *testing.T) {
 		{"msg revoke ok", messageSchema, `{"action":"revoke","phone":"628","message_id":"M1"}`, false},
 		{"msg delete ok", messageSchema, `{"action":"delete","phone":"628","message_id":"M1"}`, false},
 		{"msg mark_read ok", messageSchema, `{"action":"mark_read","phone":"628","message_id":"M1"}`, false},
+		{"msg mark_played ok", messageSchema, `{"action":"mark_played","phone":"628","message_id":"M1"}`, false},
 		{"msg star ok", messageSchema, `{"action":"star","phone":"628","message_id":"M1"}`, false},
 		{"msg unstar ok", messageSchema, `{"action":"unstar","phone":"628","message_id":"M1"}`, false},
 		{"msg download_media ok", messageSchema, `{"action":"download_media","phone":"628","message_id":"M1"}`, false},

--- a/src/ui/rest/message.go
+++ b/src/ui/rest/message.go
@@ -28,6 +28,7 @@ func InitRestMessage(app fiber.Router, service domainMessage.IMessageUsecase, se
 	app.Post("/message/:message_id/delete", rest.DeleteMessage)
 	app.Post("/message/:message_id/update", rest.UpdateMessage)
 	app.Post("/message/:message_id/read", rest.MarkAsRead)
+	app.Post("/message/:message_id/played", rest.MarkAsPlayed)
 	app.Post("/message/:message_id/star", rest.StarMessage)
 	app.Post("/message/:message_id/unstar", rest.UnstarMessage)
 	app.Post("/message/:message_id/forward", rest.ForwardMessage)
@@ -120,6 +121,25 @@ func (controller *Message) MarkAsRead(c fiber.Ctx) error {
 	utils.SanitizePhone(&request.Phone)
 
 	response, err := controller.Service.MarkAsRead(whatsapp.ContextWithDevice(c.Context(), getDeviceFromCtx(c)), request)
+	utils.PanicIfNeeded(err)
+
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: response.Status,
+		Results: response,
+	})
+}
+
+func (controller *Message) MarkAsPlayed(c fiber.Ctx) error {
+	var request domainMessage.MarkAsPlayedRequest
+	err := c.Bind().Body(&request)
+	utils.PanicIfNeeded(err)
+
+	request.MessageID = c.Params("message_id")
+	utils.SanitizePhone(&request.Phone)
+
+	response, err := controller.Service.MarkAsPlayed(whatsapp.ContextWithDevice(c.Context(), getDeviceFromCtx(c)), request)
 	utils.PanicIfNeeded(err)
 
 	return c.JSON(utils.ResponseData{

--- a/src/ui/rest/message_test.go
+++ b/src/ui/rest/message_test.go
@@ -1,15 +1,48 @@
 package rest
 
 import (
+	"context"
 	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+	domainMessage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/message"
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type playedMessageServiceStub struct {
+	domainMessage.IMessageUsecase
+	request *domainMessage.MarkAsPlayedRequest
+}
+
+func (stub *playedMessageServiceStub) MarkAsPlayed(_ context.Context, request domainMessage.MarkAsPlayedRequest) (domainMessage.GenericResponse, error) {
+	stub.request = &request
+	return domainMessage.GenericResponse{MessageID: request.MessageID, Status: "played"}, nil
+}
+
+func TestMarkAsPlayedRouteDelegatesToMessageService(t *testing.T) {
+	app := fiber.New()
+	service := &playedMessageServiceStub{}
+	InitRestMessage(app, service, nil)
+
+	request := httptest.NewRequest(
+		"POST",
+		"/message/voice-message-1/played",
+		strings.NewReader(`{"phone":"628123456789"}`),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := app.Test(request)
+
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, response.StatusCode)
+	require.NotNil(t, service.request)
+	require.Equal(t, "voice-message-1", service.request.MessageID)
+	require.Equal(t, "628123456789@s.whatsapp.net", service.request.Phone)
+}
 
 func TestPublicStaticPath(t *testing.T) {
 	tests := []struct {

--- a/src/usecase/message.go
+++ b/src/usecase/message.go
@@ -23,9 +23,12 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+type markReadFunc func(context.Context, *whatsmeow.Client, []types.MessageID, time.Time, types.JID, types.JID, ...types.ReceiptType) error
+
 type serviceMessage struct {
 	chatStorageRepo domainChatStorage.IChatStorageRepository
 	validateJIDFn   func(client *whatsmeow.Client, jid string) (types.JID, error)
+	markReadFn      markReadFunc
 	sendMessageFn   func(ctx context.Context, client *whatsmeow.Client, recipient types.JID, message *waE2E.Message) (whatsmeow.SendResponse, error)
 	sendAppStateFn  func(ctx context.Context, client *whatsmeow.Client, patch appstate.PatchInfo) error
 }
@@ -48,6 +51,13 @@ func (service serviceMessage) sendMessage(ctx context.Context, client *whatsmeow
 		return service.sendMessageFn(ctx, client, recipient, message)
 	}
 	return client.SendMessage(ctx, recipient, message)
+}
+
+func (service serviceMessage) markRead(ctx context.Context, client *whatsmeow.Client, ids []types.MessageID, timestamp time.Time, chat, sender types.JID, receiptTypeExtra ...types.ReceiptType) error {
+	if service.markReadFn != nil {
+		return service.markReadFn(ctx, client, ids, timestamp, chat, sender, receiptTypeExtra...)
+	}
+	return client.MarkRead(ctx, ids, timestamp, chat, sender, receiptTypeExtra...)
 }
 
 func (service serviceMessage) sendAppState(ctx context.Context, client *whatsmeow.Client, patch appstate.PatchInfo) error {
@@ -103,6 +113,77 @@ func (service serviceMessage) MarkAsRead(ctx context.Context, request domainMess
 
 	response.MessageID = request.MessageID
 	response.Status = fmt.Sprintf("Mark as read success %s", request.MessageID)
+	return response, nil
+}
+
+func (service serviceMessage) MarkAsPlayed(ctx context.Context, request domainMessage.MarkAsPlayedRequest) (response domainMessage.GenericResponse, err error) {
+	if err = validations.ValidateMarkAsRead(ctx, request); err != nil {
+		return response, err
+	}
+
+	client := whatsapp.ClientFromContext(ctx)
+	if client == nil {
+		return response, pkgError.ErrWaCLI
+	}
+
+	chatJID, err := service.validateJID(client, request.Phone)
+	if err != nil {
+		return response, err
+	}
+
+	if service.chatStorageRepo == nil {
+		return response, fmt.Errorf("cannot mark message %s as played without chat storage", request.MessageID)
+	}
+	message, err := service.chatStorageRepo.GetMessageByIDAndDevice(deviceIDFromContext(ctx), request.MessageID)
+	if err != nil {
+		return response, fmt.Errorf("failed to resolve message %s: %w", request.MessageID, err)
+	}
+	if message == nil {
+		return response, fmt.Errorf("message with ID %s not found for current device", request.MessageID)
+	}
+	storedChatJID, err := utils.ParseJID(message.ChatJID)
+	if err != nil {
+		return response, fmt.Errorf("failed to parse chat for message %s: %w", request.MessageID, err)
+	}
+	if storedChatJID.ToNonAD().String() != chatJID.ToNonAD().String() {
+		return response, pkgError.ValidationError(fmt.Sprintf("message %s does not belong to chat %s", request.MessageID, chatJID.ToNonAD().String()))
+	}
+	if message.MediaType != "audio" {
+		return response, pkgError.ValidationError(fmt.Sprintf("message %s is not an audio message", request.MessageID))
+	}
+	if message.IsFromMe {
+		return response, pkgError.ValidationError(fmt.Sprintf("message %s is not an incoming message", request.MessageID))
+	}
+
+	senderJID, err := utils.ParseJID(message.Sender)
+	if err != nil {
+		return response, fmt.Errorf("failed to parse sender for message %s: %w", request.MessageID, err)
+	}
+	if chatJID.Server == types.GroupServer && senderJID.User == "" {
+		return response, fmt.Errorf("sender is missing for group message %s", request.MessageID)
+	}
+	if err = service.markRead(
+		ctx,
+		client,
+		[]types.MessageID{request.MessageID},
+		time.Now(),
+		chatJID,
+		senderJID,
+		types.ReceiptTypePlayed,
+	); err != nil {
+		return response, err
+	}
+
+	logrus.Info(map[string]any{
+		"phone":        request.Phone,
+		"message_id":   request.MessageID,
+		"chat":         chatJID.String(),
+		"sender":       senderJID.String(),
+		"receipt_type": types.ReceiptTypePlayed,
+	})
+
+	response.MessageID = request.MessageID
+	response.Status = fmt.Sprintf("Mark as played success %s", request.MessageID)
 	return response, nil
 }
 

--- a/src/usecase/message.go
+++ b/src/usecase/message.go
@@ -148,7 +148,7 @@ func (service serviceMessage) MarkAsPlayed(ctx context.Context, request domainMe
 	if storedChatJID.ToNonAD().String() != chatJID.ToNonAD().String() {
 		return response, pkgError.ValidationError(fmt.Sprintf("message %s does not belong to chat %s", request.MessageID, chatJID.ToNonAD().String()))
 	}
-	if message.MediaType != "audio" {
+	if message.MediaType != "audio" && message.MediaType != "ptt" {
 		return response, pkgError.ValidationError(fmt.Sprintf("message %s is not an audio message", request.MessageID))
 	}
 	if message.IsFromMe {

--- a/src/usecase/message_test.go
+++ b/src/usecase/message_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/chatstorage"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/appstate"
@@ -81,106 +82,139 @@ func TestMarkAsPlayedSendsPlayedReceiptWithStoredGroupSender(t *testing.T) {
 	require.Equal(t, "voice-message-1", response.MessageID)
 }
 
-func TestMarkAsPlayedRejectsNonAudioMessage(t *testing.T) {
+func TestMarkAsPlayedDoesNotReadMessageFromAnotherDevice(t *testing.T) {
 	service, repo, ctx := newMessageActionTestService(t, nil)
 
 	chatJID := types.NewJID("628123456789", types.DefaultUserServer)
 	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
-		ID:        "image-message-1",
+		ID:        "device-b-voice-message",
+		ChatJID:   chatJID.String(),
+		DeviceID:  "device-b@s.whatsapp.net",
+		Sender:    chatJID.String(),
+		Timestamp: time.Now(),
+		MediaType: "audio",
+	}))
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return chatJID, nil
+	}
+	service.markReadFn = failOnMarkRead(t)
+
+	response, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
+		MessageID: "device-b-voice-message",
+		Phone:     chatJID.String(),
+	})
+
+	assert.ErrorContains(t, err, "not found for current device")
+	assert.Empty(t, response.MessageID)
+}
+
+func TestMarkAsPlayedAcceptsLegacyPTTMediaType(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	chatJID := types.NewJID("628123456789", types.DefaultUserServer)
+	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+		ID:        "legacy-ptt-message",
 		ChatJID:   chatJID.String(),
 		DeviceID:  "device-a@s.whatsapp.net",
 		Sender:    chatJID.String(),
 		Timestamp: time.Now(),
-		MediaType: "image",
+		MediaType: "ptt",
 	}))
 	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
 		return chatJID, nil
 	}
-	service.markReadFn = failOnMarkRead(t)
+	service.markReadFn = func(
+		_ context.Context,
+		_ *whatsmeow.Client,
+		ids []types.MessageID,
+		_ time.Time,
+		chat types.JID,
+		_ types.JID,
+		receiptTypes ...types.ReceiptType,
+	) error {
+		assert.Equal(t, []types.MessageID{"legacy-ptt-message"}, ids)
+		assert.Equal(t, chatJID, chat)
+		assert.Equal(t, []types.ReceiptType{types.ReceiptTypePlayed}, receiptTypes)
+		return nil
+	}
 
-	_, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
-		MessageID: "image-message-1",
+	response, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
+		MessageID: "legacy-ptt-message",
 		Phone:     chatJID.String(),
 	})
 
-	require.ErrorContains(t, err, "not an audio message")
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-ptt-message", response.MessageID)
 }
 
-func TestMarkAsPlayedRejectsMessageFromDifferentChat(t *testing.T) {
-	service, repo, ctx := newMessageActionTestService(t, nil)
-
+func TestMarkAsPlayedRejectsInvalidStoredMessage(t *testing.T) {
+	userChatJID := types.NewJID("628123456789", types.DefaultUserServer)
 	storedGroupJID := types.NewJID("120363000000000001", types.GroupServer)
 	requestedGroupJID := types.NewJID("120363000000000002", types.GroupServer)
+	groupWithoutSenderJID := types.NewJID("120363000000000003", types.GroupServer)
 	senderJID := types.NewJID("628987654321", types.DefaultUserServer)
-	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
-		ID:        "voice-message-2",
-		ChatJID:   storedGroupJID.String(),
-		DeviceID:  "device-a@s.whatsapp.net",
-		Sender:    senderJID.String(),
-		Timestamp: time.Now(),
-		MediaType: "audio",
-	}))
-	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
-		return requestedGroupJID, nil
+
+	tests := []struct {
+		name          string
+		message       domainChatStorage.Message
+		requestedChat types.JID
+		errContains   string
+	}{
+		{
+			name: "non-audio message",
+			message: domainChatStorage.Message{
+				ID: "image-message-1", ChatJID: userChatJID.String(), Sender: userChatJID.String(), MediaType: "image",
+			},
+			requestedChat: userChatJID,
+			errContains:   "not an audio message",
+		},
+		{
+			name: "message from different chat",
+			message: domainChatStorage.Message{
+				ID: "voice-message-2", ChatJID: storedGroupJID.String(), Sender: senderJID.String(), MediaType: "audio",
+			},
+			requestedChat: requestedGroupJID,
+			errContains:   "does not belong to chat",
+		},
+		{
+			name: "group message without sender",
+			message: domainChatStorage.Message{
+				ID: "voice-message-3", ChatJID: groupWithoutSenderJID.String(), MediaType: "audio",
+			},
+			requestedChat: groupWithoutSenderJID,
+			errContains:   "sender is missing",
+		},
+		{
+			name: "outgoing audio message",
+			message: domainChatStorage.Message{
+				ID: "outgoing-voice-message", ChatJID: userChatJID.String(), Sender: "device-a@s.whatsapp.net", IsFromMe: true, MediaType: "audio",
+			},
+			requestedChat: userChatJID,
+			errContains:   "is not an incoming message",
+		},
 	}
-	service.markReadFn = failOnMarkRead(t)
 
-	_, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
-		MessageID: "voice-message-2",
-		Phone:     requestedGroupJID.String(),
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, repo, ctx := newMessageActionTestService(t, nil)
+			message := tt.message
+			message.DeviceID = "device-a@s.whatsapp.net"
+			message.Timestamp = time.Now()
+			require.NoError(t, repo.StoreMessage(&message))
+			service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+				return tt.requestedChat, nil
+			}
+			service.markReadFn = failOnMarkRead(t)
 
-	require.ErrorContains(t, err, "does not belong to chat")
-}
+			response, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
+				MessageID: message.ID,
+				Phone:     tt.requestedChat.String(),
+			})
 
-func TestMarkAsPlayedRejectsGroupMessageWithoutStoredSender(t *testing.T) {
-	service, repo, ctx := newMessageActionTestService(t, nil)
-
-	groupJID := types.NewJID("120363000000000003", types.GroupServer)
-	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
-		ID:        "voice-message-3",
-		ChatJID:   groupJID.String(),
-		DeviceID:  "device-a@s.whatsapp.net",
-		Timestamp: time.Now(),
-		MediaType: "audio",
-	}))
-	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
-		return groupJID, nil
+			assert.ErrorContains(t, err, tt.errContains)
+			assert.Empty(t, response.MessageID)
+		})
 	}
-	service.markReadFn = failOnMarkRead(t)
-
-	_, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
-		MessageID: "voice-message-3",
-		Phone:     groupJID.String(),
-	})
-
-	require.ErrorContains(t, err, "sender is missing")
-}
-
-func TestMarkAsPlayedRejectsOutgoingAudioMessage(t *testing.T) {
-	service, repo, ctx := newMessageActionTestService(t, nil)
-
-	chatJID := types.NewJID("628123456789", types.DefaultUserServer)
-	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
-		ID:        "outgoing-voice-message",
-		ChatJID:   chatJID.String(),
-		DeviceID:  "device-a@s.whatsapp.net",
-		Sender:    "device-a@s.whatsapp.net",
-		Timestamp: time.Now(),
-		IsFromMe:  true,
-		MediaType: "audio",
-	}))
-	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
-		return chatJID, nil
-	}
-	service.markReadFn = failOnMarkRead(t)
-
-	_, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
-		MessageID: "outgoing-voice-message",
-		Phone:     chatJID.String(),
-	})
-
-	require.ErrorContains(t, err, "is not an incoming message")
 }
 
 func TestMessageActionsDeleteStoredMessageAfterWhatsAppSuccess(t *testing.T) {

--- a/src/usecase/message_test.go
+++ b/src/usecase/message_test.go
@@ -20,6 +20,169 @@ import (
 	"go.mau.fi/whatsmeow/types"
 )
 
+func failOnMarkRead(t *testing.T) markReadFunc {
+	t.Helper()
+	return func(context.Context, *whatsmeow.Client, []types.MessageID, time.Time, types.JID, types.JID, ...types.ReceiptType) error {
+		t.Helper()
+		t.Fatal("played receipt must not be sent")
+		return nil
+	}
+}
+
+func TestMarkAsPlayedSendsPlayedReceiptWithStoredGroupSender(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	groupJID := types.NewJID("120363000000000000", types.GroupServer)
+	senderJID := types.NewJID("628987654321", types.DefaultUserServer)
+	require.NoError(t, repo.StoreChat(&domainChatStorage.Chat{
+		DeviceID:        "device-a@s.whatsapp.net",
+		JID:             groupJID.String(),
+		Name:            "Voice group",
+		LastMessageTime: time.Now(),
+	}))
+	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+		ID:        "voice-message-1",
+		ChatJID:   groupJID.String(),
+		DeviceID:  "device-a@s.whatsapp.net",
+		Sender:    senderJID.String(),
+		Timestamp: time.Now(),
+		MediaType: "audio",
+	}))
+
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return groupJID, nil
+	}
+	receiptCalled := false
+	service.markReadFn = func(
+		_ context.Context,
+		_ *whatsmeow.Client,
+		ids []types.MessageID,
+		timestamp time.Time,
+		chat types.JID,
+		sender types.JID,
+		receiptTypes ...types.ReceiptType,
+	) error {
+		receiptCalled = true
+		require.Equal(t, []types.MessageID{"voice-message-1"}, ids)
+		require.False(t, timestamp.IsZero())
+		require.Equal(t, groupJID, chat)
+		require.Equal(t, senderJID, sender)
+		require.Equal(t, []types.ReceiptType{types.ReceiptTypePlayed}, receiptTypes)
+		return nil
+	}
+
+	response, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
+		MessageID: "voice-message-1",
+		Phone:     groupJID.String(),
+	})
+
+	require.NoError(t, err)
+	require.True(t, receiptCalled)
+	require.Equal(t, "voice-message-1", response.MessageID)
+}
+
+func TestMarkAsPlayedRejectsNonAudioMessage(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	chatJID := types.NewJID("628123456789", types.DefaultUserServer)
+	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+		ID:        "image-message-1",
+		ChatJID:   chatJID.String(),
+		DeviceID:  "device-a@s.whatsapp.net",
+		Sender:    chatJID.String(),
+		Timestamp: time.Now(),
+		MediaType: "image",
+	}))
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return chatJID, nil
+	}
+	service.markReadFn = failOnMarkRead(t)
+
+	_, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
+		MessageID: "image-message-1",
+		Phone:     chatJID.String(),
+	})
+
+	require.ErrorContains(t, err, "not an audio message")
+}
+
+func TestMarkAsPlayedRejectsMessageFromDifferentChat(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	storedGroupJID := types.NewJID("120363000000000001", types.GroupServer)
+	requestedGroupJID := types.NewJID("120363000000000002", types.GroupServer)
+	senderJID := types.NewJID("628987654321", types.DefaultUserServer)
+	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+		ID:        "voice-message-2",
+		ChatJID:   storedGroupJID.String(),
+		DeviceID:  "device-a@s.whatsapp.net",
+		Sender:    senderJID.String(),
+		Timestamp: time.Now(),
+		MediaType: "audio",
+	}))
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return requestedGroupJID, nil
+	}
+	service.markReadFn = failOnMarkRead(t)
+
+	_, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
+		MessageID: "voice-message-2",
+		Phone:     requestedGroupJID.String(),
+	})
+
+	require.ErrorContains(t, err, "does not belong to chat")
+}
+
+func TestMarkAsPlayedRejectsGroupMessageWithoutStoredSender(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	groupJID := types.NewJID("120363000000000003", types.GroupServer)
+	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+		ID:        "voice-message-3",
+		ChatJID:   groupJID.String(),
+		DeviceID:  "device-a@s.whatsapp.net",
+		Timestamp: time.Now(),
+		MediaType: "audio",
+	}))
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return groupJID, nil
+	}
+	service.markReadFn = failOnMarkRead(t)
+
+	_, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
+		MessageID: "voice-message-3",
+		Phone:     groupJID.String(),
+	})
+
+	require.ErrorContains(t, err, "sender is missing")
+}
+
+func TestMarkAsPlayedRejectsOutgoingAudioMessage(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	chatJID := types.NewJID("628123456789", types.DefaultUserServer)
+	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+		ID:        "outgoing-voice-message",
+		ChatJID:   chatJID.String(),
+		DeviceID:  "device-a@s.whatsapp.net",
+		Sender:    "device-a@s.whatsapp.net",
+		Timestamp: time.Now(),
+		IsFromMe:  true,
+		MediaType: "audio",
+	}))
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return chatJID, nil
+	}
+	service.markReadFn = failOnMarkRead(t)
+
+	_, err := service.MarkAsPlayed(ctx, domainMessage.MarkAsPlayedRequest{
+		MessageID: "outgoing-voice-message",
+		Phone:     chatJID.String(),
+	})
+
+	require.ErrorContains(t, err, "is not an incoming message")
+}
+
 func TestMessageActionsDeleteStoredMessageAfterWhatsAppSuccess(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Context

- Add `POST /message/:message_id/played` to send WhatsApp's played receipt for incoming audio and voice-note messages.
- Resolve messages through device-scoped chat storage, verify the requested chat and audio direction/type, and use the original participant JID for group receipts.
- Add the equivalent MCP `mark_played` action and document the REST endpoint in OpenAPI.
- Cover the use case, REST route, MCP dispatch, and MCP schema with regression tests.

Closes #787

## Test Results

- `go test ./... -count=1`
- `go test -race ./usecase ./ui/rest ./ui/mcp -count=1`
- `go vet ./...`
- `go build ./...`
- Parsed `docs/openapi.yaml` successfully with PyYAML
- `gofmt` and `git diff --check`
