### PR TITLE
docs: document postgres search_path via DB_URI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -290,6 +290,34 @@ To use environment variables:
 | `CHATWOOT_MESSAGE_READ`                 | Sync read state for linked WhatsApp/Chatwoot messages         | `false`                                      | `CHATWOOT_MESSAGE_READ=true`                  |
 | `CHATWOOT_MESSAGE_DELETE`               | Delete linked opposite-side messages when deletion is reported | `false`                                     | `CHATWOOT_MESSAGE_DELETE=true`                |
 
+#### PostgreSQL schema isolation
+
+`DB_URI` (and `DB_KEYS_URI`) are handed to the PostgreSQL driver as-is, so
+`search_path` works as a normal connection parameter. Use it to keep the
+`whatsmeow_*` tables out of `public` on a shared database such as Supabase:
+
+```env
+DB_URI=postgres://user:pass@host:5432/db?sslmode=disable&search_path=whatsapp
+```
+
+Create the schema before the first start — the app does not create it:
+
+```sql
+CREATE SCHEMA whatsapp;
+```
+
+Starting against a missing schema fails with
+`pq: no schema has been selected to create in (3F000)`.
+
+The schema must also be the only place in that database holding `whatsmeow_*`
+tables. The migration runner checks for existing tables through
+`information_schema` without filtering by schema, so if `public` (or any other
+schema) already has them, startup either fails with
+`pq: relation "whatsmeow_version" does not exist (42P01)` or silently keeps
+writing to the old schema when `public` is in the `search_path` list. Point a
+schema-isolated instance at a database with no other `whatsmeow_*` tables, and
+give `DB_KEYS_URI` its own database rather than a second schema in the same one.
+
 **Documentation:**
 
 - For detailed webhook payload schemas, security implementation, and integration examples, see

--- a/readme.md
+++ b/readme.md
@@ -297,8 +297,14 @@ To use environment variables:
 `whatsmeow_*` tables out of `public` on a shared database such as Supabase:
 
 ```env
-DB_URI=postgres://user:pass@host:5432/db?sslmode=disable&search_path=whatsapp
+DB_URI=postgres://user:pass@host:5432/db?sslmode=require&search_path=whatsapp
 ```
+
+Use at least `sslmode=require` on a remote/shared database — `DB_URI` carries
+both the database credentials and the WhatsApp session/key material. For
+production, prefer `sslmode=verify-full` with `sslrootcert` pointing at the
+provider's CA certificate, so the connection also validates the server
+identity.
 
 Create the schema before the first start — the app does not create it:
 

--- a/src/.env.example
+++ b/src/.env.example
@@ -39,6 +39,9 @@ MCP_OAUTH_RESOURCE_URL=
 MCP_OAUTH_DB_URI=file:storages/oauth.db
 
 # Database Settings
+# PostgreSQL: append ?search_path=<schema> to keep the whatsmeow_* tables out of
+# public. Create the schema first, and make sure no other schema in that
+# database already holds whatsmeow_* tables. See readme.md.
 DB_URI=file:storages/whatsapp.db?_foreign_keys=on
 DB_KEYS_URI=
 # Max concurrent SQLite connections for chat storage (default: 5, min: 1).

--- a/src/.env.example
+++ b/src/.env.example
@@ -39,9 +39,12 @@ MCP_OAUTH_RESOURCE_URL=
 MCP_OAUTH_DB_URI=file:storages/oauth.db
 
 # Database Settings
-# PostgreSQL: append ?search_path=<schema> to keep the whatsmeow_* tables out of
-# public. Create the schema first, and make sure no other schema in that
-# database already holds whatsmeow_* tables. See readme.md.
+# PostgreSQL: add search_path=<schema> to keep the whatsmeow_* tables out of
+# public — use ?search_path=<schema> if the URI has no query parameters yet,
+# or &search_path=<schema> to append it to existing ones, e.g.
+# postgres://user:pass@host:5432/db?sslmode=require&search_path=gowa
+# Create the schema first, and make sure no other schema in that database
+# already holds whatsmeow_* tables. See readme.md.
 DB_URI=file:storages/whatsapp.db?_foreign_keys=on
 DB_KEYS_URI=
 # Max concurrent SQLite connections for chat storage (default: 5, min: 1).


