### PR TITLE
feat(call): add call logs listing endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2481,6 +2481,65 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorInternalServer'
 
+  /call/logs:
+    get:
+      operationId: listCallLogs
+      tags:
+        - call
+      summary: Get list of call logs
+      description: |
+        List the incoming calls recorded for the current device, newest first.
+
+        Calls are captured by the `call.offer` handler, so the log covers incoming calls that arrived
+        while the device was connected. Outgoing calls, call duration and answered/ended outcomes are
+        not tracked yet.
+      parameters:
+        - $ref: '#/components/parameters/DeviceIdHeader'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 25
+            maximum: 100
+          description: Maximum number of call logs to return
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+          description: Number of call logs to skip (for pagination)
+        - name: chat_jid
+          in: query
+          schema:
+            type: string
+          description: Only return calls belonging to this chat JID
+          example: '6289685028129@s.whatsapp.net'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallLogListResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBadRequest'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorUnauthorized'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInternalServer'
+
   /chats:
     get:
       operationId: listChats
@@ -5226,6 +5285,83 @@ components:
                   close_time:
                     type: string
                     example: '18:00'
+
+    CallLogListResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          example: SUCCESS
+        message:
+          type: string
+          example: Success get call logs
+        results:
+          type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/CallLog'
+            pagination:
+              type: object
+              properties:
+                limit:
+                  type: integer
+                  example: 25
+                offset:
+                  type: integer
+                  example: 0
+                total:
+                  type: integer
+                  example: 12
+
+    CallLog:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 'call:ABC123DEF456'
+          description: Stored record identifier (`call:` prefix plus the call id)
+        chat_jid:
+          type: string
+          example: '6289685028129@s.whatsapp.net'
+          description: Chat the call belongs to (group JID for group calls)
+        sender_jid:
+          type: string
+          example: '6289685028129@s.whatsapp.net'
+          description: JID of the caller
+        timestamp:
+          type: string
+          format: date-time
+          example: '2024-01-15T10:30:00Z'
+          description: When the call offer was received
+        is_from_me:
+          type: boolean
+          example: false
+          description: Always false today; only incoming calls are recorded
+        call_metadata:
+          type: object
+          properties:
+            call_id:
+              type: string
+              example: 'ABC123DEF456'
+              description: Call identifier, also usable with POST /call/reject
+            auto_rejected:
+              type: boolean
+              example: false
+              description: Whether the call was rejected by WHATSAPP_AUTO_REJECT_CALL
+            remote_platform:
+              type: string
+              example: 'android'
+              description: Caller platform, when reported
+            remote_version:
+              type: string
+              example: '2.24.1.75'
+              description: Caller app version, when reported
+            group_jid:
+              type: string
+              example: '120363123456789@g.us'
+              description: Group JID for group calls
 
     ChatListResponse:
       type: object

--- a/readme.md
+++ b/readme.md
@@ -677,6 +677,7 @@ You may also fork or modify the source code.
 | ✅       | Forward Message                        | POST   | /message/:message_id/forward        |
 | ✅       | Download Message Media                 | GET    | /message/:message_id/download       |
 | ✅       | Reject Call                            | POST   | /call/reject                        |
