### PR TITLE
fix(mcp): include JSON payload in read tool text results

### DIFF
--- a/src/ui/mcp/app.go
+++ b/src/ui/mcp/app.go
@@ -56,7 +56,7 @@ func (h *AppHandler) handleApp(ctx context.Context, request mcpg.CallToolRequest
 			return mcpg.NewToolResultError(err.Error()), nil
 		}
 		structured := map[string]any{"is_connected": isConnected, "is_logged_in": isLoggedIn, "device_id": deviceID}
-		return mcpg.NewToolResultStructured(structured, fmt.Sprintf("connected=%t logged_in=%t", isConnected, isLoggedIn)), nil
+		return structuredWithJSON(structured, fmt.Sprintf("connected=%t logged_in=%t", isConnected, isLoggedIn)), nil
 	case "login_qr":
 		resp, err := h.appService.Login(ctx, deviceID)
 		if err != nil {

--- a/src/ui/mcp/chat.go
+++ b/src/ui/mcp/chat.go
@@ -60,13 +60,13 @@ func (h *ChatHandler) handleChat(ctx context.Context, request mcpg.CallToolReque
 		if err != nil {
 			return mcpg.NewToolResultError(err.Error()), nil
 		}
-		return mcpg.NewToolResultStructured(resp, fmt.Sprintf("Retrieved %d chats (offset %d, limit %d)", len(resp.Data), req.Offset, req.Limit)), nil
+		return structuredWithJSON(resp, fmt.Sprintf("Retrieved %d chats (offset %d, limit %d)", len(resp.Data), req.Offset, req.Limit)), nil
 	case "list_contacts":
 		resp, err := h.userService.MyListContacts(ctx)
 		if err != nil {
 			return mcpg.NewToolResultError(err.Error()), nil
 		}
-		return mcpg.NewToolResultStructured(resp, fmt.Sprintf("Found %d contacts", len(resp.Data))), nil
+		return structuredWithJSON(resp, fmt.Sprintf("Found %d contacts", len(resp.Data))), nil
 	case "get_messages":
 		chatJID := request.GetString("chat_jid", "")
 		var startTimePtr, endTimePtr *string
@@ -97,7 +97,7 @@ func (h *ChatHandler) handleChat(ctx context.Context, request mcpg.CallToolReque
 		if err != nil {
 			return mcpg.NewToolResultError(err.Error()), nil
 		}
-		return mcpg.NewToolResultStructured(resp, fmt.Sprintf("Retrieved %d messages from %s", len(resp.Data), chatJID)), nil
+		return structuredWithJSON(resp, fmt.Sprintf("Retrieved %d messages from %s", len(resp.Data), chatJID)), nil
 	case "archive":
 		req := domainChat.ArchiveChatRequest{
 			ChatJID:  request.GetString("chat_jid", ""),

--- a/src/ui/mcp/chat_test.go
+++ b/src/ui/mcp/chat_test.go
@@ -13,13 +13,14 @@ import (
 type stubChatService struct {
 	domainChat.IChatUsecase
 	listed   *domainChat.ListChatsRequest
+	listResp domainChat.ListChatsResponse
 	fetched  *domainChat.GetChatMessagesRequest
 	archived *domainChat.ArchiveChatRequest
 }
 
 func (s *stubChatService) ListChats(_ context.Context, r domainChat.ListChatsRequest) (domainChat.ListChatsResponse, error) {
 	s.listed = &r
-	return domainChat.ListChatsResponse{}, nil
+	return s.listResp, nil
 }
 func (s *stubChatService) GetChatMessages(_ context.Context, r domainChat.GetChatMessagesRequest) (domainChat.GetChatMessagesResponse, error) {
 	s.fetched = &r
@@ -27,7 +28,7 @@ func (s *stubChatService) GetChatMessages(_ context.Context, r domainChat.GetCha
 }
 func (s *stubChatService) ArchiveChat(_ context.Context, r domainChat.ArchiveChatRequest) (domainChat.ArchiveChatResponse, error) {
 	s.archived = &r
-	return domainChat.ArchiveChatResponse{}, nil
+	return domainChat.ArchiveChatResponse{Message: "Chat archived"}, nil
 }
 
 type stubUserService struct {

--- a/src/ui/mcp/group.go
+++ b/src/ui/mcp/group.go
@@ -81,13 +81,13 @@ func (h *GroupHandler) handleGroup(ctx context.Context, request mcpg.CallToolReq
 		if err != nil {
 			return mcpg.NewToolResultError(err.Error()), nil
 		}
-		return mcpg.NewToolResultStructured(resp, fmt.Sprintf("Fetched group info for %s", groupID)), nil
+		return structuredWithJSON(resp, fmt.Sprintf("Fetched group info for %s", groupID)), nil
 	case "participants":
 		resp, err := h.groupService.GetGroupParticipants(ctx, domainGroup.GetGroupParticipantsRequest{GroupID: groupID})
 		if err != nil {
 			return mcpg.NewToolResultError(err.Error()), nil
 		}
-		return mcpg.NewToolResultStructured(resp, fmt.Sprintf("Group %s has %d participants", resp.GroupID, len(resp.Participants))), nil
+		return structuredWithJSON(resp, fmt.Sprintf("Group %s has %d participants", resp.GroupID, len(resp.Participants))), nil
 	case "add_participants", "remove_participants", "promote", "demote":
 		change := map[string]whatsmeow.ParticipantChange{
 			"add_participants":    whatsmeow.ParticipantChangeAdd,
@@ -150,7 +150,7 @@ func (h *GroupHandler) handleGroup(ctx context.Context, request mcpg.CallToolReq
 		if err != nil {
 			return mcpg.NewToolResultError(err.Error()), nil
 		}
-		return mcpg.NewToolResultStructured(resp, fmt.Sprintf("Group %s has %d pending requests", groupID, len(resp))), nil
+		return structuredWithJSON(resp, fmt.Sprintf("Group %s has %d pending requests", groupID, len(resp))), nil
 	case "manage_join_requests":
 		change, err := parseParticipantRequestChange(request.GetString("request_action", ""))
 		if err != nil {

--- a/src/ui/mcp/group_test.go
+++ b/src/ui/mcp/group_test.go
@@ -17,6 +17,7 @@ type stubGroupService struct {
 	left         *domainGroup.LeaveGroupRequest
 	infoReq      *domainGroup.GroupInfoRequest
 	partsReq     *domainGroup.GetGroupParticipantsRequest
+	partsResp    domainGroup.GetGroupParticipantsResponse
 	managed      *domainGroup.ParticipantRequest
 	inviteReq    *domainGroup.GetGroupInviteLinkRequest
 	namedReq     *domainGroup.SetGroupNameRequest
@@ -45,7 +46,7 @@ func (s *stubGroupService) GroupInfo(_ context.Context, r domainGroup.GroupInfoR
 }
 func (s *stubGroupService) GetGroupParticipants(_ context.Context, r domainGroup.GetGroupParticipantsRequest) (domainGroup.GetGroupParticipantsResponse, error) {
 	s.partsReq = &r
-	return domainGroup.GetGroupParticipantsResponse{}, nil
+	return s.partsResp, nil
 }
 func (s *stubGroupService) ManageParticipant(_ context.Context, r domainGroup.ParticipantRequest) ([]domainGroup.ParticipantStatus, error) {
 	s.managed = &r

--- a/src/ui/mcp/result.go
+++ b/src/ui/mcp/result.go
@@ -1,0 +1,18 @@
+package mcp
+
+import (
+	"encoding/json"
+
+	mcpg "github.com/mark3labs/mcp-go/mcp"
+)
+
+// structuredWithJSON keeps the human summary but appends the JSON payload to
+// the text block: text-only MCP clients never read structuredContent, so a
+// read tool that only summarizes returns nothing usable to them.
+func structuredWithJSON(structured any, summary string) *mcpg.CallToolResult {
+	payload, err := json.Marshal(structured)
+	if err != nil {
+		return mcpg.NewToolResultStructured(structured, summary)
+	}
+	return mcpg.NewToolResultStructured(structured, summary+"\n"+string(payload))
+}

--- a/src/ui/mcp/result.go
+++ b/src/ui/mcp/result.go
@@ -12,7 +12,7 @@ import (
 func structuredWithJSON(structured any, summary string) *mcpg.CallToolResult {
 	payload, err := json.Marshal(structured)
 	if err != nil {
-		return mcpg.NewToolResultStructured(structured, summary)
+		return mcpg.NewToolResultText(summary)
 	}
 	return mcpg.NewToolResultStructured(structured, summary+"\n"+string(payload))
 }

--- a/src/ui/mcp/result_test.go
+++ b/src/ui/mcp/result_test.go
@@ -45,12 +45,6 @@ func TestStructuredWithJSON(t *testing.T) {
 			summary:    "Found 0 contacts",
 			want:       "Found 0 contacts\nnull",
 		},
-		{
-			name:       "unmarshalable payload keeps the summary",
-			structured: make(chan int),
-			summary:    "Retrieved 0 chats",
-			want:       "Retrieved 0 chats",
-		},
 	}
 
 	for _, tc := range cases {
@@ -60,6 +54,14 @@ func TestStructuredWithJSON(t *testing.T) {
 			assert.Equal(t, tc.structured, res.StructuredContent)
 		})
 	}
+
+	t.Run("unmarshalable payload drops structured content", func(t *testing.T) {
+		res := structuredWithJSON(make(chan int), "Retrieved 0 chats")
+		assert.Equal(t, "Retrieved 0 chats", resultText(t, res))
+		assert.Nil(t, res.StructuredContent)
+		_, err := json.Marshal(res)
+		assert.NoError(t, err)
+	})
 }
 
 func TestReadToolsSerializePayloadIntoText(t *testing.T) {

--- a/src/ui/mcp/result_test.go
+++ b/src/ui/mcp/result_test.go
@@ -1,0 +1,109 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	domainChat "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chat"
+	domainGroup "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/group"
+	mcpg "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resultText(t *testing.T, res *mcpg.CallToolResult) string {
+	t.Helper()
+	require.NotNil(t, res)
+	require.Len(t, res.Content, 1)
+	text, ok := res.Content[0].(mcpg.TextContent)
+	require.True(t, ok, "expected a text content block")
+	return text.Text
+}
+
+func TestStructuredWithJSON(t *testing.T) {
+	cases := []struct {
+		name       string
+		structured any
+		summary    string
+		want       string
+	}{
+		{
+			name:       "map payload",
+			structured: map[string]any{"is_connected": true},
+			summary:    "connected=true logged_in=true",
+			want:       "connected=true logged_in=true\n{\"is_connected\":true}",
+		},
+		{
+			name:       "slice payload",
+			structured: []string{"628@s.whatsapp.net"},
+			summary:    "Found 1 contacts",
+			want:       "Found 1 contacts\n[\"628@s.whatsapp.net\"]",
+		},
+		{
+			name:       "nil payload",
+			structured: nil,
+			summary:    "Found 0 contacts",
+			want:       "Found 0 contacts\nnull",
+		},
+		{
+			name:       "unmarshalable payload keeps the summary",
+			structured: make(chan int),
+			summary:    "Retrieved 0 chats",
+			want:       "Retrieved 0 chats",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := structuredWithJSON(tc.structured, tc.summary)
+			assert.Equal(t, tc.want, resultText(t, res))
+			assert.Equal(t, tc.structured, res.StructuredContent)
+		})
+	}
+}
+
+func TestReadToolsSerializePayloadIntoText(t *testing.T) {
+	t.Run("list_chats", func(t *testing.T) {
+		cs := &stubChatService{listResp: domainChat.ListChatsResponse{
+			Data: []domainChat.ChatInfo{{JID: "628@s.whatsapp.net", Name: "Bob"}},
+		}}
+		h := InitMcpChat(cs, &stubUserService{}, &stubResolver{})
+		res, err := h.handleChat(deviceCtx(), callReq(map[string]any{"action": "list_chats"}))
+		require.NoError(t, err)
+
+		text := resultText(t, res)
+		assert.Contains(t, text, "Retrieved 1 chats")
+		payload, err := json.Marshal(res.StructuredContent)
+		require.NoError(t, err)
+		assert.Contains(t, text, string(payload))
+		assert.Contains(t, text, `"jid":"628@s.whatsapp.net"`)
+	})
+
+	t.Run("group participants", func(t *testing.T) {
+		svc := &stubGroupService{partsResp: domainGroup.GetGroupParticipantsResponse{
+			GroupID:      "123@g.us",
+			Participants: []domainGroup.GroupParticipant{{JID: "628@s.whatsapp.net"}},
+		}}
+		h := InitMcpGroup(svc, &stubResolver{})
+		res, err := h.handleGroup(deviceCtx(), callReq(map[string]any{
+			"action": "participants", "group_id": "123@g.us",
+		}))
+		require.NoError(t, err)
+
+		text := resultText(t, res)
+		assert.Contains(t, text, "Group 123@g.us has 1 participants")
+		payload, err := json.Marshal(res.StructuredContent)
+		require.NoError(t, err)
+		assert.Contains(t, text, string(payload))
+	})
+
+	t.Run("write actions keep the summary only", func(t *testing.T) {
+		cs := &stubChatService{}
+		h := InitMcpChat(cs, &stubUserService{}, &stubResolver{})
+		res, err := h.handleChat(deviceCtx(), callReq(map[string]any{
+			"action": "archive", "chat_jid": "628@s.whatsapp.net", "archived": true,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "Chat archived", resultText(t, res))
+	})
+}


### PR DESCRIPTION
## Context

Text-only MCP clients (Claude among them) never read `structuredContent`, and our
read tools put the payload nowhere else — the `content` text block was just a
summary like "Retrieved 3 chats (offset 0, limit 25)". So those tools are
effectively blind on such clients. Closes #821.

Added `structuredWithJSON` in `src/ui/mcp/result.go`, which keeps the existing
human summary and appends the marshalled payload to the same text block (the
structured content is unchanged, so clients that do read it see exactly what they
saw before). If marshalling fails it falls back to the summary alone.

Swapped at the read call sites only:

- `src/ui/mcp/chat.go` — `list_chats`, `list_contacts`, `get_messages`
- `src/ui/mcp/group.go` — `info`, `participants`, `join_requests`
- `src/ui/mcp/app.go` — `status`

Write actions (send, create, join, leave, archive, mark read, participant
changes, ...) still return a summary; their text already describes the outcome
and dumping the response JSON there adds nothing. `invite_link` and
`download_media` are left alone too — the link and the file path are already in
their summary text.

## Test Results

- `gofmt -l .` — clean for `ui/mcp` (the three files it lists,
  `pkg/error/app_error.go`, `usecase/device_test.go`,
  `infrastructure/whatsapp/chatwoot_content_test.go`, are unformatted on main
  already and untouched here)
- `go build ./...`, `go vet ./...`, `go test ./...` all pass from `src/`
- New `src/ui/mcp/result_test.go`: table test over `structuredWithJSON` (map,
  slice, nil and an unmarshalable payload) plus handler tests asserting
  `list_chats` and group `participants` return text containing the serialized
  payload, and that `archive` still returns the summary only


---
_Generated by [Claude Code](https://claude.ai/code/session_01GntpfJ8xPKDMfUgJSaJX6b)_