### PR TITLE
feat(newsletter): add media download endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3662,6 +3662,54 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorInternalServer'
 
+  /newsletter/messages/{server_id}/download:
+    get:
+      operationId: downloadNewsletterMessageMedia
+      tags:
+        - newsletter
+      summary: Download media from a newsletter message
+      description: |
+        Fetches one newsletter message directly from WhatsApp by server ID,
+        downloads its media to the server's statics directory, and returns the
+        saved file metadata and public URL. Supported media types are images,
+        videos, video notes, audio, documents, and stickers.
+      parameters:
+        - $ref: '#/components/parameters/DeviceIdHeader'
+        - name: server_id
+          in: path
+          required: true
+          description: Newsletter message server ID returned by GET /newsletter/messages
+          schema:
+            type: integer
+            minimum: 1
+          example: 8872
+        - name: newsletter_id
+          in: query
+          required: true
+          description: Newsletter JID containing the message
+          schema:
+            type: string
+          example: '120363024512399999@newsletter'
+      responses:
+        '200':
+          description: Media downloaded successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NewsletterMediaDownloadResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBadRequest'
+        '500':
+          description: Message lookup or media download failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInternalServer'
+
   /chatwoot/sync:
     post:
       operationId: chatwootSyncHistory
@@ -4990,6 +5038,52 @@ components:
         text:
           type: string
           example: "Hello from the channel!"
+    NewsletterMediaDownloadResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 200
+        code:
+          type: string
+          example: SUCCESS
+        message:
+          type: string
+          example: Media downloaded successfully
+        results:
+          type: object
+          properties:
+            server_id:
+              type: integer
+              example: 8872
+            message_id:
+              type: string
+              example: ACBD7F85529AAD63FAF376F622351D14
+            status:
+              type: string
+              example: Media downloaded successfully to statics/media/120363024512399999/2026-08-28/image.jpg
+            media_type:
+              type: string
+              enum: [image, video, video_note, audio, document, sticker]
+              example: image
+            mime_type:
+              type: string
+              example: image/jpeg
+            filename:
+              type: string
+              example: image.jpg
+            file_path:
+              type: string
+              description: Local server path where the downloaded media was saved
+              example: statics/media/120363024512399999/2026-08-28/image.jpg
+            file_url:
+              type: string
+              description: Public URL for the saved media file
+              example: http://localhost:3000/statics/media/120363024512399999/2026-08-28/image.jpg
+            file_size:
+              type: integer
+              format: int64
+              example: 524288
     MyListContactsResponse:
       type: object
       properties:

--- a/readme.md
+++ b/readme.md
@@ -699,6 +699,7 @@ You may also fork or modify the source code.
 | ✅       | Get Group Invite Link                  | GET    | /group/invite-link                  |
 | ✅       | Unfollow Newsletter                    | POST   | /newsletter/unfollow                |
 | ✅       | Get Newsletter Messages                | GET    | /newsletter/messages                |
+| ✅       | Download Newsletter Message Media      | GET    | /newsletter/messages/{server_id}/download |
 | ✅       | Get Chat List                          | GET    | /chats                              |
 | ✅       | Get Chat Messages                      | GET    | /chat/:chat_jid/messages            |
 | ✅       | Pin Chat                               | POST   | /chat/:chat_jid/pin                 |

