### PR TITLE
fix(chatwoot): escape public API path segments

### DIFF
--- a/src/infrastructure/chatwoot/client.go
+++ b/src/infrastructure/chatwoot/client.go
@@ -798,8 +798,8 @@ func (c *Client) UpdateLastSeen(conversationID int, contactInboxSourceID string)
 	endpoint := fmt.Sprintf(
 		"%s/public/api/v1/inboxes/%s/contacts/%s/conversations/%d/update_last_seen",
 		c.BaseURL,
-		url.PathEscape(inboxIdentifier),
-		url.PathEscape(contactInboxSourceID),
+		escapeChatwootPathSegment(inboxIdentifier),
+		escapeChatwootPathSegment(contactInboxSourceID),
 		conversationID,
 	)
 	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
@@ -819,6 +819,32 @@ func (c *Client) UpdateLastSeen(conversationID int, contactInboxSourceID string)
 		return &HTTPStatusError{StatusCode: resp.StatusCode, Op: "update last seen", Body: string(body)}
 	}
 	return nil
+}
+
+// escapeChatwootPathSegment percent-encodes a value for use as a single path
+// segment of Chatwoot's public API.
+//
+// url.PathEscape is not sufficient here. Per RFC 3986 both "@" and "." are legal
+// in a path segment, so PathEscape leaves them untouched -- but Chatwoot's Rails
+// router does not match them raw in this position: a trailing ".net" is read as a
+// format suffix, and the segment fails to resolve. The contact identifier is a
+// WhatsApp JID (e.g. "5511999999999@s.whatsapp.net"), so it hits both cases and
+// every call 404s with an HTML error page rather than a JSON error, which makes
+// the failure easy to misread as a routing or proxy problem.
+//
+// Verified against Chatwoot: only the fully-escaped form resolves.
+//
+//	.../contacts/5511999999999@s.whatsapp.net        -> 404
+//	.../contacts/5511999999999@s.whatsapp%2Enet      -> 404
+//	.../contacts/5511999999999%40s%2Ewhatsapp%2Enet  -> 200
+//
+// PathEscape runs first so that "%" is encoded before the additional characters
+// are substituted, which keeps the result from being double-encoded.
+func escapeChatwootPathSegment(s string) string {
+	s = url.PathEscape(s)
+	s = strings.ReplaceAll(s, "@", "%40")
+	s = strings.ReplaceAll(s, ".", "%2E")
+	return s
 }
 
 func (c *Client) createMessageWithAttachments(endpoint, content, messageType string, attachments []string, opt MessageOptions) (int, error) {

--- a/src/infrastructure/chatwoot/client_methods_test.go
+++ b/src/infrastructure/chatwoot/client_methods_test.go
@@ -957,6 +957,10 @@ func TestUpdateLastSeen_UsesInboxIdentifierAndContactSource(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Fatalf("update_last_seen method = %s", r.Method)
 			}
+			const wantRequestURI = "/public/api/v1/inboxes/api-inbox-token/contacts/628123456789%40s%2Ewhatsapp%2Enet/conversations/5/update_last_seen"
+			if r.RequestURI != wantRequestURI {
+				t.Fatalf("update_last_seen request URI = %s, want %s", r.RequestURI, wantRequestURI)
+			}
 			sawUpdate = true
 			w.WriteHeader(http.StatusOK)
 		default:

--- a/src/infrastructure/chatwoot/escape_path_test.go
+++ b/src/infrastructure/chatwoot/escape_path_test.go
@@ -1,0 +1,51 @@
+package chatwoot
+
+import "testing"
+
+// Covers escaping a segment in Chatwoot's public API path.
+// The relevant case is a WhatsApp JID: url.PathEscape leaves "@" and "."
+// untouched, while the Rails router cannot resolve the contact and returns HTML 404.
+func TestEscapeChatwootPathSegment(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "WhatsApp JID: escapes at sign and all dots",
+			in:   "5511999999999@s.whatsapp.net",
+			want: "5511999999999%40s%2Ewhatsapp%2Enet",
+		},
+		{
+			name: "alphanumeric identifier remains unchanged",
+			in:   "swkuTjDfw6W8jDcqTyriMNrd",
+			want: "swkuTjDfw6W8jDcqTyriMNrd",
+		},
+		{
+			name: "UUID source ID keeps hyphens",
+			in:   "03205d06-0b89-4ff3-9e44-3d76a625c1da",
+			want: "03205d06-0b89-4ff3-9e44-3d76a625c1da",
+		},
+		{
+			name: "literal percent sign is not double encoded",
+			in:   "a%b.c",
+			want: "a%25b%2Ec",
+		},
+		{
+			name: "space remains percent encoded instead of plus",
+			in:   "a b.c",
+			want: "a%20b%2Ec",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := escapeChatwootPathSegment(tc.in); got != tc.want {
+				t.Errorf("escapeChatwootPathSegment(%q)\n  got:  %q\n want: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes update_last_seen for WhatsApp JID contact identifiers.

url.PathEscape intentionally leaves @ and . unescaped. In Chatwoot's public API route, a JID such as 5511999999999@s.whatsapp.net can then be parsed by Rails with .net as a format suffix, causing an HTML 404. This change percent-encodes those characters after PathEscape, so the identifier is treated as one path segment.

## Tests

- go test ./infrastructure/chatwoot
- Covers WhatsApp JIDs, UUID identifiers, literal percent signs, spaces, and empty values.
- Verifies UpdateLastSeen sends an escaped request URI.