### PR TITLE
feat: expose referral metadata in chat messages

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5374,6 +5374,10 @@ components:
           type: string
           example: '{"call_id":"ABC","auto_rejected":false}'
           description: JSON string with call details when media_type is `call`. Omitted when not applicable (matches Go json omitempty).
+        referral_metadata:
+          type: string
+          example: '{"ctwa_clid":"clid_123","source_app":"whatsapp"}'
+          description: JSON string with Meta Ads referral/attribution details when the message originated from a Click-to-WhatsApp ad. Omitted when not applicable (matches Go json omitempty).
         filename:
           type: string
           example: 'photo.jpg'

--- a/src/domains/chat/chat.go
+++ b/src/domains/chat/chat.go
@@ -66,12 +66,13 @@ type MessageInfo struct {
 	MediaType         string         `json:"media_type"`
 	Reactions         []ReactionInfo `json:"reactions,omitempty"`
 	// CallMetadata is JSON when media_type is "call" (incoming call log).
-	CallMetadata string `json:"call_metadata,omitempty"`
-	Filename     string `json:"filename"`
-	URL          string `json:"url"`
-	FileLength   uint64 `json:"file_length"`
-	CreatedAt    string `json:"created_at"`
-	UpdatedAt    string `json:"updated_at"`
+	CallMetadata     string `json:"call_metadata,omitempty"`
+	ReferralMetadata string `json:"referral_metadata,omitempty"`
+	Filename         string `json:"filename"`
+	URL              string `json:"url"`
+	FileLength       uint64 `json:"file_length"`
+	CreatedAt        string `json:"created_at"`
+	UpdatedAt        string `json:"updated_at"`
 }
 
 type PaginationResponse struct {

--- a/src/usecase/chat.go
+++ b/src/usecase/chat.go
@@ -204,6 +204,7 @@ func (service serviceChat) GetChatMessages(ctx context.Context, request domainCh
 			IsFromMe:          message.IsFromMe,
 			MediaType:         message.MediaType,
 			CallMetadata:      message.CallMetadata,
+			ReferralMetadata:  message.ReferralMetadata,
 			Filename:          message.Filename,
 			URL:               message.URL,
 			FileLength:        message.FileLength,

--- a/src/usecase/chat_test.go
+++ b/src/usecase/chat_test.go
@@ -369,6 +369,82 @@ func TestChatSenderDisplayNameJSONContract(t *testing.T) {
 	}
 }
 
+func TestGetChatMessagesExposesReferralMetadata(t *testing.T) {
+	accountJID := types.NewJID("628999999999", types.DefaultUserServer)
+	deviceID := accountJID.String()
+	chatJID := "628123456789@s.whatsapp.net"
+	now := time.Date(2026, time.May, 16, 8, 0, 0, 0, time.UTC)
+	referralMetadata := `{"ctwa_clid":"clid_123","source_app":"whatsapp"}`
+	repo := &chatUsecaseRepoStub{
+		chat: &domainChatStorage.Chat{
+			DeviceID:        deviceID,
+			JID:             chatJID,
+			Name:            "Alice",
+			LastMessageTime: now,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		},
+		messages: []*domainChatStorage.Message{
+			{
+				ID:               "msg-ad",
+				ChatJID:          chatJID,
+				DeviceID:         deviceID,
+				Sender:           chatJID,
+				Content:          "hello from the ad",
+				Timestamp:        now,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+				ReferralMetadata: referralMetadata,
+			},
+			{
+				ID:        "msg-plain",
+				ChatJID:   chatJID,
+				DeviceID:  deviceID,
+				Sender:    chatJID,
+				Content:   "hello again",
+				Timestamp: now.Add(time.Minute),
+				CreatedAt: now.Add(time.Minute),
+				UpdatedAt: now.Add(time.Minute),
+			},
+		},
+	}
+	service := NewChatService(repo)
+	client := &whatsmeow.Client{Store: &store.Device{ID: &accountJID, PushName: "Primary Account"}}
+	ctx := whatsapp.ContextWithDevice(context.Background(), whatsapp.NewDeviceInstance(deviceID, client, nil))
+
+	response, err := service.GetChatMessages(ctx, domainChat.GetChatMessagesRequest{
+		ChatJID: chatJID,
+		Limit:   50,
+	})
+	if err != nil {
+		t.Fatalf("get chat messages: %v", err)
+	}
+	if len(response.Data) != 2 {
+		t.Fatalf("expected two messages, got %d", len(response.Data))
+	}
+	if response.Data[0].ReferralMetadata != referralMetadata {
+		t.Fatalf("referral metadata = %q, want %q", response.Data[0].ReferralMetadata, referralMetadata)
+	}
+	if response.Data[1].ReferralMetadata != "" {
+		t.Fatalf("expected empty referral metadata, got %q", response.Data[1].ReferralMetadata)
+	}
+
+	payload, err := json.Marshal(response.Data)
+	if err != nil {
+		t.Fatalf("marshal messages payload: %v", err)
+	}
+	var messages []map[string]any
+	if err := json.Unmarshal(payload, &messages); err != nil {
+		t.Fatalf("unmarshal messages payload: %v", err)
+	}
+	if messages[0]["referral_metadata"] != referralMetadata {
+		t.Fatalf("message referral_metadata = %#v", messages[0]["referral_metadata"])
+	}
+	if _, ok := messages[1]["referral_metadata"]; ok {
+		t.Fatalf("referral_metadata must be omitted when empty, got %#v", messages[1])
+	}
+}
+
 type chatUsecaseRepoStub struct {
 	domainChatStorage.IChatStorageRepository
 	chat                *domainChatStorage.Chat


### PR DESCRIPTION
## Context

Rebase of #641 by @juliomuhlbauer onto current main, with the test the review
asked for. His commit is cherry-picked, so authorship stays with him.

`referral_metadata` (Meta Ads / Click-to-WhatsApp attribution) has been stored
since migration 16 and both storage read paths — `GetMessages` and
`SearchMessages` — already select it, but `GET /chat/:jid/messages` never
returned it. This adds `ReferralMetadata` to `domainChat.MessageInfo`, maps it
in `GetChatMessages`, and documents it in the `ChatMessage` OpenAPI schema.

What changed against the original PR:

- Conflict resolution in the `MessageInfo` literal keeps everything main has
  gained since April — `SenderDisplayName` and the `Reactions` block — and only
  adds the one `ReferralMetadata: message.ReferralMetadata` line, so nothing in
  the response regresses.
- The openapi hunk moved with the schema: the original patched around line 4233,
  the `ChatMessage` schema now lives at ~5374. The property sits next to
  `call_metadata`, matching the Go field order.
- gofmt'd the struct — the original left `CallMetadata`/`ReferralMetadata`
  misaligned, which was CodeRabbit's nit.
- Parity check: `MessageInfo` is still built in exactly one place. The MCP
  `whatsapp_chat` / `messages` action returns the same
  `GetChatMessagesResponse` as structured output, so it picks the field up for
  free; the websocket path doesn't emit `MessageInfo`. No other wiring needed.

The field is typed `string` with `omitempty`, same as the sibling
`CallMetadata` — the raw JSON blob is passed through rather than parsed.

Supersedes #641.

## Test Results

`src/usecase/chat_test.go` gets `TestGetChatMessagesExposesReferralMetadata`: it
runs `GetChatMessages` over a stub repo holding one message with referral
metadata and one without, asserts the mapping, then marshals the response and
checks `referral_metadata` is present on the first and absent on the second, so
the `omitempty` tag is covered too. Dropping the mapping line makes it fail.

From `src/`:

- `gofmt -l .` — no new entries (three files are already unformatted on main and
  are left alone: `infrastructure/whatsapp/chatwoot_content_test.go`,
  `pkg/error/app_error.go`, `usecase/device_test.go`)
- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass, 13 packages ok


---
_Generated by [Claude Code](https://claude.ai/code/session_01GntpfJ8xPKDMfUgJSaJX6b)_