--- a/src/domains/newsletter/newsletter.go
+++ b/src/domains/newsletter/newsletter.go
@@ -5,6 +5,7 @@ import "context"
 type INewsletterUsecase interface {
 	Unfollow(ctx context.Context, request UnfollowRequest) (err error)
 	GetMessages(ctx context.Context, request GetMessagesRequest) (response GetMessagesResponse, err error)
+	DownloadMedia(ctx context.Context, request DownloadMediaRequest) (response DownloadMediaResponse, err error)
 }
 
 type UnfollowRequest struct {
@@ -36,4 +37,21 @@ type Message struct {
 
 type GetMessagesResponse struct {
 	Data []Message `json:"data"`
+}
+
+type DownloadMediaRequest struct {
+	NewsletterID string `json:"newsletter_id" query:"newsletter_id"`
+	ServerID     int    `json:"server_id" uri:"server_id"`
+}
+
+type DownloadMediaResponse struct {
+	ServerID  int    `json:"server_id"`
+	MessageID string `json:"message_id"`
+	Status    string `json:"status"`
+	MediaType string `json:"media_type"`
+	MimeType  string `json:"mime_type"`
+	Filename  string `json:"filename"`
+	FilePath  string `json:"file_path"`
+	FileURL   string `json:"file_url,omitempty"`
+	FileSize  int64  `json:"file_size"`
 }

--- a/src/ui/rest/newsletter.go
+++ b/src/ui/rest/newsletter.go
@@ -1,8 +1,11 @@
 package rest
 
 import (
+	"strconv"
+
 	domainNewsletter "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/newsletter"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
+	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/gofiber/fiber/v3"
 )
@@ -15,6 +18,7 @@ func InitRestNewsletter(app fiber.Router, service domainNewsletter.INewsletterUs
 	rest := Newsletter{Service: service}
 	app.Post("/newsletter/unfollow", rest.Unfollow)
 	app.Get("/newsletter/messages", rest.GetMessages)
+	app.Get("/newsletter/messages/:server_id/download", rest.DownloadMedia)
 	return rest
 }
 
@@ -45,6 +49,30 @@ func (controller *Newsletter) GetMessages(c fiber.Ctx) error {
 		Status:  200,
 		Code:    "SUCCESS",
 		Message: "Success get newsletter messages",
+		Results: response,
+	})
+}
+
+func (controller *Newsletter) DownloadMedia(c fiber.Ctx) error {
+	var request domainNewsletter.DownloadMediaRequest
+	err := c.Bind().Query(&request)
+	utils.PanicIfNeeded(err)
+
+	request.ServerID, err = strconv.Atoi(c.Params("server_id"))
+	if err != nil {
+		utils.PanicIfNeeded(pkgError.ValidationError("server_id: must be a valid integer."))
+	}
+
+	response, err := controller.Service.DownloadMedia(whatsapp.ContextWithDevice(c.Context(), getDeviceFromCtx(c)), request)
+	utils.PanicIfNeeded(err)
+	if response.FileURL == "" {
+		response.FileURL = publicStaticFileURL(c, response.FilePath)
+	}
+
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: response.Status,
 		Results: response,
 	})
 }