### PR DESCRIPTION
## Context

Closes #825.

Turns out this already works — no code change needed. `DB_URI` goes straight to
`sqlstore.New(ctx, "postgres", DBURI, dbLog)` in
`src/infrastructure/whatsapp/database.go`, nothing rewrites the query string, and
lib/pq forwards `search_path` as a startup parameter. So
`?search_path=whatsapp` puts every `whatsmeow_*` table in that schema today.

What is missing is documentation, plus two failure modes that are easy to hit and
whose error messages give no hint about the cause:

- the schema has to exist first, otherwise startup dies with
  `pq: no schema has been selected to create in (3F000)`
- the target database must not already have `whatsmeow_*` tables in some other
  schema. `dbutil`'s existence checks run
  `SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name=$1)`
  with no `table_schema` filter, so a leftover set in `public` makes the version
  table check succeed against the wrong schema. With `search_path=whatsapp` that
  surfaces as `pq: relation "whatsmeow_version" does not exist (42P01)`; with
  `search_path=whatsapp,public` it silently keeps writing to `public`. Same
  reason `DB_KEYS_URI` cannot be a second schema in the same database — it needs
  its own database.

So this adds a `#### PostgreSQL schema isolation` subsection under the env var
table in `readme.md` and a three-line comment above `DB_URI` in
`src/.env.example`. No unit test — there is no new pure function to test, and the
behaviour under test is the driver's.

## Test Results

PostgreSQL 16 (Debian package, `service postgresql start`), whatsmeow
`v0.0.0-20260904121843-28bfe537ea6a`. A throwaway Go program called the repo's
own `whatsapp.InitWaDB` with each DSN, against a database reset between runs.

| DSN | Where the tables landed |
|---|---|
| `?search_path=whatsapp` (schema exists, DB otherwise empty) | `whatsapp` (17 tables) |
| `?search_path=whatsapp,public` (DB otherwise empty) | `whatsapp` (17 tables) |
| no `search_path` | `public` (17 tables) |
| `?search_path=whatsapp`, schema missing | startup fails, 3F000 |
| `?search_path=whatsapp`, `public` already populated | startup fails, 42P01 |
| `?search_path=whatsapp,public`, `public` already populated | silently stays on `public` |
| second container on `?search_path=wakeys` in the same DB | startup fails, 42P01 |

`information_schema` after the first run:

```
 table_schema | table_name
--------------+------------------------------------
 whatsapp     | whatsmeow_app_state_mutation_macs
 whatsapp     | whatsmeow_app_state_sync_keys
 whatsapp     | whatsmeow_app_state_version
 whatsapp     | whatsmeow_chat_settings
 whatsapp     | whatsmeow_contacts
 whatsapp     | whatsmeow_device
 whatsapp     | whatsmeow_event_buffer
 whatsapp     | whatsmeow_identity_keys
 whatsapp     | whatsmeow_lid_map
 whatsapp     | whatsmeow_message_secrets
 whatsapp     | whatsmeow_nct_salt
 whatsapp     | whatsmeow_pre_keys
 whatsapp     | whatsmeow_privacy_tokens
 whatsapp     | whatsmeow_retry_buffer
 whatsapp     | whatsmeow_sender_keys
 whatsapp     | whatsmeow_sessions
 whatsapp     | whatsmeow_version
(17 rows)
```

Not just DDL — a `PutDevice` / `GetAllDevices` round trip on the same container
returned the device and left `public` untouched:

```
ROUNDTRIP OK devices=1
 wa_devices | public_tables
------------+---------------
          1 |             0
```

The failure paths, verbatim:

```
Database initialization error: failed to upgrade database: failed to create
version table: pq: no schema has been selected to create in at column 14 (3F000)

Database initialization error: failed to upgrade database: pq: relation
"whatsmeow_version" does not exist at column 29 (42P01)
```

`gofmt -l` clean on the touched files, and `go build ./... && go vet ./... &&
go test ./...` pass from `src/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GntpfJ8xPKDMfUgJSaJX6b)_