### PR TITLE
fix(message): use original group sender for read receipts

### DIFF
--- a/src/domains/chatstorage/interfaces.go
+++ b/src/domains/chatstorage/interfaces.go
@@ -26,8 +26,9 @@ type IChatStorageRepository interface {
 	StoreMessage(message *Message) error
 	StoreMessageEdit(edit *MessageEdit) error
 	StoreMessagesBatch(messages []*Message) error
-	GetMessageByID(id string) (*Message, error)                    // New method for efficient ID-only search
-	GetMessageByIDAndDevice(deviceID, id string) (*Message, error) // Device-scoped ID lookup for device-isolated flows
+	GetMessageByID(id string) (*Message, error)                                 // New method for efficient ID-only search
+	GetMessageByIDAndDevice(deviceID, id string) (*Message, error)              // Device-scoped ID lookup for device-isolated flows
+	GetMessageByIDChatAndDevice(deviceID, chatJID, id string) (*Message, error) // Full storage identity lookup for chat-scoped flows
 	GetMessageEdits(originalMessageID, deviceID string) ([]*MessageEdit, error)
 	GetMessages(filter *MessageFilter) ([]*Message, error)
 	SearchMessages(deviceID, chatJID, searchText string, limit int) ([]*Message, error) // Database-level search with device isolation

--- a/src/infrastructure/chatstorage/sqlite_repository_message_lookup.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_message_lookup.go
@@ -1,0 +1,28 @@
+package chatstorage
+
+import (
+	"database/sql"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+)
+
+// GetMessageByIDChatAndDevice retrieves a message by its full storage identity.
+// The messages table is keyed by (id, chat_jid, device_id), so callers that
+// already know the chat must include it to avoid selecting a colliding ID from
+// another conversation on the same device.
+func (r *SQLiteRepository) GetMessageByIDChatAndDevice(deviceID, chatJID, id string) (*domainChatStorage.Message, error) {
+	query := `
+		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
+			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
+			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
+		FROM messages
+		WHERE id = ? AND chat_jid = ? AND device_id = ?
+		LIMIT 1
+	`
+
+	message, err := r.scanMessage(r.db.QueryRow(query, id, chatJID, deviceID))
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return message, err
+}

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -103,6 +103,14 @@ func (r *deviceChatStorage) GetMessageByIDAndDevice(deviceID, id string) (*domai
 	return r.base.GetMessageByIDAndDevice(targetDeviceID, id)
 }
 
+func (r *deviceChatStorage) GetMessageByIDChatAndDevice(deviceID, chatJID, id string) (*domainChatStorage.Message, error) {
+	targetDeviceID := deviceID
+	if targetDeviceID == "" {
+		targetDeviceID = r.deviceID
+	}
+	return r.base.GetMessageByIDChatAndDevice(targetDeviceID, chatJID, id)
+}
+
 func (r *deviceChatStorage) GetMessageEdits(originalMessageID, deviceID string) ([]*domainChatStorage.MessageEdit, error) {
 	targetDeviceID := deviceID
 	if targetDeviceID == "" {

--- a/src/usecase/message.go
+++ b/src/usecase/message.go
@@ -84,6 +84,35 @@ func (service serviceMessage) deleteStoredMessage(ctx context.Context, client *w
 	return nil
 }
 
+func isGroupReadSenderServer(server string) bool {
+	switch server {
+	case types.DefaultUserServer, types.HiddenUserServer, types.LegacyUserServer, types.MessengerServer:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeGroupReadSender(ctx context.Context, client *whatsmeow.Client, rawSender string, messageID string) (types.JID, error) {
+	if rawSender == "" {
+		return types.JID{}, fmt.Errorf("sender is missing for group message %s", messageID)
+	}
+
+	senderJID, err := utils.ParseJID(rawSender)
+	if err != nil {
+		return types.JID{}, fmt.Errorf("failed to parse sender for message %s: %w", messageID, err)
+	}
+	senderJID = senderJID.ToNonAD()
+
+	if senderJID.Server == types.HiddenUserServer {
+		senderJID = utils.ResolveLIDToPhone(ctx, senderJID, client).ToNonAD()
+	}
+	if senderJID.User == "" || !isGroupReadSenderServer(senderJID.Server) {
+		return types.JID{}, fmt.Errorf("invalid sender JID %s for group message %s", senderJID.String(), messageID)
+	}
+	return senderJID, nil
+}
+
 func (service serviceMessage) MarkAsRead(ctx context.Context, request domainMessage.MarkAsReadRequest) (response domainMessage.GenericResponse, err error) {
 	if err = validations.ValidateMarkAsRead(ctx, request); err != nil {
 		return response, err
@@ -94,21 +123,51 @@ func (service serviceMessage) MarkAsRead(ctx context.Context, request domainMess
 		return response, pkgError.ErrWaCLI
 	}
 
-	dataWaRecipient, err := utils.ValidateJidWithLogin(client, request.Phone)
+	chatJID, err := service.validateJID(client, request.Phone)
 	if err != nil {
 		return response, err
 	}
 
+	senderJID := client.Store.ID.ToNonAD()
+	if chatJID.Server == types.GroupServer {
+		if service.chatStorageRepo == nil {
+			return response, fmt.Errorf("cannot mark message %s as read without chat storage", request.MessageID)
+		}
+
+		message, lookupErr := service.chatStorageRepo.GetMessageByIDChatAndDevice(
+			deviceIDFromContext(ctx),
+			chatJID.ToNonAD().String(),
+			request.MessageID,
+		)
+		if lookupErr != nil {
+			return response, fmt.Errorf("failed to resolve message %s: %w", request.MessageID, lookupErr)
+		}
+		if message == nil {
+			return response, fmt.Errorf(
+				"message with ID %s not found for current device and chat %s",
+				request.MessageID,
+				chatJID.ToNonAD().String(),
+			)
+		}
+
+		if !message.IsFromMe {
+			senderJID, err = normalizeGroupReadSender(ctx, client, message.Sender, request.MessageID)
+			if err != nil {
+				return response, err
+			}
+		}
+	}
+
 	ids := []types.MessageID{request.MessageID}
-	if err = client.MarkRead(ctx, ids, time.Now(), dataWaRecipient, *client.Store.ID); err != nil {
+	if err = service.markRead(ctx, client, ids, time.Now(), chatJID, senderJID); err != nil {
 		return response, err
 	}
 
 	logrus.Info(map[string]any{
 		"phone":      request.Phone,
 		"message_id": request.MessageID,
-		"chat":       dataWaRecipient.String(),
-		"sender":     client.Store.ID.String(),
+		"chat":       chatJID.String(),
+		"sender":     senderJID.String(),
 	})
 
 	response.MessageID = request.MessageID

--- a/src/usecase/message_mark_read_test.go
+++ b/src/usecase/message_mark_read_test.go
@@ -1,0 +1,275 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	domainMessage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func failOnReadReceipt(t *testing.T) markReadFunc {
+	t.Helper()
+	return func(context.Context, *whatsmeow.Client, []types.MessageID, time.Time, types.JID, types.JID, ...types.ReceiptType) error {
+		t.Helper()
+		t.Fatal("read receipt must not be sent")
+		return nil
+	}
+}
+
+func storeGroupMessageForReadTest(t *testing.T, repo domainChatStorage.IChatStorageRepository, deviceID string, groupJID, senderJID types.JID, messageID string) {
+	t.Helper()
+	require.NoError(t, repo.StoreChat(&domainChatStorage.Chat{
+		DeviceID:        deviceID,
+		JID:             groupJID.String(),
+		Name:            "Read receipt group",
+		LastMessageTime: time.Now(),
+	}))
+	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+		ID:        messageID,
+		ChatJID:   groupJID.String(),
+		DeviceID:  deviceID,
+		Sender:    senderJID.String(),
+		Content:   "stored incoming message",
+		Timestamp: time.Now(),
+	}))
+}
+
+func TestMarkAsReadSendsReceiptWithStoredGroupSender(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	groupJID := types.NewJID("120363000000000000", types.GroupServer)
+	senderJID := types.NewJID("628987654321", types.DefaultUserServer)
+	storeGroupMessageForReadTest(t, repo, "device-a@s.whatsapp.net", groupJID, senderJID, "group-message-1")
+
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return groupJID, nil
+	}
+	receiptCalled := false
+	service.markReadFn = func(
+		_ context.Context,
+		_ *whatsmeow.Client,
+		ids []types.MessageID,
+		timestamp time.Time,
+		chat types.JID,
+		sender types.JID,
+		receiptTypes ...types.ReceiptType,
+	) error {
+		receiptCalled = true
+		require.Equal(t, []types.MessageID{"group-message-1"}, ids)
+		require.False(t, timestamp.IsZero())
+		require.Equal(t, groupJID, chat)
+		require.Equal(t, senderJID, sender)
+		require.Empty(t, receiptTypes)
+		return nil
+	}
+
+	response, err := service.MarkAsRead(ctx, domainMessage.MarkAsReadRequest{
+		MessageID: "group-message-1",
+		Phone:     groupJID.String(),
+	})
+
+	require.NoError(t, err)
+	require.True(t, receiptCalled)
+	require.Equal(t, "group-message-1", response.MessageID)
+}
+
+func TestMarkAsReadSelectsMessageByChatWhenIDCollides(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	const messageID = "duplicate-group-message"
+	otherGroupJID := types.NewJID("120363000000000010", types.GroupServer)
+	targetGroupJID := types.NewJID("120363000000000020", types.GroupServer)
+	otherSenderJID := types.NewJID("628111111111", types.DefaultUserServer)
+	targetSenderJID := types.NewJID("628222222222", types.DefaultUserServer)
+
+	// Store the colliding row first. An ID+device-only lookup can select this
+	// row even though the request targets targetGroupJID.
+	storeGroupMessageForReadTest(t, repo, "device-a@s.whatsapp.net", otherGroupJID, otherSenderJID, messageID)
+	storeGroupMessageForReadTest(t, repo, "device-a@s.whatsapp.net", targetGroupJID, targetSenderJID, messageID)
+
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return targetGroupJID, nil
+	}
+	service.markReadFn = func(
+		_ context.Context,
+		_ *whatsmeow.Client,
+		ids []types.MessageID,
+		_ time.Time,
+		chat types.JID,
+		sender types.JID,
+		_ ...types.ReceiptType,
+	) error {
+		require.Equal(t, []types.MessageID{messageID}, ids)
+		require.Equal(t, targetGroupJID, chat)
+		require.Equal(t, targetSenderJID, sender)
+		return nil
+	}
+
+	response, err := service.MarkAsRead(ctx, domainMessage.MarkAsReadRequest{
+		MessageID: messageID,
+		Phone:     targetGroupJID.String(),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, messageID, response.MessageID)
+}
+
+func TestMarkAsReadRejectsGroupMessageFromAnotherDevice(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	groupJID := types.NewJID("120363000000000001", types.GroupServer)
+	senderJID := types.NewJID("628987654321", types.DefaultUserServer)
+	storeGroupMessageForReadTest(t, repo, "device-b@s.whatsapp.net", groupJID, senderJID, "other-device-message")
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return groupJID, nil
+	}
+	service.markReadFn = failOnReadReceipt(t)
+
+	response, err := service.MarkAsRead(ctx, domainMessage.MarkAsReadRequest{
+		MessageID: "other-device-message",
+		Phone:     groupJID.String(),
+	})
+
+	assert.ErrorContains(t, err, "not found for current device")
+	assert.Empty(t, response.MessageID)
+}
+
+func TestMarkAsReadRejectsMessageFromDifferentGroup(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	storedGroupJID := types.NewJID("120363000000000002", types.GroupServer)
+	requestedGroupJID := types.NewJID("120363000000000003", types.GroupServer)
+	senderJID := types.NewJID("628987654321", types.DefaultUserServer)
+	storeGroupMessageForReadTest(t, repo, "device-a@s.whatsapp.net", storedGroupJID, senderJID, "wrong-group-message")
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return requestedGroupJID, nil
+	}
+	service.markReadFn = failOnReadReceipt(t)
+
+	response, err := service.MarkAsRead(ctx, domainMessage.MarkAsReadRequest{
+		MessageID: "wrong-group-message",
+		Phone:     requestedGroupJID.String(),
+	})
+
+	assert.ErrorContains(t, err, "not found for current device and chat")
+	assert.Empty(t, response.MessageID)
+}
+
+func TestMarkAsReadRejectsGroupMessageWithoutSender(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	groupJID := types.NewJID("120363000000000004", types.GroupServer)
+	storeGroupMessageForReadTest(t, repo, "device-a@s.whatsapp.net", groupJID, types.JID{}, "missing-sender-message")
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return groupJID, nil
+	}
+	service.markReadFn = failOnReadReceipt(t)
+
+	response, err := service.MarkAsRead(ctx, domainMessage.MarkAsReadRequest{
+		MessageID: "missing-sender-message",
+		Phone:     groupJID.String(),
+	})
+
+	assert.ErrorContains(t, err, "sender is missing")
+	assert.Empty(t, response.MessageID)
+}
+
+func TestMarkAsReadRejectsNonUserGroupSender(t *testing.T) {
+	service, repo, ctx := newMessageActionTestService(t, nil)
+
+	groupJID := types.NewJID("120363000000000005", types.GroupServer)
+	invalidSenderJID := types.NewJID("120363999999999999", types.GroupServer)
+	storeGroupMessageForReadTest(t, repo, "device-a@s.whatsapp.net", groupJID, invalidSenderJID, "invalid-sender-message")
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return groupJID, nil
+	}
+	service.markReadFn = failOnReadReceipt(t)
+
+	response, err := service.MarkAsRead(ctx, domainMessage.MarkAsReadRequest{
+		MessageID: "invalid-sender-message",
+		Phone:     groupJID.String(),
+	})
+
+	assert.ErrorContains(t, err, "invalid sender")
+	assert.Empty(t, response.MessageID)
+}
+
+func TestMarkAsReadAcceptsSupportedUserSenderServers(t *testing.T) {
+	supportedServers := []string{
+		types.DefaultUserServer,
+		types.HiddenUserServer,
+		types.LegacyUserServer,
+		types.MessengerServer,
+	}
+
+	for index, server := range supportedServers {
+		t.Run(server, func(t *testing.T) {
+			service, repo, ctx := newMessageActionTestService(t, nil)
+			groupJID := types.NewJID("12036300000000010"+string(rune('0'+index)), types.GroupServer)
+			senderJID := types.NewJID("62898765432"+string(rune('0'+index)), server)
+			messageID := "supported-sender-" + server
+			storeGroupMessageForReadTest(t, repo, "device-a@s.whatsapp.net", groupJID, senderJID, messageID)
+			service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+				return groupJID, nil
+			}
+			service.markReadFn = func(
+				_ context.Context,
+				_ *whatsmeow.Client,
+				_ []types.MessageID,
+				_ time.Time,
+				_ types.JID,
+				gotSender types.JID,
+				_ ...types.ReceiptType,
+			) error {
+				require.Equal(t, senderJID.ToNonAD(), gotSender)
+				return nil
+			}
+
+			_, err := service.MarkAsRead(ctx, domainMessage.MarkAsReadRequest{
+				MessageID: messageID,
+				Phone:     groupJID.String(),
+			})
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestMarkAsReadKeepsDirectChatBehaviorWithoutStorage(t *testing.T) {
+	service, _, ctx := newMessageActionTestService(t, nil)
+	service.chatStorageRepo = nil
+
+	chatJID := types.NewJID("628123456789", types.DefaultUserServer)
+	deviceJID := types.NewJID("device-a", types.DefaultUserServer)
+	service.validateJIDFn = func(_ *whatsmeow.Client, _ string) (types.JID, error) {
+		return chatJID, nil
+	}
+	service.markReadFn = func(
+		_ context.Context,
+		_ *whatsmeow.Client,
+		ids []types.MessageID,
+		_ time.Time,
+		chat types.JID,
+		sender types.JID,
+		receiptTypes ...types.ReceiptType,
+	) error {
+		require.Equal(t, []types.MessageID{"direct-message"}, ids)
+		require.Equal(t, chatJID, chat)
+		require.Equal(t, deviceJID, sender)
+		require.Empty(t, receiptTypes)
+		return nil
+	}
+
+	response, err := service.MarkAsRead(ctx, domainMessage.MarkAsReadRequest{
+		MessageID: "direct-message",
+		Phone:     chatJID.String(),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "direct-message", response.MessageID)
+}


### PR DESCRIPTION
## Context

`MarkAsRead` previously passed the active device JID as the `sender` argument to whatsmeow for every read receipt. In group chats, the receipt participant must be the original message sender; using our own device JID can make an incoming group read receipt ineffective even though the call itself succeeds.

This is a focused replacement for the still-needed `MarkAsRead` fix from #772. It intentionally excludes the unrelated URL/port, download-media, and document-filename changes that accumulated there.

## Changes

- Use the existing injectable `service.validateJID` / `service.markRead` path.
- Resolve group messages by their full storage identity: `(device_id, chat_jid, message_id)` using the normalized non-AD chat JID.
- Delegate the new chat-scoped lookup through the per-device chat-storage wrapper.
- Normalize stored sender JIDs to non-AD form and resolve `@lid` to PN when a mapping is available.
- Accept only supported user sender servers before calling `MarkRead`: `s.whatsapp.net`, `lid`, `c.us`, and `msgr`.
- Reject missing or non-user group senders instead of falling back to our own device JID.
- Preserve the existing direct-chat behavior without requiring chat storage.

## Regression coverage

Added focused tests for:

- incoming group receipts using the stored original sender;
- duplicate message IDs across two groups on the same device selecting the requested chat row;
- messages from another device or another group being rejected;
- missing and non-user (`@g.us`) group senders being rejected before the wire call;
- supported user sender servers remaining accepted;
- direct-chat behavior remaining compatible without chat storage.

## Verification

The review regressions were written first and reproduced both reported failures against the previous implementation: the duplicate-ID lookup selected the wrong chat row, and a `@g.us` sender reached the receipt call.

After the fixes, verification passed with:

```text
go test ./usecase -run TestMarkAsRead -count=1
go test ./infrastructure/chatstorage -count=1
go test ./... -count=1
go vet ./...
```

The final branch is one commit ahead of current `main`, changes only source/test files, and contains no temporary PR workflow.