+| ✅       | Get Call Logs                          | GET    | /call/logs                          |
 | ✅       | Join Group with Link                   | POST   | /group/join-with-link               |
 | ✅       | Get Group Info from Link               | GET    | /group/info-from-link               |
 | ✅       | Get Group Info                         | GET    | /group/info                         |

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -692,7 +692,7 @@ func initApp() {
 
 	// Usecase
 	appUsecase = usecase.NewAppService(chatStorageRepo, dm)
-	callUsecase = usecase.NewCallService()
+	callUsecase = usecase.NewCallService(chatStorageRepo)
 	chatUsecase = usecase.NewChatService(chatStorageRepo)
 	sendUsecase = usecase.NewSendService(appUsecase, chatStorageRepo)
 	userUsecase = usecase.NewUserService(chatStorageRepo)

--- a/src/domains/call/call.go
+++ b/src/domains/call/call.go
@@ -4,9 +4,45 @@ import "context"
 
 type ICallUsecase interface {
 	RejectCall(ctx context.Context, callerJID string, callID string) error
+	ListCallLogs(ctx context.Context, request ListCallLogsRequest) (ListCallLogsResponse, error)
 }
 
 type RejectCallRequest struct {
 	CallerJID string `json:"caller_jid" form:"caller_jid"`
 	CallID    string `json:"call_id" form:"call_id"`
+}
+
+type ListCallLogsRequest struct {
+	Limit   int    `json:"limit" query:"limit"`
+	Offset  int    `json:"offset" query:"offset"`
+	ChatJID string `json:"chat_jid" query:"chat_jid"`
+}
+
+type ListCallLogsResponse struct {
+	Data       []CallLogInfo      `json:"data"`
+	Pagination PaginationResponse `json:"pagination"`
+}
+
+type CallLogInfo struct {
+	ID           string       `json:"id"`
+	ChatJID      string       `json:"chat_jid"`
+	SenderJID    string       `json:"sender_jid"`
+	Timestamp    string       `json:"timestamp"`
+	IsFromMe     bool         `json:"is_from_me"`
+	CallMetadata CallMetadata `json:"call_metadata"`
+}
+
+// CallMetadata mirrors the JSON stored on the synthetic call message row.
+type CallMetadata struct {
+	CallID         string `json:"call_id"`
+	AutoRejected   bool   `json:"auto_rejected"`
+	RemotePlatform string `json:"remote_platform,omitempty"`
+	RemoteVersion  string `json:"remote_version,omitempty"`
+	GroupJID       string `json:"group_jid,omitempty"`
+}
+
+type PaginationResponse struct {
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+	Total  int `json:"total"`
 }

--- a/src/domains/chatstorage/chatstorage.go
+++ b/src/domains/chatstorage/chatstorage.go
@@ -181,6 +181,15 @@ type MessageFilter struct {
 	IsFromMe  *bool
 }
 
+// CallRecordFilter represents query filters for stored call records
+// (synthetic messages with media_type "call").
+type CallRecordFilter struct {
+	DeviceID string
+	ChatJID  string
+	Limit    int
+	Offset   int
+}
+
 // ChatFilter represents query filters for chats
 type ChatFilter struct {
 	DeviceID   string

--- a/src/domains/chatstorage/interfaces.go
+++ b/src/domains/chatstorage/interfaces.go
@@ -32,6 +32,8 @@ type IChatStorageRepository interface {
 	GetMessageEdits(originalMessageID, deviceID string) ([]*MessageEdit, error)
 	GetMessages(filter *MessageFilter) ([]*Message, error)
 	SearchMessages(deviceID, chatJID, searchText string, limit int) ([]*Message, error) // Database-level search with device isolation
+	// GetCallRecords lists call records (media_type "call") newest first, plus the unpaginated total.
+	GetCallRecords(filter *CallRecordFilter) ([]*Message, int64, error)
 	DeleteMessage(id, chatJID string) error
 	DeleteMessageByDevice(deviceID, id, chatJID string) error
 	StoreSentMessageWithContext(ctx context.Context, messageID string, senderJID string, recipientJID string, content string, timestamp time.Time, msg *waE2E.Message) error

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -2348,6 +2348,71 @@ func (r *SQLiteRepository) CreateIncomingCallRecord(ctx context.Context, evt *ev
 	return r.StoreMessage(message)
 }
 
+// GetCallRecords retrieves stored call records (synthetic messages with
+// media_type "call") newest first, together with the unpaginated total.
+func (r *SQLiteRepository) GetCallRecords(filter *domainChatStorage.CallRecordFilter) ([]*domainChatStorage.Message, int64, error) {
+	if filter == nil || filter.DeviceID == "" {
+		return nil, 0, fmt.Errorf("device_id is required for call record queries (data isolation)")
+	}
+
+	conditions := []string{"device_id = ?", "media_type = 'call'"}
+	args := []any{filter.DeviceID}
+
+	if filter.ChatJID != "" {
+		conditions = append(conditions, "chat_jid = ?")
+		args = append(args, filter.ChatJID)
+	}
+
+	whereClause := " WHERE " + strings.Join(conditions, " AND ")
+
+	total, err := r.getCount("SELECT COUNT(*) FROM messages"+whereClause, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	query := `
+		SELECT id, chat_jid, device_id, sender, content, timestamp, is_from_me,
+			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
+			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
+		FROM messages` + whereClause + `
+		ORDER BY timestamp DESC
+	`
+
+	if filter.Limit > 0 {
+		if filter.Limit > 1000 {
+			filter.Limit = 1000
+		}
+		query += " LIMIT ?"
+		args = append(args, filter.Limit)
+
+		if filter.Offset > 0 {
+			query += " OFFSET ?"
+			args = append(args, filter.Offset)
+		}
+	}
+
+	rows, err := r.db.Query(query, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var messages []*domainChatStorage.Message
+	for rows.Next() {
+		message, err := r.scanMessage(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		messages = append(messages, message)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	return messages, total, nil
+}
+
 // GetStorageStatistics returns current storage statistics for logging purposes
 func (r *SQLiteRepository) GetStorageStatistics() (chatCount int64, messageCount int64, err error) {
 	// Count all chats using efficient query

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -2375,7 +2375,7 @@ func (r *SQLiteRepository) GetCallRecords(filter *domainChatStorage.CallRecordFi
 			media_type, call_metadata, filename, url, direct_path, media_key, file_sha256,
 			file_enc_sha256, file_length, referral_metadata, created_at, updated_at
 		FROM messages` + whereClause + `
-		ORDER BY timestamp DESC
+		ORDER BY timestamp DESC, id DESC
 	`
 
 	if filter.Limit > 0 {

--- a/src/infrastructure/chatstorage/sqlite_repository_call_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_call_test.go
@@ -1,0 +1,101 @@
+package chatstorage
+
+import (
+	"testing"
+	"time"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/stretchr/testify/require"
+)
+
+func seedCallRecord(t *testing.T, repo *SQLiteRepository, deviceID, chatJID, messageID, metadata string, timestamp time.Time) {
+	t.Helper()
+	require.NoError(t, repo.StoreChat(&domainChatStorage.Chat{
+		DeviceID:        deviceID,
+		JID:             chatJID,
+		Name:            chatJID,
+		LastMessageTime: timestamp,
+	}))
+	require.NoError(t, repo.StoreMessage(&domainChatStorage.Message{
+		ID:           messageID,
+		ChatJID:      chatJID,
+		DeviceID:     deviceID,
+		Sender:       chatJID,
+		Content:      "Incoming call",
+		Timestamp:    timestamp,
+		MediaType:    "call",
+		CallMetadata: metadata,
+	}))
+}
+
+func TestGetCallRecordsReturnsOnlyCallRowsForDeviceNewestFirst(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "device-a@s.whatsapp.net"
+	otherDeviceID := "device-b@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+	base := time.Date(2026, time.August, 22, 9, 0, 0, 0, time.UTC)
+
+	seedChatMessage(t, repo, deviceID, chatJID, "text-1", "hello", base)
+	seedCallRecord(t, repo, deviceID, chatJID, "call:older", `{"call_id":"older","auto_rejected":false}`, base)
+	seedCallRecord(t, repo, deviceID, chatJID, "call:newer", `{"call_id":"newer","auto_rejected":true}`, base.Add(time.Hour))
+	seedCallRecord(t, repo, otherDeviceID, chatJID, "call:other-device", `{"call_id":"other"}`, base.Add(2*time.Hour))
+
+	records, total, err := repo.GetCallRecords(&domainChatStorage.CallRecordFilter{
+		DeviceID: deviceID,
+		Limit:    25,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), total)
+	require.Len(t, records, 2)
+	require.Equal(t, "call:newer", records[0].ID)
+	require.Equal(t, "call:older", records[1].ID)
+	for _, record := range records {
+		require.Equal(t, "call", record.MediaType)
+		require.Equal(t, deviceID, record.DeviceID)
+	}
+	require.Equal(t, `{"call_id":"newer","auto_rejected":true}`, records[0].CallMetadata)
+}
+
+func TestGetCallRecordsRespectsLimitOffsetAndChatFilter(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "device-a@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+	otherChatJID := "628987654321@s.whatsapp.net"
+	base := time.Date(2026, time.August, 22, 9, 0, 0, 0, time.UTC)
+
+	seedCallRecord(t, repo, deviceID, chatJID, "call:1", "", base)
+	seedCallRecord(t, repo, deviceID, chatJID, "call:2", "", base.Add(time.Hour))
+	seedCallRecord(t, repo, deviceID, chatJID, "call:3", "", base.Add(2*time.Hour))
+	seedCallRecord(t, repo, deviceID, otherChatJID, "call:4", "", base.Add(3*time.Hour))
+
+	page, total, err := repo.GetCallRecords(&domainChatStorage.CallRecordFilter{
+		DeviceID: deviceID,
+		Limit:    2,
+		Offset:   1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(4), total)
+	require.Len(t, page, 2)
+	require.Equal(t, "call:3", page[0].ID)
+	require.Equal(t, "call:2", page[1].ID)
+
+	filtered, filteredTotal, err := repo.GetCallRecords(&domainChatStorage.CallRecordFilter{
+		DeviceID: deviceID,
+		ChatJID:  otherChatJID,
+		Limit:    25,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), filteredTotal)
+	require.Len(t, filtered, 1)
+	require.Equal(t, "call:4", filtered[0].ID)
+}
+
+func TestGetCallRecordsRequiresDeviceID(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	_, _, err := repo.GetCallRecords(&domainChatStorage.CallRecordFilter{Limit: 25})
+	require.Error(t, err)
+
+	_, _, err = repo.GetCallRecords(nil)
+	require.Error(t, err)
+}

--- a/src/infrastructure/chatstorage/sqlite_repository_call_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_call_test.go
@@ -90,6 +90,46 @@ func TestGetCallRecordsRespectsLimitOffsetAndChatFilter(t *testing.T) {
 	require.Equal(t, "call:4", filtered[0].ID)
 }
 
+func TestGetCallRecordsPaginatesDeterministicallyWithEqualTimestamps(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+	deviceID := "device-a@s.whatsapp.net"
+	chatJID := "628123456789@s.whatsapp.net"
+	same := time.Date(2026, time.August, 22, 9, 0, 0, 0, time.UTC)
+
+	seedCallRecord(t, repo, deviceID, chatJID, "call:1", "", same)
+	seedCallRecord(t, repo, deviceID, chatJID, "call:2", "", same)
+	seedCallRecord(t, repo, deviceID, chatJID, "call:3", "", same)
+	seedCallRecord(t, repo, deviceID, chatJID, "call:4", "", same)
+	seedCallRecord(t, repo, deviceID, chatJID, "call:5", "", same)
+
+	page1, total, err := repo.GetCallRecords(&domainChatStorage.CallRecordFilter{
+		DeviceID: deviceID,
+		Limit:    3,
+		Offset:   0,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+	require.Len(t, page1, 3)
+
+	page2, total, err := repo.GetCallRecords(&domainChatStorage.CallRecordFilter{
+		DeviceID: deviceID,
+		Limit:    3,
+		Offset:   3,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(5), total)
+	require.Len(t, page2, 2)
+
+	seen := make(map[string]bool)
+	var ids []string
+	for _, record := range append(append([]*domainChatStorage.Message{}, page1...), page2...) {
+		require.Falsef(t, seen[record.ID], "record %s duplicated across pages", record.ID)
+		seen[record.ID] = true
+		ids = append(ids, record.ID)
+	}
+	require.Equal(t, []string{"call:5", "call:4", "call:3", "call:2", "call:1"}, ids)
+}
+
 func TestGetCallRecordsRequiresDeviceID(t *testing.T) {
 	repo := newTestSQLiteRepository(t)
 

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -134,6 +134,13 @@ func (r *deviceChatStorage) SearchMessages(deviceID, chatJID, searchText string,
 	return r.base.SearchMessages(targetDeviceID, chatJID, searchText, limit)
 }
 
+func (r *deviceChatStorage) GetCallRecords(filter *domainChatStorage.CallRecordFilter) ([]*domainChatStorage.Message, int64, error) {
+	if filter != nil && filter.DeviceID == "" {
+		filter.DeviceID = r.deviceID
+	}
+	return r.base.GetCallRecords(filter)
+}
+
 func (r *deviceChatStorage) DeleteMessage(id, chatJID string) error {
 	return r.base.DeleteMessageByDevice(r.deviceID, id, chatJID)
 }

--- a/src/ui/rest/call.go
+++ b/src/ui/rest/call.go
@@ -3,6 +3,7 @@ package rest
 import (
 	domainCall "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/call"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
+	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
 	"github.com/gofiber/fiber/v3"
 )
@@ -41,9 +42,11 @@ func (controller *Call) RejectCall(c fiber.Ctx) error {
 func (controller *Call) ListCallLogs(c fiber.Ctx) error {
 	var request domainCall.ListCallLogsRequest
 
-	request.Limit = fiber.Query[int](c, "limit", 25)
-	request.Offset = fiber.Query[int](c, "offset", 0)
-	request.ChatJID = c.Query("chat_jid", "")
+	err := c.Bind().Query(&request)
+	if err != nil {
+		err = pkgError.ValidationError(err.Error())
+	}
+	utils.PanicIfNeeded(err)
 
 	response, err := controller.Service.ListCallLogs(
 		whatsapp.ContextWithDevice(c.Context(), getDeviceFromCtx(c)),
@@ -51,6 +54,7 @@ func (controller *Call) ListCallLogs(c fiber.Ctx) error {
 	)
 	utils.PanicIfNeeded(err)
 
+	c.Set("Cache-Control", "no-store")
 	return c.JSON(utils.ResponseData{
 		Status:  200,
 		Code:    "SUCCESS",

--- a/src/ui/rest/call.go
+++ b/src/ui/rest/call.go
@@ -14,6 +14,7 @@ type Call struct {
 func InitRestCall(app fiber.Router, service domainCall.ICallUsecase) Call {
 	rest := Call{Service: service}
 	app.Post("/call/reject", rest.RejectCall)
+	app.Get("/call/logs", rest.ListCallLogs)
 	return rest
 }
 
@@ -34,5 +35,26 @@ func (controller *Call) RejectCall(c fiber.Ctx) error {
 		Code:    "SUCCESS",
 		Message: "Call rejected successfully",
 		Results: nil,
+	})
+}
+
+func (controller *Call) ListCallLogs(c fiber.Ctx) error {
+	var request domainCall.ListCallLogsRequest
+
+	request.Limit = fiber.Query[int](c, "limit", 25)
+	request.Offset = fiber.Query[int](c, "offset", 0)
+	request.ChatJID = c.Query("chat_jid", "")
+
+	response, err := controller.Service.ListCallLogs(
+		whatsapp.ContextWithDevice(c.Context(), getDeviceFromCtx(c)),
+		request,
+	)
+	utils.PanicIfNeeded(err)
+
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: "Success get call logs",
+		Results: response,
 	})
 }

--- a/src/usecase/call.go
+++ b/src/usecase/call.go
@@ -2,10 +2,13 @@ package usecase
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	domainCall "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/call"
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/infrastructure/whatsapp"
 	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
@@ -13,10 +16,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type serviceCall struct{}
+type serviceCall struct {
+	chatStorageRepo domainChatStorage.IChatStorageRepository
+}
 
-func NewCallService() domainCall.ICallUsecase {
-	return &serviceCall{}
+func NewCallService(chatStorageRepo domainChatStorage.IChatStorageRepository) domainCall.ICallUsecase {
+	return &serviceCall{
+		chatStorageRepo: chatStorageRepo,
+	}
 }
 
 func (service serviceCall) RejectCall(ctx context.Context, callerJID string, callID string) error {
@@ -45,4 +52,58 @@ func (service serviceCall) RejectCall(ctx context.Context, callerJID string, cal
 
 	logrus.Info("Rejected call successfully")
 	return nil
+}
+
+// ListCallLogs returns the call records persisted by the incoming call handler
+// for the device in context, newest first.
+func (service serviceCall) ListCallLogs(ctx context.Context, request domainCall.ListCallLogsRequest) (response domainCall.ListCallLogsResponse, err error) {
+	if err = validations.ValidateListCallLogs(ctx, &request); err != nil {
+		return response, err
+	}
+
+	deviceID := deviceIDFromContext(ctx)
+	if deviceID == "" {
+		return response, fmt.Errorf("device identification required")
+	}
+
+	if service.chatStorageRepo == nil {
+		return response, pkgError.InternalServerError("chat storage repository is not available")
+	}
+
+	records, total, err := service.chatStorageRepo.GetCallRecords(&domainChatStorage.CallRecordFilter{
+		DeviceID: deviceID,
+		ChatJID:  strings.TrimSpace(request.ChatJID),
+		Limit:    request.Limit,
+		Offset:   request.Offset,
+	})
+	if err != nil {
+		logrus.WithError(err).Error("Failed to get call records")
+		return response, err
+	}
+
+	callLogs := make([]domainCall.CallLogInfo, 0, len(records))
+	for _, record := range records {
+		callLog := domainCall.CallLogInfo{
+			ID:        record.ID,
+			ChatJID:   record.ChatJID,
+			SenderJID: record.Sender,
+			Timestamp: record.Timestamp.Format(time.RFC3339),
+			IsFromMe:  record.IsFromMe,
+		}
+		if record.CallMetadata != "" {
+			if err := json.Unmarshal([]byte(record.CallMetadata), &callLog.CallMetadata); err != nil {
+				logrus.WithError(err).WithField("message_id", record.ID).Warn("Failed to parse call metadata")
+			}
+		}
+		callLogs = append(callLogs, callLog)
+	}
+
+	response.Data = callLogs
+	response.Pagination = domainCall.PaginationResponse{
+		Limit:  request.Limit,
+		Offset: request.Offset,
+		Total:  int(total),
+	}
+
+	return response, nil
 }

--- a/src/validations/call_validation.go
+++ b/src/validations/call_validation.go
@@ -27,3 +27,21 @@ func ValidateRejectCall(ctx context.Context, callerJID string, callID string) er
 
 	return nil
 }
+
+func ValidateListCallLogs(ctx context.Context, request *domainCall.ListCallLogsRequest) error {
+	// Set default limit if not provided
+	if request.Limit == 0 {
+		request.Limit = 25
+	}
+
+	err := validation.ValidateStructWithContext(ctx, request,
+		validation.Field(&request.Limit, validation.Min(1), validation.Max(100)),
+		validation.Field(&request.Offset, validation.Min(0)),
+	)
+
+	if err != nil {
+		return pkgError.ValidationError(err.Error())
+	}
+
+	return nil
+}

--- a/src/validations/call_validation_test.go
+++ b/src/validations/call_validation_test.go
@@ -1,0 +1,67 @@
+package validations
+
+import (
+	"context"
+	"testing"
+
+	domainCall "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/call"
+	pkgError "github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/error"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateListCallLogs(t *testing.T) {
+	type args struct {
+		request domainCall.ListCallLogsRequest
+	}
+	tests := []struct {
+		name          string
+		args          args
+		err           any
+		expectedLimit int
+	}{
+		{
+			name:          "should success with valid request",
+			args:          args{request: domainCall.ListCallLogsRequest{Limit: 25, Offset: 0}},
+			err:           nil,
+			expectedLimit: 25,
+		},
+		{
+			name:          "should success with zero limit (auto set to default)",
+			args:          args{request: domainCall.ListCallLogsRequest{Limit: 0, Offset: 0}},
+			err:           nil,
+			expectedLimit: 25,
+		},
+		{
+			name:          "should success with max limit and chat filter",
+			args:          args{request: domainCall.ListCallLogsRequest{Limit: 100, Offset: 50, ChatJID: "6289685028129@s.whatsapp.net"}},
+			err:           nil,
+			expectedLimit: 100,
+		},
+		{
+			name:          "should error with limit too high",
+			args:          args{request: domainCall.ListCallLogsRequest{Limit: 101, Offset: 0}},
+			err:           pkgError.ValidationError("limit: must be no greater than 100."),
+			expectedLimit: 101,
+		},
+		{
+			name:          "should error with negative limit",
+			args:          args{request: domainCall.ListCallLogsRequest{Limit: -1, Offset: 0}},
+			err:           pkgError.ValidationError("limit: must be no less than 1."),
+			expectedLimit: -1,
+		},
+		{
+			name:          "should error with negative offset",
+			args:          args{request: domainCall.ListCallLogsRequest{Limit: 25, Offset: -1}},
+			err:           pkgError.ValidationError("offset: must be no less than 0."),
+			expectedLimit: 25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateListCallLogs(context.Background(), &tt.args.request)
+			assert.Equal(t, tt.err, err)
+			assert.Equal(t, tt.expectedLimit, tt.args.request.Limit)
+		})
+	}
+}


### PR DESCRIPTION
## Context

Closes the read side of #796: incoming calls are already persisted, but there is
no way to get at them without paging every chat.

`handleCallOffer` stores each `call.offer` through `CreateIncomingCallRecord` as
a synthetic message row with `media_type = "call"` and a small `call_metadata`
JSON blob. Today the only way to read those back is `GET /chat/:jid/messages`
per chat, filtering `media_type == "call"` client-side — which means you need to
know the chat first, and you page through unrelated messages to find calls.

`GET /call/logs` lists those records for the device in context, newest first,
with `limit` (default 25, max 100), `offset` and an optional `chat_jid` filter.
`call_metadata` is parsed into fields instead of being handed back as a JSON
string, so `call_id` can be fed straight into `POST /call/reject`.

Layering follows the existing chat list path: handler parses the query,
`ValidateListCallLogs` applies the limit/offset bounds, and the usecase resolves
the device from context before calling storage. Storage side is a new
`GetCallRecords(*CallRecordFilter)` on `IChatStorageRepository`, the SQLite
repository and `chatstorage_wrapper.go`, filtering `device_id = ?` plus
`media_type = 'call'` and returning the unpaginated total for the pagination
echo. No migration — it queries rows that already exist.

```
$ curl -s -H 'X-Device-Id: 628123456789@s.whatsapp.net' \
    'http://localhost:3000/call/logs?limit=2'
{
  "code": "SUCCESS",
  "message": "Success get call logs",
  "results": {
    "data": [
      {
        "id": "call:ABC123DEF456",
        "chat_jid": "6289685028129@s.whatsapp.net",
        "sender_jid": "6289685028129@s.whatsapp.net",
        "timestamp": "2026-08-22T10:05:00Z",
        "is_from_me": false,
        "call_metadata": {
          "call_id": "ABC123DEF456",
          "auto_rejected": true,
          "remote_platform": "android"
        }
      }
    ],
    "pagination": { "limit": 2, "offset": 0, "total": 12 }
  }
}
```

Deliberately not covered, since it needs event handling this PR does not touch:

- outgoing calls — only `events.CallOffer` is wired up, so `is_from_me` is
  always false today
- duration and outcome (answered/ended/missed) — `CallAccept` and
  `CallTerminate` aren't handled, so there is nothing to report
- backfill of calls from before the device was linked; history sync does not
  carry call records
- no MCP tool, and no `search` param (the stored content is a fixed
  "Incoming call" string, so matching on it buys nothing)

This is a first slice: it exposes what is already stored. Enriching
`call_metadata` from the other call events is the natural follow-up, and the
endpoint shape doesn't change when it lands.

## Test Results

From `src/`:

- `gofmt -l .` — no new entries (`pkg/error/app_error.go`,
  `usecase/device_test.go` and `infrastructure/whatsapp/chatwoot_content_test.go`
  are already unformatted on main)
- `go build ./...` — ok
- `go vet ./...` — clean
- `go test ./...` — all packages pass

New tests:

- `src/infrastructure/chatstorage/sqlite_repository_call_test.go` — against a
  real in-memory-ish SQLite repo: only `media_type = 'call'` rows come back,
  only for the requested device, ordered newest first; limit/offset paging and
  the `chat_jid` filter; missing `device_id` is rejected
- `src/validations/call_validation_test.go` — table test for the limit default
  (25), the 1..100 bounds and the offset floor


---
_Generated by [Claude Code](https://claude.ai/code/session_01GntpfJ8xPKDMfUgJSaJX6b)_