### PR TITLE
fix(chat): preserve peer name for outgoing messages

### DIFF
--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -1903,8 +1903,17 @@ func (r *SQLiteRepository) CreateMessage(ctx context.Context, evt *events.Messag
 		return r.DeleteMessageByDevice(deviceID, revokedMessageID, chatJID)
 	}
 
+	// PushName belongs to the sender. For messages sent from this account, using
+	// it as the peer chat name would label the recipient with our own name.
+	chatNameSenderUser := normalizedSender.User
+	chatNamePushName := evt.Info.PushName
+	if evt.Info.IsFromMe {
+		chatNameSenderUser = normalizedChatJID.User
+		chatNamePushName = ""
+	}
+
 	// Get appropriate chat name using pushname if available (device-scoped)
-	chatName := r.GetChatNameWithPushNameByDevice(deviceID, normalizedChatJID, chatJID, normalizedSender.User, evt.Info.PushName)
+	chatName := r.GetChatNameWithPushNameByDevice(deviceID, normalizedChatJID, chatJID, chatNameSenderUser, chatNamePushName)
 
 	// Get existing chat to preserve ephemeral_expiration and archived status if needed (device-scoped)
 	existingChat, err := r.GetChatByDevice(deviceID, chatJID)

--- a/src/infrastructure/chatstorage/sqlite_repository_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_test.go
@@ -9,7 +9,12 @@ import (
 	"time"
 
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/sqlite"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
 )
 
 func newTestSQLiteRepository(t *testing.T) *SQLiteRepository {
@@ -42,6 +47,55 @@ func TestSQLiteRepositoryInitializesMessageReactionsSchema(t *testing.T) {
 	}
 	if tableName != "message_reactions" {
 		t.Fatalf("expected message_reactions table, got %q", tableName)
+	}
+}
+
+func TestCreateMessageFromMeKeepsPeerChatName(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	accountJID := types.NewJID("15550101000", types.DefaultUserServer)
+	peerJID := types.NewJID("15550102000", types.DefaultUserServer)
+	timestamp := time.Date(2026, time.September, 2, 15, 30, 0, 0, time.UTC)
+
+	if err := repo.StoreChat(&domainChatStorage.Chat{
+		DeviceID:        accountJID.String(),
+		JID:             peerJID.String(),
+		Name:            peerJID.User,
+		LastMessageTime: timestamp.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("store peer chat: %v", err)
+	}
+
+	ctx := whatsapp.ContextWithDevice(
+		context.Background(),
+		whatsapp.NewDeviceInstance(accountJID.String(), nil, repo),
+	)
+	event := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Chat:     peerJID,
+				Sender:   accountJID,
+				IsFromMe: true,
+			},
+			ID:        "outgoing-message-1",
+			PushName:  "Alice Smith",
+			Timestamp: timestamp,
+		},
+		Message: &waE2E.Message{Conversation: proto.String("Hello Bob")},
+	}
+
+	if err := repo.CreateMessage(ctx, event); err != nil {
+		t.Fatalf("create outgoing message: %v", err)
+	}
+
+	chat, err := repo.GetChatByDevice(accountJID.String(), peerJID.String())
+	if err != nil {
+		t.Fatalf("get peer chat: %v", err)
+	}
+	if chat == nil {
+		t.Fatal("expected peer chat")
+	}
+	if chat.Name != peerJID.User {
+		t.Fatalf("outgoing message changed peer chat name to %q, want %q", chat.Name, peerJID.User)
 	}
 }
 


### PR DESCRIPTION
## Context

After pairing account Alice (`+1 555-010-1000`), a chat with saved contact Bob (`+1 555-010-2000`) is initially displayed as Bob. If Alice then sends Bob a message from the primary phone, the linked-device event received by GOWA contains:

- `IsFromMe = true`
- `Chat = 15550102000@s.whatsapp.net`
- `Sender = 15550101000@s.whatsapp.net`
- `PushName = Alice Smith`

`CreateMessage` previously passed the sender's push name to the chat-name resolver. When the existing peer name was a numeric/JID placeholder, it was replaced with `Alice Smith`, so `/chats` and gowa-ui mislabeled Bob's conversation as Alice.

## Fix

For `IsFromMe` events:

- do not use the sender's `PushName` as the peer chat name;
- use the normalized chat JID user as the deterministic fallback.

Incoming-message behavior, group/newsletter naming, LID normalization, and device scoping remain unchanged.

## Test results

- Added `TestCreateMessageFromMeKeepsPeerChatName`.
- Verified the regression test fails before the fix (`"Alice Smith"` replaces Bob's JID placeholder) and passes after it.
- `go test ./... -count=1`
- `go vet ./...`