--- a/src/ui/rest/newsletter_test.go
+++ b/src/ui/rest/newsletter_test.go
@@ -1,0 +1,73 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+	domainNewsletter "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/newsletter"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type newsletterServiceStub struct {
+	domainNewsletter.INewsletterUsecase
+	request       *domainNewsletter.DownloadMediaRequest
+	contextDevice *whatsapp.DeviceInstance
+}
+
+func (stub *newsletterServiceStub) DownloadMedia(ctx context.Context, request domainNewsletter.DownloadMediaRequest) (domainNewsletter.DownloadMediaResponse, error) {
+	stub.request = &request
+	stub.contextDevice, _ = whatsapp.DeviceFromContext(ctx)
+	return domainNewsletter.DownloadMediaResponse{
+		ServerID:  request.ServerID,
+		MessageID: "ACBD7F85529AAD63FAF376F622351D14",
+		Status:    "Media downloaded successfully",
+		MediaType: "image",
+		MimeType:  "image/jpeg",
+		Filename:  "result.jpg",
+		FilePath:  "statics/media/120363123456789/2026-08-28/result.jpg",
+		FileSize:  1234,
+	}, nil
+}
+
+func TestDownloadNewsletterMediaRoute(t *testing.T) {
+	oldBasePath := config.AppBasePath
+	config.AppBasePath = "/api"
+	defer func() {
+		config.AppBasePath = oldBasePath
+	}()
+
+	device := whatsapp.NewDeviceInstance("device-a", nil, nil)
+	service := &newsletterServiceStub{}
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals("device", device)
+		return c.Next()
+	})
+	InitRestNewsletter(app, service)
+
+	request := httptest.NewRequest(
+		"GET",
+		"http://example.com/newsletter/messages/8872/download?newsletter_id=120363123456789%40newsletter",
+		nil,
+	)
+	response, err := app.Test(request)
+
+	require.NoError(t, err)
+	require.Equal(t, fiber.StatusOK, response.StatusCode)
+	require.NotNil(t, service.request)
+	assert.Equal(t, 8872, service.request.ServerID)
+	assert.Equal(t, "120363123456789@newsletter", service.request.NewsletterID)
+	assert.Same(t, device, service.contextDevice)
+
+	var body struct {
+		Results domainNewsletter.DownloadMediaResponse `json:"results"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+	assert.Equal(t, "http://example.com/api/statics/media/120363123456789/2026-08-28/result.jpg", body.Results.FileURL)
+}

--- a/src/usecase/newsletter.go
+++ b/src/usecase/newsletter.go
@@ -2,14 +2,20 @@ package usecase
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	domainNewsletter "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/newsletter"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/validations"
+	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 )
 
@@ -78,4 +84,98 @@ func (service serviceNewsletter) GetMessages(ctx context.Context, request domain
 	}
 
 	return response, nil
+}
+
+func (service serviceNewsletter) DownloadMedia(ctx context.Context, request domainNewsletter.DownloadMediaRequest) (response domainNewsletter.DownloadMediaResponse, err error) {
+	if err = validations.ValidateDownloadNewsletterMedia(ctx, request); err != nil {
+		return response, err
+	}
+
+	client := whatsapp.ClientFromContext(ctx)
+	if client == nil {
+		return response, pkgError.ErrWaCLI
+	}
+
+	JID, err := utils.ValidateJidWithLogin(client, request.NewsletterID)
+	if err != nil {
+		return response, err
+	}
+
+	messages, err := client.GetNewsletterMessages(ctx, JID, &whatsmeow.GetNewsletterMessagesParams{
+		Count:  1,
+		Before: types.MessageServerID(request.ServerID + 1),
+	})
+	if err != nil {
+		return response, fmt.Errorf("failed to get newsletter message: %w", err)
+	}
+
+	message, err := findNewsletterMessage(messages, request.ServerID)
+	if err != nil {
+		return response, err
+	}
+
+	downloadable, mediaType, err := newsletterDownloadableMedia(message.Message)
+	if err != nil {
+		return response, fmt.Errorf("newsletter message %d does not contain downloadable media", request.ServerID)
+	}
+
+	newsletterDir := utils.ExtractPhoneNumber(JID.String())
+	dateDir := filepath.Join(config.PathMedia, newsletterDir, message.Timestamp.Format("2006-01-02"))
+	if err = os.MkdirAll(dateDir, 0755); err != nil {
+		return response, fmt.Errorf("failed to create media directory: %w", err)
+	}
+
+	extractedMedia, err := utils.ExtractMedia(ctx, client, dateDir, downloadable)
+	if err != nil {
+		return response, fmt.Errorf("failed to download newsletter media: %w", err)
+	}
+
+	fileInfo, statErr := os.Stat(extractedMedia.MediaPath)
+	if statErr != nil {
+		logrus.Warnf("Could not get file size for %s: %v", extractedMedia.MediaPath, statErr)
+	}
+
+	response.ServerID = request.ServerID
+	response.MessageID = string(message.MessageID)
+	response.Status = fmt.Sprintf("Media downloaded successfully to %s", extractedMedia.MediaPath)
+	response.MediaType = mediaType
+	response.MimeType = extractedMedia.MimeType
+	response.Filename = filepath.Base(extractedMedia.MediaPath)
+	response.FilePath = extractedMedia.MediaPath
+	if fileInfo != nil {
+		response.FileSize = fileInfo.Size()
+	}
+
+	return response, nil
+}
+
+func findNewsletterMessage(messages []*types.NewsletterMessage, serverID int) (*types.NewsletterMessage, error) {
+	for _, message := range messages {
+		if message != nil && int(message.MessageServerID) == serverID {
+			return message, nil
+		}
+	}
+
+	return nil, fmt.Errorf("newsletter message with server ID %d not found", serverID)
+}
+
+func newsletterDownloadableMedia(message *waE2E.Message) (whatsmeow.DownloadableMessage, string, error) {
+	if message != nil {
+		switch {
+		case message.GetImageMessage() != nil:
+			return message.GetImageMessage(), "image", nil
+		case message.GetVideoMessage() != nil:
+			return message.GetVideoMessage(), "video", nil
+		case message.GetPtvMessage() != nil:
+			return message.GetPtvMessage(), "video_note", nil
+		case message.GetAudioMessage() != nil:
+			return message.GetAudioMessage(), "audio", nil
+		case message.GetDocumentMessage() != nil:
+			return message.GetDocumentMessage(), "document", nil
+		case message.GetStickerMessage() != nil:
+			return message.GetStickerMessage(), "sticker", nil
+		}
+	}
+
+	return nil, "", fmt.Errorf("newsletter message does not contain downloadable media")
 }

--- a/src/usecase/newsletter_test.go
+++ b/src/usecase/newsletter_test.go
@@ -1,0 +1,98 @@
+package usecase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+)
+
+func TestFindNewsletterMessage(t *testing.T) {
+	target := &types.NewsletterMessage{MessageServerID: 8872, MessageID: "target"}
+
+	tests := []struct {
+		name     string
+		messages []*types.NewsletterMessage
+		serverID int
+		want     *types.NewsletterMessage
+		wantErr  string
+	}{
+		{
+			name:     "finds exact server id",
+			messages: []*types.NewsletterMessage{{MessageServerID: 8871}, target},
+			serverID: 8872,
+			want:     target,
+		},
+		{
+			name:     "rejects empty result",
+			serverID: 8872,
+			wantErr:  "newsletter message with server ID 8872 not found",
+		},
+		{
+			name:     "rejects mismatched result",
+			messages: []*types.NewsletterMessage{{MessageServerID: 8871}},
+			serverID: 8872,
+			wantErr:  "newsletter message with server ID 8872 not found",
+		},
+		{
+			name:     "ignores nil entries",
+			messages: []*types.NewsletterMessage{nil},
+			serverID: 8872,
+			wantErr:  "newsletter message with server ID 8872 not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findNewsletterMessage(tt.messages, tt.serverID)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Same(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewsletterDownloadableMedia(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   *waE2E.Message
+		mediaType string
+		wantErr   string
+	}{
+		{name: "image", message: &waE2E.Message{ImageMessage: &waE2E.ImageMessage{}}, mediaType: "image"},
+		{name: "video", message: &waE2E.Message{VideoMessage: &waE2E.VideoMessage{}}, mediaType: "video"},
+		{name: "video note", message: &waE2E.Message{PtvMessage: &waE2E.VideoMessage{}}, mediaType: "video_note"},
+		{name: "audio", message: &waE2E.Message{AudioMessage: &waE2E.AudioMessage{}}, mediaType: "audio"},
+		{name: "document", message: &waE2E.Message{DocumentMessage: &waE2E.DocumentMessage{}}, mediaType: "document"},
+		{name: "sticker", message: &waE2E.Message{StickerMessage: &waE2E.StickerMessage{}}, mediaType: "sticker"},
+		{name: "nil message", wantErr: "newsletter message does not contain downloadable media"},
+		{name: "text only", message: &waE2E.Message{Conversation: stringPointer("hello")}, wantErr: "newsletter message does not contain downloadable media"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			media, mediaType, err := newsletterDownloadableMedia(tt.message)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				assert.Nil(t, media)
+				assert.Empty(t, mediaType)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.NotNil(t, media)
+			assert.Equal(t, tt.mediaType, mediaType)
+		})
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/src/validations/newsletter_validation.go
+++ b/src/validations/newsletter_validation.go
@@ -3,6 +3,7 @@ package validations
 import (
 	"context"
 	"errors"
+	"math"
 	"strings"
 
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
@@ -59,6 +60,9 @@ func validatePositiveServerID(value any) error {
 	serverID, ok := value.(int)
 	if !ok || serverID < 1 {
 		return errors.New("must be no less than 1")
+	}
+	if serverID == math.MaxInt {
+		return errors.New("must be less than the maximum integer value")
 	}
 
 	return nil

--- a/src/validations/newsletter_validation.go
+++ b/src/validations/newsletter_validation.go
@@ -2,6 +2,7 @@ package validations
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
@@ -36,6 +37,28 @@ func ValidateGetNewsletterMessages(ctx context.Context, request *domainNewslette
 
 	if err != nil {
 		return pkgError.ValidationError(err.Error())
+	}
+
+	return nil
+}
+
+func ValidateDownloadNewsletterMedia(ctx context.Context, request domainNewsletter.DownloadMediaRequest) error {
+	err := validation.ValidateStructWithContext(ctx, &request,
+		validation.Field(&request.NewsletterID, validation.Required, validation.By(validateNewsletterJIDShape)),
+		validation.Field(&request.ServerID, validation.By(validatePositiveServerID)),
+	)
+
+	if err != nil {
+		return pkgError.ValidationError(err.Error())
+	}
+
+	return nil
+}
+
+func validatePositiveServerID(value any) error {
+	serverID, ok := value.(int)
+	if !ok || serverID < 1 {
+		return errors.New("must be no less than 1")
 	}
 
 	return nil

--- a/src/validations/newsletter_validation_test.go
+++ b/src/validations/newsletter_validation_test.go
@@ -115,3 +115,54 @@ func TestValidateGetNewsletterMessages(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDownloadNewsletterMedia(t *testing.T) {
+	tests := []struct {
+		name    string
+		request domainNewsletter.DownloadMediaRequest
+		err     any
+	}{
+		{
+			name: "should accept valid request",
+			request: domainNewsletter.DownloadMediaRequest{
+				NewsletterID: "120363123456789@newsletter",
+				ServerID:     8872,
+			},
+		},
+		{
+			name:    "should reject empty newsletter id",
+			request: domainNewsletter.DownloadMediaRequest{ServerID: 8872},
+			err:     pkgError.ValidationError("newsletter_id: cannot be blank."),
+		},
+		{
+			name: "should reject non-newsletter jid",
+			request: domainNewsletter.DownloadMediaRequest{
+				NewsletterID: "120363123456789@g.us",
+				ServerID:     8872,
+			},
+			err: pkgError.ValidationError("newsletter_id: must end with @newsletter."),
+		},
+		{
+			name: "should reject zero server id",
+			request: domainNewsletter.DownloadMediaRequest{
+				NewsletterID: "120363123456789@newsletter",
+			},
+			err: pkgError.ValidationError("server_id: must be no less than 1."),
+		},
+		{
+			name: "should reject negative server id",
+			request: domainNewsletter.DownloadMediaRequest{
+				NewsletterID: "120363123456789@newsletter",
+				ServerID:     -1,
+			},
+			err: pkgError.ValidationError("server_id: must be no less than 1."),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDownloadNewsletterMedia(context.Background(), tt.request)
+			assert.Equal(t, tt.err, err)
+		})
+	}
+}

--- a/src/validations/newsletter_validation_test.go
+++ b/src/validations/newsletter_validation_test.go
@@ -2,6 +2,7 @@ package validations
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	domainNewsletter "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/newsletter"
@@ -156,6 +157,14 @@ func TestValidateDownloadNewsletterMedia(t *testing.T) {
 				ServerID:     -1,
 			},
 			err: pkgError.ValidationError("server_id: must be no less than 1."),
+		},
+		{
+			name: "should reject server id that would overflow lookup boundary",
+			request: domainNewsletter.DownloadMediaRequest{
+				NewsletterID: "120363123456789@newsletter",
+				ServerID:     math.MaxInt,
+			},
+			err: pkgError.ValidationError("server_id: must be less than the maximum integer value."),
 		},
 	}
 


### PR DESCRIPTION
## Summary

- add a dedicated newsletter media download endpoint using newsletter server IDs
- download image, video, video-note, audio, document, and sticker media through whatsmeow
- return local file metadata and a base-path-aware public URL without exposing WhatsApp media secrets
- document the endpoint and cover validation, target selection, media selection, and REST behavior

## API

`GET /newsletter/messages/{server_id}/download?newsletter_id=...`

## Verification

- `go test ./...`
- `go vet ./...`
- OpenAPI YAML parse check

Closes #817