### PR TITLE
feat(device): add per-device chat storage and auto-download-media overrides

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -978,6 +978,7 @@ paths:
           application/json:
             schema:
               type: object
+              minProperties: 1
               properties:
                 chat_storage:
                   type: boolean

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -979,6 +979,7 @@ paths:
             schema:
               type: object
               minProperties: 1
+              additionalProperties: false
               properties:
                 chat_storage:
                   type: boolean

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -887,6 +887,160 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorInternalServer'
 
+  /devices/{device_id}/settings:
+    get:
+      operationId: getDeviceStorageSettings
+      tags:
+        - device
+      summary: Get device storage settings
+      description: |
+        Get the per-device chat_storage / auto_download_media overrides for a specific device.
+        A null value means the device has no override and follows the instance-wide default
+        (chat storage is always on; auto_download_media follows --auto-download-media /
+        WHATSAPP_AUTO_DOWNLOAD_MEDIA).
+      parameters:
+        - name: device_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Device ID
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  code:
+                    type: string
+                    example: SUCCESS
+                  message:
+                    type: string
+                    example: Device storage settings retrieved
+                  results:
+                    type: object
+                    properties:
+                      device_id:
+                        type: string
+                        description: The device ID
+                        example: 'my-device'
+                      chat_storage:
+                        type: boolean
+                        nullable: true
+                        description: Per-device chat storage override. Null follows the instance-wide default (always on).
+                        example: false
+                      auto_download_media:
+                        type: boolean
+                        nullable: true
+                        description: Per-device auto-download-media override. Null follows --auto-download-media / WHATSAPP_AUTO_DOWNLOAD_MEDIA.
+                        example: true
+        '404':
+          description: Device not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorNotFound'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInternalServer'
+    patch:
+      operationId: updateDeviceStorageSettings
+      tags:
+        - device
+      summary: Set device storage settings
+      description: |
+        Apply a partial update to a device's chat_storage / auto_download_media overrides.
+        Only the fields present in the request body are changed — an omitted field keeps its
+        current value. A field sent as `null` clears the override, falling back to the
+        instance-wide default. At least one of chat_storage or auto_download_media is required.
+
+        Multi-tenant deployments running one instance for many customer devices use this to
+        keep specific devices (e.g. alarm/service accounts) out of chat storage or off
+        automatic media downloads without changing the instance-wide flags for every other
+        device.
+      parameters:
+        - name: device_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Device ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                chat_storage:
+                  type: boolean
+                  nullable: true
+                  description: Set to enable/disable chat storage for this device, or null to clear the override.
+                  example: false
+                auto_download_media:
+                  type: boolean
+                  nullable: true
+                  description: Set to enable/disable auto media download for this device, or null to clear the override.
+                  example: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 200
+                  code:
+                    type: string
+                    example: SUCCESS
+                  message:
+                    type: string
+                    example: Device storage settings updated
+                  results:
+                    type: object
+                    properties:
+                      device_id:
+                        type: string
+                        description: The device ID
+                        example: 'my-device'
+                      chat_storage:
+                        type: boolean
+                        nullable: true
+                        example: false
+                      auto_download_media:
+                        type: boolean
+                        nullable: true
+                        example: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBadRequest'
+        '404':
+          description: Device not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorNotFound'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorInternalServer'
+
   /user/info:
     get:
       operationId: userInfo

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -962,10 +962,9 @@ paths:
         current value. A field sent as `null` clears the override, falling back to the
         instance-wide default. At least one of chat_storage or auto_download_media is required.
 
-        Multi-tenant deployments running one instance for many customer devices use this to
-        keep specific devices (e.g. alarm/service accounts) out of chat storage or off
-        automatic media downloads without changing the instance-wide flags for every other
-        device.
+        Useful when one instance hosts many devices: specific devices (e.g. notification-only
+        accounts) can be kept out of chat storage or off automatic media downloads without
+        changing the instance-wide flags for every other device.
       parameters:
         - name: device_id
           in: path

--- a/readme.md
+++ b/readme.md
@@ -152,8 +152,8 @@ Download:
   - A field is `null` when the device has no override: chat storage falls back to always-on,
     auto_download_media falls back to `--auto-download-media` / `WHATSAPP_AUTO_DOWNLOAD_MEDIA`.
   - Send a field as `null` with `PATCH` to clear that override.
-  - Useful for a single instance hosting many customer devices — e.g. keeping an
-    alarm/service device out of chat storage without touching every other device.
+  - Useful when one instance hosts many devices — e.g. keeping a notification-only
+    device out of chat storage without changing the flags for every other device.
 - **Webhook signatures** — Webhook requests include an HMAC-SHA-256 signature in the `X-Hub-Signature-256`
   header, generated with the default key `secret`.
 

--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,16 @@ Download:
   - When a device has a custom webhook, events for that device are sent to the device-specific URL.
   - When no device webhook is set, events fall back to the global webhook (`--webhook`).
   - Set `webhook_url` to an empty string with `PATCH` to clear it and use the global webhook.
+- **Per-device storage settings** — Each device can override chat storage and automatic media
+  download independently of the instance-wide flags.
+  - Set via API: `PATCH /devices/:device_id/settings` with `{"chat_storage": false}`,
+    `{"auto_download_media": true}`, or both. Only the fields present in the body are changed.
+  - Get via API: `GET /devices/:device_id/settings`.
+  - A field is `null` when the device has no override: chat storage falls back to always-on,
+    auto_download_media falls back to `--auto-download-media` / `WHATSAPP_AUTO_DOWNLOAD_MEDIA`.
+  - Send a field as `null` with `PATCH` to clear that override.
+  - Useful for a single instance hosting many customer devices — e.g. keeping an
+    alarm/service device out of chat storage without touching every other device.
 - **Webhook signatures** — Webhook requests include an HMAC-SHA-256 signature in the `X-Hub-Signature-256`
   header, generated with the default key `secret`.
 
@@ -634,6 +644,8 @@ You may also fork or modify the source code.
 | ✅       | Get Device Status                      | GET    | /devices/:device_id/status          |
 | ✅       | Get Device Webhook                     | GET    | /devices/:device_id/webhook         |
 | ✅       | Set Device Webhook                     | PATCH  | /devices/:device_id/webhook         |
+| ✅       | Get Device Storage Settings            | GET    | /devices/:device_id/settings        |
+| ✅       | Set Device Storage Settings            | PATCH  | /devices/:device_id/settings        |
 | ✅       | Log In with QR Code                    | GET    | /app/login                          |
 | ✅       | Log In with Pairing Code               | GET    | /app/login-with-code                |
 | ✅       | Passkey Pairing Status                 | GET    | /app/passkey                        |

--- a/src/domains/chatstorage/chatstorage.go
+++ b/src/domains/chatstorage/chatstorage.go
@@ -157,6 +157,8 @@ type DeviceRecord struct {
 	WebhookSecret             string    `db:"webhook_secret"`
 	WebhookEvents             string    `db:"webhook_events"`
 	WebhookInsecureSkipVerify bool      `db:"webhook_insecure_skip_verify"`
+	ChatStorage               *bool     `db:"chat_storage"`
+	AutoDownloadMedia         *bool     `db:"auto_download_media"`
 	CreatedAt                 time.Time `db:"created_at"`
 	UpdatedAt                 time.Time `db:"updated_at"`
 }
@@ -167,6 +169,28 @@ type DeviceWebhookConfig struct {
 	WebhookSecret             string  `json:"webhook_secret,omitempty"`
 	WebhookEvents             string  `json:"webhook_events,omitempty"`
 	WebhookInsecureSkipVerify bool    `json:"webhook_insecure_skip_verify,omitempty"`
+}
+
+// DeviceStorageSettings holds the per-device overrides for chat storage and
+// automatic media downloads. A nil field means "no override configured" —
+// callers on the message path fall back to the instance-wide default
+// (chat storage is always on; auto_download_media follows
+// --auto-download-media / WHATSAPP_AUTO_DOWNLOAD_MEDIA).
+type DeviceStorageSettings struct {
+	ChatStorage       *bool `json:"chat_storage"`
+	AutoDownloadMedia *bool `json:"auto_download_media"`
+}
+
+// DeviceStoragePatch describes a partial update to DeviceStorageSettings, as sent
+// through PATCH /devices/{device_id}/settings. HasChatStorage/HasAutoDownloadMedia
+// distinguish "the field was absent from the request body" (leave the stored value
+// untouched) from "the field was present" — when present, a nil pointer clears the
+// override back to "follow the instance default", and a non-nil pointer pins it.
+type DeviceStoragePatch struct {
+	HasChatStorage       bool
+	ChatStorage          *bool
+	HasAutoDownloadMedia bool
+	AutoDownloadMedia    *bool
 }
 
 // MessageFilter represents query filters for messages

--- a/src/domains/chatstorage/interfaces.go
+++ b/src/domains/chatstorage/interfaces.go
@@ -124,7 +124,10 @@ type IChatStorageRepository interface {
 	// present in patch are touched.
 	SetDeviceStorageSettings(deviceID string, patch DeviceStoragePatch) error
 	// GetDeviceStorageSettings retrieves the per-device chat_storage /
-	// auto_download_media overrides. Returns nil fields when no override is set.
+	// auto_download_media overrides. Returns (nil, nil) if the device does not
+	// exist. For an existing device, always returns a non-nil
+	// *DeviceStorageSettings; ChatStorage/AutoDownloadMedia are nil fields on it
+	// when no override is set for that field.
 	GetDeviceStorageSettings(deviceID string) (*DeviceStorageSettings, error)
 
 	// Schema operations

--- a/src/domains/chatstorage/interfaces.go
+++ b/src/domains/chatstorage/interfaces.go
@@ -119,6 +119,13 @@ type IChatStorageRepository interface {
 	SetDeviceWebhookConfig(deviceID string, config *DeviceWebhookConfig) error
 	// GetDeviceWebhookConfig retrieves the full webhook configuration for a device.
 	GetDeviceWebhookConfig(deviceID string) (*DeviceWebhookConfig, error)
+	// SetDeviceStorageSettings applies a partial update to the per-device
+	// chat_storage / auto_download_media overrides. Only the fields flagged as
+	// present in patch are touched.
+	SetDeviceStorageSettings(deviceID string, patch DeviceStoragePatch) error
+	// GetDeviceStorageSettings retrieves the per-device chat_storage /
+	// auto_download_media overrides. Returns nil fields when no override is set.
+	GetDeviceStorageSettings(deviceID string) (*DeviceStorageSettings, error)
 
 	// Schema operations
 	InitializeSchema() error

--- a/src/domains/device/interfaces.go
+++ b/src/domains/device/interfaces.go
@@ -28,4 +28,9 @@ type IDeviceUsecase interface {
 	SetDeviceWebhookConfig(ctx context.Context, deviceID string, config *chatstorage.DeviceWebhookConfig) error
 	// GetDeviceWebhookConfig retrieves the complete webhook configuration for a specific device.
 	GetDeviceWebhookConfig(ctx context.Context, deviceID string) (*chatstorage.DeviceWebhookConfig, error)
+	// SetDeviceStorageSettings applies a partial update to a device's chat_storage /
+	// auto_download_media overrides.
+	SetDeviceStorageSettings(ctx context.Context, deviceID string, patch chatstorage.DeviceStoragePatch) error
+	// GetDeviceStorageSettings retrieves a device's chat_storage / auto_download_media overrides.
+	GetDeviceStorageSettings(ctx context.Context, deviceID string) (*chatstorage.DeviceStorageSettings, error)
 }

--- a/src/infrastructure/chatstorage/sqlite_repository.go
+++ b/src/infrastructure/chatstorage/sqlite_repository.go
@@ -1637,7 +1637,7 @@ func (r *SQLiteRepository) GetDeviceRecordByJID(jid string) (*domainChatStorage.
 	}
 
 	rows, err := r.db.Query(`
-		SELECT device_id, display_name, jid, COALESCE(ad_jid, ''), webhook_url, COALESCE(webhook_secret, ''), COALESCE(webhook_events, ''), COALESCE(webhook_insecure_skip_verify, FALSE), created_at, updated_at
+		SELECT device_id, display_name, jid, COALESCE(ad_jid, ''), webhook_url, COALESCE(webhook_secret, ''), COALESCE(webhook_events, ''), COALESCE(webhook_insecure_skip_verify, FALSE), chat_storage, auto_download_media, created_at, updated_at
 		FROM devices
 		WHERE jid = ? OR ad_jid = ?
 		LIMIT 2
@@ -1650,6 +1650,7 @@ func (r *SQLiteRepository) GetDeviceRecordByJID(jid string) (*domainChatStorage.
 	var records []*domainChatStorage.DeviceRecord
 	for rows.Next() {
 		rec := &domainChatStorage.DeviceRecord{}
+		var chatStorage, autoDownloadMedia sql.NullBool
 		if err := rows.Scan(
 			&rec.DeviceID,
 			&rec.DisplayName,
@@ -1659,10 +1660,20 @@ func (r *SQLiteRepository) GetDeviceRecordByJID(jid string) (*domainChatStorage.
 			&rec.WebhookSecret,
 			&rec.WebhookEvents,
 			&rec.WebhookInsecureSkipVerify,
+			&chatStorage,
+			&autoDownloadMedia,
 			&rec.CreatedAt,
 			&rec.UpdatedAt,
 		); err != nil {
 			return nil, err
+		}
+		if chatStorage.Valid {
+			v := chatStorage.Bool
+			rec.ChatStorage = &v
+		}
+		if autoDownloadMedia.Valid {
+			v := autoDownloadMedia.Bool
+			rec.AutoDownloadMedia = &v
 		}
 		records = append(records, rec)
 	}
@@ -1790,6 +1801,81 @@ func (r *SQLiteRepository) GetDeviceWebhookConfig(deviceID string) (*domainChatS
 	}
 	config.WebhookURL = webhookURL
 	return &config, nil
+}
+
+// SetDeviceStorageSettings applies a partial update to the per-device chat_storage /
+// auto_download_media overrides. Only columns whose Has* flag is set in patch are
+// included in the UPDATE, so an omitted field keeps its stored value untouched while
+// a present field with a nil pointer clears the override back to NULL (follow the
+// instance default). Returns sql.ErrNoRows if the device does not exist.
+func (r *SQLiteRepository) SetDeviceStorageSettings(deviceID string, patch domainChatStorage.DeviceStoragePatch) error {
+	if strings.TrimSpace(deviceID) == "" {
+		return fmt.Errorf("device id is required")
+	}
+	if !patch.HasChatStorage && !patch.HasAutoDownloadMedia {
+		return nil
+	}
+
+	setClauses := make([]string, 0, 3)
+	args := make([]any, 0, 4)
+
+	if patch.HasChatStorage {
+		setClauses = append(setClauses, "chat_storage = ?")
+		args = append(args, patch.ChatStorage)
+	}
+	if patch.HasAutoDownloadMedia {
+		setClauses = append(setClauses, "auto_download_media = ?")
+		args = append(args, patch.AutoDownloadMedia)
+	}
+	setClauses = append(setClauses, "updated_at = ?")
+	args = append(args, time.Now())
+	args = append(args, deviceID)
+
+	query := fmt.Sprintf("UPDATE devices SET %s WHERE device_id = ?", strings.Join(setClauses, ", "))
+	result, err := r.db.Exec(query, args...)
+	if err != nil {
+		return err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// GetDeviceStorageSettings retrieves the per-device chat_storage / auto_download_media
+// overrides. Returns (nil, nil) if the device does not exist so callers can distinguish
+// "device not found" (nil, nil here — mirroring GetDeviceWebhookConfig) from storage
+// errors, and the usecase layer checks device existence separately before calling.
+func (r *SQLiteRepository) GetDeviceStorageSettings(deviceID string) (*domainChatStorage.DeviceStorageSettings, error) {
+	if strings.TrimSpace(deviceID) == "" {
+		return nil, fmt.Errorf("device id is required")
+	}
+	var chatStorage, autoDownloadMedia sql.NullBool
+	err := r.db.QueryRow(`
+		SELECT chat_storage, auto_download_media
+		FROM devices WHERE device_id = ? LIMIT 1
+	`, deviceID).Scan(&chatStorage, &autoDownloadMedia)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	settings := &domainChatStorage.DeviceStorageSettings{}
+	if chatStorage.Valid {
+		v := chatStorage.Bool
+		settings.ChatStorage = &v
+	}
+	if autoDownloadMedia.Valid {
+		v := autoDownloadMedia.Bool
+		settings.AutoDownloadMedia = &v
+	}
+	return settings, nil
 }
 
 // GetChatNameWithPushName determines the appropriate name for a chat with pushname support
@@ -2804,5 +2890,13 @@ func (r *SQLiteRepository) getMigrations() []string {
 			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (device_id, chat_jid, poll_message_id)
 		)`,
+
+		// Migration 45: Per-device chat storage override (NULL = follow the
+		// instance-wide default, which is always-on)
+		`ALTER TABLE devices ADD COLUMN chat_storage BOOLEAN DEFAULT NULL`,
+
+		// Migration 46: Per-device auto-download-media override (NULL = follow
+		// --auto-download-media / WHATSAPP_AUTO_DOWNLOAD_MEDIA)
+		`ALTER TABLE devices ADD COLUMN auto_download_media BOOLEAN DEFAULT NULL`,
 	}
 }

--- a/src/infrastructure/chatstorage/sqlite_repository_device_storage_settings_test.go
+++ b/src/infrastructure/chatstorage/sqlite_repository_device_storage_settings_test.go
@@ -1,0 +1,175 @@
+package chatstorage
+
+import (
+	"database/sql"
+	"testing"
+
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+// A device with no chat_storage/auto_download_media override must report both
+// fields as nil so callers know to fall back to the instance-wide default.
+func TestGetDeviceStorageSettings_NoOverride(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	if err := repo.SaveDeviceRecord(&domainChatStorage.DeviceRecord{DeviceID: "dev1", JID: "628177700001@s.whatsapp.net"}); err != nil {
+		t.Fatalf("save device record: %v", err)
+	}
+
+	settings, err := repo.GetDeviceStorageSettings("dev1")
+	if err != nil {
+		t.Fatalf("get device storage settings: %v", err)
+	}
+	if settings == nil {
+		t.Fatal("expected non-nil settings for an existing device")
+	}
+	if settings.ChatStorage != nil {
+		t.Fatalf("expected nil ChatStorage, got %v", *settings.ChatStorage)
+	}
+	if settings.AutoDownloadMedia != nil {
+		t.Fatalf("expected nil AutoDownloadMedia, got %v", *settings.AutoDownloadMedia)
+	}
+}
+
+// GetDeviceStorageSettings on a device id that was never registered returns (nil, nil),
+// mirroring GetDeviceWebhookConfig's contract.
+func TestGetDeviceStorageSettings_UnknownDevice(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	settings, err := repo.GetDeviceStorageSettings("unknown")
+	if err != nil {
+		t.Fatalf("get device storage settings: %v", err)
+	}
+	if settings != nil {
+		t.Fatalf("expected nil settings for unknown device, got %+v", settings)
+	}
+}
+
+// SetDeviceStorageSettings only touches the columns flagged as present in the patch:
+// setting chat_storage must leave a previously set auto_download_media untouched.
+func TestSetDeviceStorageSettings_PartialUpdateLeavesOtherFieldUntouched(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	if err := repo.SaveDeviceRecord(&domainChatStorage.DeviceRecord{DeviceID: "dev1", JID: "628177700001@s.whatsapp.net"}); err != nil {
+		t.Fatalf("save device record: %v", err)
+	}
+
+	if err := repo.SetDeviceStorageSettings("dev1", domainChatStorage.DeviceStoragePatch{
+		HasAutoDownloadMedia: true,
+		AutoDownloadMedia:    boolPtr(false),
+	}); err != nil {
+		t.Fatalf("set auto_download_media: %v", err)
+	}
+
+	if err := repo.SetDeviceStorageSettings("dev1", domainChatStorage.DeviceStoragePatch{
+		HasChatStorage: true,
+		ChatStorage:    boolPtr(false),
+	}); err != nil {
+		t.Fatalf("set chat_storage: %v", err)
+	}
+
+	settings, err := repo.GetDeviceStorageSettings("dev1")
+	if err != nil {
+		t.Fatalf("get device storage settings: %v", err)
+	}
+	if settings == nil || settings.ChatStorage == nil || *settings.ChatStorage != false {
+		t.Fatalf("expected chat_storage=false, got %+v", settings)
+	}
+	if settings.AutoDownloadMedia == nil || *settings.AutoDownloadMedia != false {
+		t.Fatalf("expected auto_download_media to still be false from the earlier call, got %+v", settings)
+	}
+}
+
+// A patch field present with a nil value clears the override back to "follow the
+// instance default" (NULL in the database), not to false.
+func TestSetDeviceStorageSettings_NilValueClearsOverride(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	if err := repo.SaveDeviceRecord(&domainChatStorage.DeviceRecord{DeviceID: "dev1", JID: "628177700001@s.whatsapp.net"}); err != nil {
+		t.Fatalf("save device record: %v", err)
+	}
+
+	if err := repo.SetDeviceStorageSettings("dev1", domainChatStorage.DeviceStoragePatch{
+		HasChatStorage: true,
+		ChatStorage:    boolPtr(false),
+	}); err != nil {
+		t.Fatalf("set chat_storage: %v", err)
+	}
+
+	if err := repo.SetDeviceStorageSettings("dev1", domainChatStorage.DeviceStoragePatch{
+		HasChatStorage: true,
+		ChatStorage:    nil,
+	}); err != nil {
+		t.Fatalf("clear chat_storage: %v", err)
+	}
+
+	settings, err := repo.GetDeviceStorageSettings("dev1")
+	if err != nil {
+		t.Fatalf("get device storage settings: %v", err)
+	}
+	if settings == nil || settings.ChatStorage != nil {
+		t.Fatalf("expected chat_storage override cleared (nil), got %+v", settings)
+	}
+}
+
+// SetDeviceStorageSettings on a device id that does not exist reports sql.ErrNoRows,
+// mirroring SetDeviceWebhookConfig/SetDeviceWebhookURL.
+func TestSetDeviceStorageSettings_UnknownDevice(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	err := repo.SetDeviceStorageSettings("unknown", domainChatStorage.DeviceStoragePatch{
+		HasChatStorage: true,
+		ChatStorage:    boolPtr(true),
+	})
+	if err != sql.ErrNoRows {
+		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+// A patch with neither field flagged as present is a no-op, not an error.
+func TestSetDeviceStorageSettings_EmptyPatchIsNoop(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	if err := repo.SaveDeviceRecord(&domainChatStorage.DeviceRecord{DeviceID: "dev1", JID: "628177700001@s.whatsapp.net"}); err != nil {
+		t.Fatalf("save device record: %v", err)
+	}
+
+	if err := repo.SetDeviceStorageSettings("dev1", domainChatStorage.DeviceStoragePatch{}); err != nil {
+		t.Fatalf("expected no error for empty patch, got %v", err)
+	}
+}
+
+// GetDeviceRecordByJID (used on the message path to resolve per-device overrides)
+// must surface chat_storage/auto_download_media alongside the existing webhook fields.
+func TestGetDeviceRecordByJID_IncludesStorageSettings(t *testing.T) {
+	repo := newTestSQLiteRepository(t)
+
+	jid := "628177700001@s.whatsapp.net"
+	if err := repo.SaveDeviceRecord(&domainChatStorage.DeviceRecord{DeviceID: "dev1", JID: jid}); err != nil {
+		t.Fatalf("save device record: %v", err)
+	}
+	if err := repo.SetDeviceStorageSettings("dev1", domainChatStorage.DeviceStoragePatch{
+		HasChatStorage:       true,
+		ChatStorage:          boolPtr(false),
+		HasAutoDownloadMedia: true,
+		AutoDownloadMedia:    boolPtr(true),
+	}); err != nil {
+		t.Fatalf("set storage settings: %v", err)
+	}
+
+	record, err := repo.GetDeviceRecordByJID(jid)
+	if err != nil {
+		t.Fatalf("get device record by jid: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected a device record")
+	}
+	if record.ChatStorage == nil || *record.ChatStorage != false {
+		t.Fatalf("expected ChatStorage=false, got %+v", record.ChatStorage)
+	}
+	if record.AutoDownloadMedia == nil || *record.AutoDownloadMedia != true {
+		t.Fatalf("expected AutoDownloadMedia=true, got %+v", record.AutoDownloadMedia)
+	}
+}

--- a/src/infrastructure/whatsapp/auto_reply.go
+++ b/src/infrastructure/whatsapp/auto_reply.go
@@ -86,7 +86,7 @@ func handleAutoReply(ctx context.Context, evt *events.Message, chatStorageRepo d
 	}
 
 	// Store the auto-reply message in chat storage if send was successful
-	if chatStorageRepo != nil {
+	if chatStorageRepo != nil && isChatStorageEnabledForClient(client) {
 		// Get our own JID as sender
 		senderJID := ""
 		if client.Store.ID != nil {

--- a/src/infrastructure/whatsapp/auto_reply.go
+++ b/src/infrastructure/whatsapp/auto_reply.go
@@ -86,7 +86,7 @@ func handleAutoReply(ctx context.Context, evt *events.Message, chatStorageRepo d
 	}
 
 	// Store the auto-reply message in chat storage if send was successful
-	if chatStorageRepo != nil && isChatStorageEnabledForClient(client) {
+	if chatStorageRepo != nil && isChatStorageEnabledForClient(ctx, client) {
 		// Get our own JID as sender
 		senderJID := ""
 		if client.Store.ID != nil {

--- a/src/infrastructure/whatsapp/chatstorage_wrapper.go
+++ b/src/infrastructure/whatsapp/chatstorage_wrapper.go
@@ -381,3 +381,14 @@ func (r *deviceChatStorage) SetDeviceWebhookConfig(deviceID string, config *doma
 func (r *deviceChatStorage) GetDeviceWebhookConfig(deviceID string) (*domainChatStorage.DeviceWebhookConfig, error) {
 	return r.base.GetDeviceWebhookConfig(deviceID)
 }
+
+// SetDeviceStorageSettings applies a partial update to a device's chat_storage /
+// auto_download_media overrides.
+func (r *deviceChatStorage) SetDeviceStorageSettings(deviceID string, patch domainChatStorage.DeviceStoragePatch) error {
+	return r.base.SetDeviceStorageSettings(deviceID, patch)
+}
+
+// GetDeviceStorageSettings retrieves a device's chat_storage / auto_download_media overrides.
+func (r *deviceChatStorage) GetDeviceStorageSettings(deviceID string) (*domainChatStorage.DeviceStorageSettings, error) {
+	return r.base.GetDeviceStorageSettings(deviceID)
+}

--- a/src/infrastructure/whatsapp/device_storage_settings.go
+++ b/src/infrastructure/whatsapp/device_storage_settings.go
@@ -1,94 +1,105 @@
 package whatsapp
 
 import (
+	"context"
+
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
 	"github.com/sirupsen/logrus"
 	"go.mau.fi/whatsmeow"
 )
 
-// deviceStorageRecordForTest is a seam for unit tests, mirroring webhookStorageForTest
-// in webhook_forward.go: it lets tests stub the device record lookup without a real
-// DeviceManager/storage.
-var deviceStorageRecordForTest func(deviceJID string) (*domainChatStorage.DeviceRecord, error)
+// deviceStorageSettingsForTest is a seam for unit tests, mirroring webhookStorageForTest
+// in webhook_forward.go: it lets tests stub the device-ID-keyed settings lookup without
+// a real DeviceManager/storage.
+var deviceStorageSettingsForTest func(deviceID string) (*domainChatStorage.DeviceStorageSettings, error)
 
-// getDeviceRecordForStorageSettings resolves the device record used to derive the
-// per-device chat_storage / auto_download_media overrides, using the test override
-// if set and otherwise the live DeviceManager storage (same resolution path as
-// getWebhookConfigForDevice).
-func getDeviceRecordForStorageSettings(deviceJID string) (*domainChatStorage.DeviceRecord, error) {
-	if deviceStorageRecordForTest != nil {
-		return deviceStorageRecordForTest(deviceJID)
+// getDeviceStorageSettingsForID resolves the chat_storage / auto_download_media
+// overrides for the device registered under deviceID, using the test override if set
+// and otherwise the live DeviceManager storage.
+func getDeviceStorageSettingsForID(deviceID string) (*domainChatStorage.DeviceStorageSettings, error) {
+	if deviceStorageSettingsForTest != nil {
+		return deviceStorageSettingsForTest(deviceID)
 	}
 	dm := GetDeviceManager()
 	if dm != nil && dm.storage != nil {
-		return dm.storage.GetDeviceRecordByJID(deviceJID)
+		return dm.storage.GetDeviceStorageSettings(deviceID)
 	}
 	return nil, nil
 }
 
-// clientDeviceJID returns the own-account JID (bare number form) for a connected
-// client, or "" when the client or its store is not yet available.
-func clientDeviceJID(client *whatsmeow.Client) string {
-	if client == nil || client.Store == nil || client.Store.ID == nil {
-		return ""
-	}
-	return client.Store.ID.ToNonAD().String()
-}
-
 // isChatStorageEnabledForClient reports whether incoming messages/reactions/history
-// should be persisted to the local chat storage database for the device behind
-// client. See isChatStorageEnabledForDeviceJID for the resolution rules.
-func isChatStorageEnabledForClient(client *whatsmeow.Client) bool {
-	return isChatStorageEnabledForDeviceJID(clientDeviceJID(client))
+// should be persisted to the local chat storage database for the device carried in
+// ctx. See isChatStorageEnabledForDeviceID for the resolution rules. Falls back to
+// enabled when ctx carries no device (e.g. a call path outside the event handler),
+// matching the pre-existing instance-wide default.
+func isChatStorageEnabledForClient(ctx context.Context, client *whatsmeow.Client) bool {
+	instance, ok := DeviceFromContext(ctx)
+	if !ok || instance == nil {
+		return true
+	}
+	return isChatStorageEnabledForDeviceID(instance.ID())
 }
 
-// isChatStorageEnabledForDeviceJID reports whether chat storage is enabled for the
-// device identified by deviceJID. A per-device chat_storage=false override skips
-// storage entirely for that device; no override (nil) keeps the instance-wide
-// default of always storing, so existing deployments are unaffected. Split out
-// from the *whatsmeow.Client variant so it can be unit tested without a live
+// isChatStorageEnabledForDeviceID reports whether chat storage is enabled for the
+// device registered under deviceID. Resolving by the device's registry ID (rather
+// than its bare-number JID) always identifies the exact slot, even when sibling
+// companion sessions share the same account number (issue #760). A per-device
+// chat_storage=false override skips storage entirely for that device; no override
+// (nil) keeps the instance-wide default of always storing, so existing deployments
+// are unaffected. A lookup error fails closed (disabled): a transient storage
+// failure cannot distinguish "no override" from a persisted false, so defaulting to
+// enabled on an indeterminate read would silently defeat an explicit opt-out. Split
+// out from the *whatsmeow.Client variant so it can be unit tested without a live
 // client/store.
-func isChatStorageEnabledForDeviceJID(deviceJID string) bool {
-	if deviceJID == "" {
+func isChatStorageEnabledForDeviceID(deviceID string) bool {
+	if deviceID == "" {
 		return true
 	}
 
-	record, err := getDeviceRecordForStorageSettings(deviceJID)
+	settings, err := getDeviceStorageSettingsForID(deviceID)
 	if err != nil {
-		logrus.Warnf("Failed to resolve chat_storage override for device %s, defaulting to enabled: %v", deviceJID, err)
-		return true
+		logrus.Warnf("Failed to resolve chat_storage override for device %s, failing closed (disabled): %v", deviceID, err)
+		return false
 	}
-	if record != nil && record.ChatStorage != nil {
-		return *record.ChatStorage
+	if settings != nil && settings.ChatStorage != nil {
+		return *settings.ChatStorage
 	}
 	return true
 }
 
 // isAutoDownloadMediaEnabledForClient reports whether incoming media should be
-// auto-downloaded for the device behind client. See
-// isAutoDownloadMediaEnabledForDeviceJID for the resolution rules.
-func isAutoDownloadMediaEnabledForClient(client *whatsmeow.Client) bool {
-	return isAutoDownloadMediaEnabledForDeviceJID(clientDeviceJID(client))
+// auto-downloaded for the device carried in ctx. See
+// isAutoDownloadMediaEnabledForDeviceID for the resolution rules. Falls back to the
+// instance-wide flag when ctx carries no device.
+func isAutoDownloadMediaEnabledForClient(ctx context.Context, client *whatsmeow.Client) bool {
+	instance, ok := DeviceFromContext(ctx)
+	if !ok || instance == nil {
+		return config.WhatsappAutoDownloadMedia
+	}
+	return isAutoDownloadMediaEnabledForDeviceID(instance.ID())
 }
 
-// isAutoDownloadMediaEnabledForDeviceJID reports whether auto-download is enabled
-// for the device identified by deviceJID. No override (nil) falls back to the
-// instance-wide --auto-download-media / WHATSAPP_AUTO_DOWNLOAD_MEDIA flag. Split
-// out from the *whatsmeow.Client variant so it can be unit tested without a live
+// isAutoDownloadMediaEnabledForDeviceID reports whether auto-download is enabled
+// for the device registered under deviceID. No override (nil) falls back to the
+// instance-wide --auto-download-media / WHATSAPP_AUTO_DOWNLOAD_MEDIA flag. A lookup
+// error fails closed (disabled), for the same reason as
+// isChatStorageEnabledForDeviceID: falling back to a global flag that may be true
+// would override a persisted false during a transient storage failure. Split out
+// from the *whatsmeow.Client variant so it can be unit tested without a live
 // client/store.
-func isAutoDownloadMediaEnabledForDeviceJID(deviceJID string) bool {
-	if deviceJID == "" {
+func isAutoDownloadMediaEnabledForDeviceID(deviceID string) bool {
+	if deviceID == "" {
 		return config.WhatsappAutoDownloadMedia
 	}
 
-	record, err := getDeviceRecordForStorageSettings(deviceJID)
+	settings, err := getDeviceStorageSettingsForID(deviceID)
 	if err != nil {
-		logrus.Warnf("Failed to resolve auto_download_media override for device %s, defaulting to global: %v", deviceJID, err)
-		return config.WhatsappAutoDownloadMedia
+		logrus.Warnf("Failed to resolve auto_download_media override for device %s, failing closed (disabled): %v", deviceID, err)
+		return false
 	}
-	if record != nil && record.AutoDownloadMedia != nil {
-		return *record.AutoDownloadMedia
+	if settings != nil && settings.AutoDownloadMedia != nil {
+		return *settings.AutoDownloadMedia
 	}
 	return config.WhatsappAutoDownloadMedia
 }

--- a/src/infrastructure/whatsapp/device_storage_settings.go
+++ b/src/infrastructure/whatsapp/device_storage_settings.go
@@ -1,0 +1,96 @@
+package whatsapp
+
+import (
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/sirupsen/logrus"
+	"go.mau.fi/whatsmeow"
+)
+
+// deviceStorageRecordForTest is a seam for unit tests, mirroring webhookStorageForTest
+// in webhook_forward.go: it lets tests stub the device record lookup without a real
+// DeviceManager/storage.
+var deviceStorageRecordForTest func(deviceJID string) (*domainChatStorage.DeviceRecord, error)
+
+// getDeviceRecordForStorageSettings resolves the device record used to derive the
+// per-device chat_storage / auto_download_media overrides, using the test override
+// if set and otherwise the live DeviceManager storage (same resolution path as
+// getWebhookConfigForDevice).
+func getDeviceRecordForStorageSettings(deviceJID string) (*domainChatStorage.DeviceRecord, error) {
+	if deviceStorageRecordForTest != nil {
+		return deviceStorageRecordForTest(deviceJID)
+	}
+	dm := GetDeviceManager()
+	if dm != nil && dm.storage != nil {
+		return dm.storage.GetDeviceRecordByJID(deviceJID)
+	}
+	return nil, nil
+}
+
+// clientDeviceJID returns the own-account JID (bare number form) for a connected
+// client, or "" when the client or its store is not yet available.
+func clientDeviceJID(client *whatsmeow.Client) string {
+	if client == nil || client.Store == nil || client.Store.ID == nil {
+		return ""
+	}
+	return client.Store.ID.ToNonAD().String()
+}
+
+// isChatStorageEnabledForClient reports whether incoming messages/reactions/history
+// should be persisted to the local chat storage database for the device behind
+// client. See isChatStorageEnabledForDeviceJID for the resolution rules.
+func isChatStorageEnabledForClient(client *whatsmeow.Client) bool {
+	return isChatStorageEnabledForDeviceJID(clientDeviceJID(client))
+}
+
+// isChatStorageEnabledForDeviceJID reports whether chat storage is enabled for the
+// device identified by deviceJID. A per-device chat_storage=false override skips
+// storage entirely for that device; no override (nil) keeps the instance-wide
+// default of always storing, so existing single-tenant deployments are unaffected.
+// Multi-tenant deployments running one instance for many customer devices use the
+// override to keep alarm/service devices out of chat storage without touching
+// every other device. Split out from the *whatsmeow.Client variant so it can be
+// unit tested without a live client/store.
+func isChatStorageEnabledForDeviceJID(deviceJID string) bool {
+	if deviceJID == "" {
+		return true
+	}
+
+	record, err := getDeviceRecordForStorageSettings(deviceJID)
+	if err != nil {
+		logrus.Warnf("Failed to resolve chat_storage override for device %s, defaulting to enabled: %v", deviceJID, err)
+		return true
+	}
+	if record != nil && record.ChatStorage != nil {
+		return *record.ChatStorage
+	}
+	return true
+}
+
+// isAutoDownloadMediaEnabledForClient reports whether incoming media should be
+// auto-downloaded for the device behind client. See
+// isAutoDownloadMediaEnabledForDeviceJID for the resolution rules.
+func isAutoDownloadMediaEnabledForClient(client *whatsmeow.Client) bool {
+	return isAutoDownloadMediaEnabledForDeviceJID(clientDeviceJID(client))
+}
+
+// isAutoDownloadMediaEnabledForDeviceJID reports whether auto-download is enabled
+// for the device identified by deviceJID. No override (nil) falls back to the
+// instance-wide --auto-download-media / WHATSAPP_AUTO_DOWNLOAD_MEDIA flag. Split
+// out from the *whatsmeow.Client variant so it can be unit tested without a live
+// client/store.
+func isAutoDownloadMediaEnabledForDeviceJID(deviceJID string) bool {
+	if deviceJID == "" {
+		return config.WhatsappAutoDownloadMedia
+	}
+
+	record, err := getDeviceRecordForStorageSettings(deviceJID)
+	if err != nil {
+		logrus.Warnf("Failed to resolve auto_download_media override for device %s, defaulting to global: %v", deviceJID, err)
+		return config.WhatsappAutoDownloadMedia
+	}
+	if record != nil && record.AutoDownloadMedia != nil {
+		return *record.AutoDownloadMedia
+	}
+	return config.WhatsappAutoDownloadMedia
+}

--- a/src/infrastructure/whatsapp/device_storage_settings.go
+++ b/src/infrastructure/whatsapp/device_storage_settings.go
@@ -46,11 +46,9 @@ func isChatStorageEnabledForClient(client *whatsmeow.Client) bool {
 // isChatStorageEnabledForDeviceJID reports whether chat storage is enabled for the
 // device identified by deviceJID. A per-device chat_storage=false override skips
 // storage entirely for that device; no override (nil) keeps the instance-wide
-// default of always storing, so existing single-tenant deployments are unaffected.
-// Multi-tenant deployments running one instance for many customer devices use the
-// override to keep alarm/service devices out of chat storage without touching
-// every other device. Split out from the *whatsmeow.Client variant so it can be
-// unit tested without a live client/store.
+// default of always storing, so existing deployments are unaffected. Split out
+// from the *whatsmeow.Client variant so it can be unit tested without a live
+// client/store.
 func isChatStorageEnabledForDeviceJID(deviceJID string) bool {
 	if deviceJID == "" {
 		return true

--- a/src/infrastructure/whatsapp/device_storage_settings_test.go
+++ b/src/infrastructure/whatsapp/device_storage_settings_test.go
@@ -1,6 +1,7 @@
 package whatsapp
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -8,131 +9,152 @@ import (
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
 )
 
-func withDeviceStorageRecordForTest(t *testing.T, fn func(deviceJID string) (*chatstorage.DeviceRecord, error)) {
+func withDeviceStorageSettingsForTest(t *testing.T, fn func(deviceID string) (*chatstorage.DeviceStorageSettings, error)) {
 	t.Helper()
-	original := deviceStorageRecordForTest
-	deviceStorageRecordForTest = fn
-	t.Cleanup(func() { deviceStorageRecordForTest = original })
+	original := deviceStorageSettingsForTest
+	deviceStorageSettingsForTest = fn
+	t.Cleanup(func() { deviceStorageSettingsForTest = original })
 }
 
-func TestIsChatStorageEnabledForDeviceJID_NoDeviceID(t *testing.T) {
-	if !isChatStorageEnabledForDeviceJID("") {
-		t.Fatal("expected chat storage enabled by default when no device JID is known")
+func TestIsChatStorageEnabledForDeviceID_NoDeviceID(t *testing.T) {
+	if !isChatStorageEnabledForDeviceID("") {
+		t.Fatal("expected chat storage enabled by default when no device ID is known")
 	}
 }
 
-func TestIsChatStorageEnabledForDeviceJID_DeviceNotFound(t *testing.T) {
-	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+func TestIsChatStorageEnabledForDeviceID_DeviceNotFound(t *testing.T) {
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
 		return nil, nil
 	})
 
-	if !isChatStorageEnabledForDeviceJID("unknown@s.whatsapp.net") {
+	if !isChatStorageEnabledForDeviceID("device-a") {
 		t.Fatal("expected chat storage enabled when the device has no record")
 	}
 }
 
-func TestIsChatStorageEnabledForDeviceJID_NoOverrideDefaultsEnabled(t *testing.T) {
-	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
-		return &chatstorage.DeviceRecord{DeviceID: deviceJID}, nil
+func TestIsChatStorageEnabledForDeviceID_NoOverrideDefaultsEnabled(t *testing.T) {
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
+		return &chatstorage.DeviceStorageSettings{}, nil
 	})
 
-	if !isChatStorageEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+	if !isChatStorageEnabledForDeviceID("device-a") {
 		t.Fatal("expected chat storage enabled when no override is set")
 	}
 }
 
-func TestIsChatStorageEnabledForDeviceJID_ExplicitFalseOverride(t *testing.T) {
+func TestIsChatStorageEnabledForDeviceID_ExplicitFalseOverride(t *testing.T) {
 	disabled := false
-	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
-		return &chatstorage.DeviceRecord{DeviceID: deviceJID, ChatStorage: &disabled}, nil
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
+		return &chatstorage.DeviceStorageSettings{ChatStorage: &disabled}, nil
 	})
 
-	if isChatStorageEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+	if isChatStorageEnabledForDeviceID("device-a") {
 		t.Fatal("expected chat storage disabled by explicit override")
 	}
 }
 
-func TestIsChatStorageEnabledForDeviceJID_ExplicitTrueOverride(t *testing.T) {
+func TestIsChatStorageEnabledForDeviceID_ExplicitTrueOverride(t *testing.T) {
 	enabled := true
-	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
-		return &chatstorage.DeviceRecord{DeviceID: deviceJID, ChatStorage: &enabled}, nil
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
+		return &chatstorage.DeviceStorageSettings{ChatStorage: &enabled}, nil
 	})
 
-	if !isChatStorageEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+	if !isChatStorageEnabledForDeviceID("device-a") {
 		t.Fatal("expected chat storage enabled by explicit override")
 	}
 }
 
-func TestIsChatStorageEnabledForDeviceJID_LookupErrorDefaultsEnabled(t *testing.T) {
-	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+func TestIsChatStorageEnabledForDeviceID_LookupErrorFailsClosed(t *testing.T) {
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
 		return nil, errors.New("boom")
 	})
 
-	if !isChatStorageEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
-		t.Fatal("expected chat storage enabled (fail open) when the lookup errors")
+	if isChatStorageEnabledForDeviceID("device-a") {
+		t.Fatal("expected chat storage disabled (fail closed) when the lookup errors")
 	}
 }
 
-func TestIsAutoDownloadMediaEnabledForDeviceJID_NoDeviceIDFollowsGlobal(t *testing.T) {
+func TestIsAutoDownloadMediaEnabledForDeviceID_NoDeviceIDFollowsGlobal(t *testing.T) {
 	original := config.WhatsappAutoDownloadMedia
 	t.Cleanup(func() { config.WhatsappAutoDownloadMedia = original })
 
 	config.WhatsappAutoDownloadMedia = false
-	if isAutoDownloadMediaEnabledForDeviceJID("") {
-		t.Fatal("expected global false to apply when no device JID is known")
+	if isAutoDownloadMediaEnabledForDeviceID("") {
+		t.Fatal("expected global false to apply when no device ID is known")
 	}
 
 	config.WhatsappAutoDownloadMedia = true
-	if !isAutoDownloadMediaEnabledForDeviceJID("") {
-		t.Fatal("expected global true to apply when no device JID is known")
+	if !isAutoDownloadMediaEnabledForDeviceID("") {
+		t.Fatal("expected global true to apply when no device ID is known")
 	}
 }
 
-func TestIsAutoDownloadMediaEnabledForDeviceJID_NoOverrideFollowsGlobal(t *testing.T) {
+func TestIsAutoDownloadMediaEnabledForDeviceID_NoOverrideFollowsGlobal(t *testing.T) {
 	original := config.WhatsappAutoDownloadMedia
 	t.Cleanup(func() { config.WhatsappAutoDownloadMedia = original })
 	config.WhatsappAutoDownloadMedia = false
 
-	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
-		return &chatstorage.DeviceRecord{DeviceID: deviceJID}, nil
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
+		return &chatstorage.DeviceStorageSettings{}, nil
 	})
 
-	if isAutoDownloadMediaEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+	if isAutoDownloadMediaEnabledForDeviceID("device-a") {
 		t.Fatal("expected global default (false) to apply when no override is set")
 	}
 }
 
-func TestIsAutoDownloadMediaEnabledForDeviceJID_OverrideWinsOverGlobal(t *testing.T) {
+func TestIsAutoDownloadMediaEnabledForDeviceID_OverrideWinsOverGlobal(t *testing.T) {
 	original := config.WhatsappAutoDownloadMedia
 	t.Cleanup(func() { config.WhatsappAutoDownloadMedia = original })
 	config.WhatsappAutoDownloadMedia = false
 
 	enabled := true
-	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
-		return &chatstorage.DeviceRecord{DeviceID: deviceJID, AutoDownloadMedia: &enabled}, nil
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
+		return &chatstorage.DeviceStorageSettings{AutoDownloadMedia: &enabled}, nil
 	})
 
-	if !isAutoDownloadMediaEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+	if !isAutoDownloadMediaEnabledForDeviceID("device-a") {
 		t.Fatal("expected the per-device override (true) to win over the global default (false)")
 	}
 }
 
-func TestIsAutoDownloadMediaEnabledForDeviceJID_LookupErrorFollowsGlobal(t *testing.T) {
+func TestIsAutoDownloadMediaEnabledForDeviceID_LookupErrorFailsClosed(t *testing.T) {
 	original := config.WhatsappAutoDownloadMedia
 	t.Cleanup(func() { config.WhatsappAutoDownloadMedia = original })
 	config.WhatsappAutoDownloadMedia = true
 
-	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
 		return nil, errors.New("boom")
 	})
 
-	if !isAutoDownloadMediaEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
-		t.Fatal("expected global default to apply when the lookup errors")
+	if isAutoDownloadMediaEnabledForDeviceID("device-a") {
+		t.Fatal("expected auto-download disabled (fail closed) when the lookup errors, even though the global default is true")
 	}
 }
 
-func TestClientDeviceJID_NilClient(t *testing.T) {
-	if got := clientDeviceJID(nil); got != "" {
-		t.Fatalf("expected empty device JID for nil client, got %q", got)
+// TestIsChatStorageEnabledForClient_SiblingSlotsShareNumberButHonorOwnOverride
+// covers the maintainer's P1: two device slots that are sibling companion sessions
+// for the same WhatsApp account (issue #760) share one bare-number JID but must
+// each be resolved by their own registry ID, not collapsed onto one ambiguous
+// record. Regression for #833.
+func TestIsChatStorageEnabledForClient_SiblingSlotsShareNumberButHonorOwnOverride(t *testing.T) {
+	enabledSlot := true
+	disabledSlot := false
+	settingsByDeviceID := map[string]*chatstorage.DeviceStorageSettings{
+		"slot-a": {ChatStorage: &disabledSlot},
+		"slot-b": {ChatStorage: &enabledSlot},
+	}
+	withDeviceStorageSettingsForTest(t, func(deviceID string) (*chatstorage.DeviceStorageSettings, error) {
+		return settingsByDeviceID[deviceID], nil
+	})
+
+	ctxA := ContextWithDevice(context.Background(), NewDeviceInstance("slot-a", nil, nil))
+	ctxB := ContextWithDevice(context.Background(), NewDeviceInstance("slot-b", nil, nil))
+
+	if isChatStorageEnabledForClient(ctxA, nil) {
+		t.Fatal("expected slot-a to honor its own chat_storage=false override")
+	}
+	if !isChatStorageEnabledForClient(ctxB, nil) {
+		t.Fatal("expected slot-b to honor its own chat_storage=true override, unaffected by slot-a")
 	}
 }

--- a/src/infrastructure/whatsapp/device_storage_settings_test.go
+++ b/src/infrastructure/whatsapp/device_storage_settings_test.go
@@ -1,0 +1,138 @@
+package whatsapp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+)
+
+func withDeviceStorageRecordForTest(t *testing.T, fn func(deviceJID string) (*chatstorage.DeviceRecord, error)) {
+	t.Helper()
+	original := deviceStorageRecordForTest
+	deviceStorageRecordForTest = fn
+	t.Cleanup(func() { deviceStorageRecordForTest = original })
+}
+
+func TestIsChatStorageEnabledForDeviceJID_NoDeviceID(t *testing.T) {
+	if !isChatStorageEnabledForDeviceJID("") {
+		t.Fatal("expected chat storage enabled by default when no device JID is known")
+	}
+}
+
+func TestIsChatStorageEnabledForDeviceJID_DeviceNotFound(t *testing.T) {
+	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+		return nil, nil
+	})
+
+	if !isChatStorageEnabledForDeviceJID("unknown@s.whatsapp.net") {
+		t.Fatal("expected chat storage enabled when the device has no record")
+	}
+}
+
+func TestIsChatStorageEnabledForDeviceJID_NoOverrideDefaultsEnabled(t *testing.T) {
+	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+		return &chatstorage.DeviceRecord{DeviceID: deviceJID}, nil
+	})
+
+	if !isChatStorageEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+		t.Fatal("expected chat storage enabled when no override is set")
+	}
+}
+
+func TestIsChatStorageEnabledForDeviceJID_ExplicitFalseOverride(t *testing.T) {
+	disabled := false
+	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+		return &chatstorage.DeviceRecord{DeviceID: deviceJID, ChatStorage: &disabled}, nil
+	})
+
+	if isChatStorageEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+		t.Fatal("expected chat storage disabled by explicit override")
+	}
+}
+
+func TestIsChatStorageEnabledForDeviceJID_ExplicitTrueOverride(t *testing.T) {
+	enabled := true
+	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+		return &chatstorage.DeviceRecord{DeviceID: deviceJID, ChatStorage: &enabled}, nil
+	})
+
+	if !isChatStorageEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+		t.Fatal("expected chat storage enabled by explicit override")
+	}
+}
+
+func TestIsChatStorageEnabledForDeviceJID_LookupErrorDefaultsEnabled(t *testing.T) {
+	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+		return nil, errors.New("boom")
+	})
+
+	if !isChatStorageEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+		t.Fatal("expected chat storage enabled (fail open) when the lookup errors")
+	}
+}
+
+func TestIsAutoDownloadMediaEnabledForDeviceJID_NoDeviceIDFollowsGlobal(t *testing.T) {
+	original := config.WhatsappAutoDownloadMedia
+	t.Cleanup(func() { config.WhatsappAutoDownloadMedia = original })
+
+	config.WhatsappAutoDownloadMedia = false
+	if isAutoDownloadMediaEnabledForDeviceJID("") {
+		t.Fatal("expected global false to apply when no device JID is known")
+	}
+
+	config.WhatsappAutoDownloadMedia = true
+	if !isAutoDownloadMediaEnabledForDeviceJID("") {
+		t.Fatal("expected global true to apply when no device JID is known")
+	}
+}
+
+func TestIsAutoDownloadMediaEnabledForDeviceJID_NoOverrideFollowsGlobal(t *testing.T) {
+	original := config.WhatsappAutoDownloadMedia
+	t.Cleanup(func() { config.WhatsappAutoDownloadMedia = original })
+	config.WhatsappAutoDownloadMedia = false
+
+	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+		return &chatstorage.DeviceRecord{DeviceID: deviceJID}, nil
+	})
+
+	if isAutoDownloadMediaEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+		t.Fatal("expected global default (false) to apply when no override is set")
+	}
+}
+
+func TestIsAutoDownloadMediaEnabledForDeviceJID_OverrideWinsOverGlobal(t *testing.T) {
+	original := config.WhatsappAutoDownloadMedia
+	t.Cleanup(func() { config.WhatsappAutoDownloadMedia = original })
+	config.WhatsappAutoDownloadMedia = false
+
+	enabled := true
+	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+		return &chatstorage.DeviceRecord{DeviceID: deviceJID, AutoDownloadMedia: &enabled}, nil
+	})
+
+	if !isAutoDownloadMediaEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+		t.Fatal("expected the per-device override (true) to win over the global default (false)")
+	}
+}
+
+func TestIsAutoDownloadMediaEnabledForDeviceJID_LookupErrorFollowsGlobal(t *testing.T) {
+	original := config.WhatsappAutoDownloadMedia
+	t.Cleanup(func() { config.WhatsappAutoDownloadMedia = original })
+	config.WhatsappAutoDownloadMedia = true
+
+	withDeviceStorageRecordForTest(t, func(deviceJID string) (*chatstorage.DeviceRecord, error) {
+		return nil, errors.New("boom")
+	})
+
+	if !isAutoDownloadMediaEnabledForDeviceJID("6289600000000@s.whatsapp.net") {
+		t.Fatal("expected global default to apply when the lookup errors")
+	}
+}
+
+func TestClientDeviceJID_NilClient(t *testing.T) {
+	if got := clientDeviceJID(nil); got != "" {
+		t.Fatalf("expected empty device JID for nil client, got %q", got)
+	}
+}

--- a/src/infrastructure/whatsapp/event_call.go
+++ b/src/infrastructure/whatsapp/event_call.go
@@ -30,7 +30,7 @@ func handleCallOffer(ctx context.Context, evt *events.CallOffer, chatStorageRepo
 		}
 	}
 
-	if chatStorageRepo != nil {
+	if chatStorageRepo != nil && isChatStorageEnabledForClient(client) {
 		if err := chatStorageRepo.CreateIncomingCallRecord(ctx, evt, autoRejected); err != nil {
 			switch {
 			case errors.Is(err, domainChatStorage.ErrMissingDeviceContext),

--- a/src/infrastructure/whatsapp/event_call.go
+++ b/src/infrastructure/whatsapp/event_call.go
@@ -30,7 +30,7 @@ func handleCallOffer(ctx context.Context, evt *events.CallOffer, chatStorageRepo
 		}
 	}
 
-	if chatStorageRepo != nil && isChatStorageEnabledForClient(client) {
+	if chatStorageRepo != nil && isChatStorageEnabledForClient(ctx, client) {
 		if err := chatStorageRepo.CreateIncomingCallRecord(ctx, evt, autoRejected); err != nil {
 			switch {
 			case errors.Is(err, domainChatStorage.ErrMissingDeviceContext),

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -348,7 +348,7 @@ func buildOptionalFields(ctx context.Context, client *whatsmeow.Client, evt *eve
 
 func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.Message, payload map[string]any) error {
 	if audioMedia := msg.GetAudioMessage(); audioMedia != nil {
-		if isAutoDownloadMediaEnabledForClient(client) {
+		if isAutoDownloadMediaEnabledForClient(ctx, client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, audioMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -366,7 +366,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if documentMedia := msg.GetDocumentMessage(); documentMedia != nil {
-		if isAutoDownloadMediaEnabledForClient(client) {
+		if isAutoDownloadMediaEnabledForClient(ctx, client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, documentMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -385,7 +385,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if imageMedia := msg.GetImageMessage(); imageMedia != nil {
-		if isAutoDownloadMediaEnabledForClient(client) {
+		if isAutoDownloadMediaEnabledForClient(ctx, client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, imageMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -404,7 +404,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if stickerMedia := msg.GetStickerMessage(); stickerMedia != nil {
-		if isAutoDownloadMediaEnabledForClient(client) {
+		if isAutoDownloadMediaEnabledForClient(ctx, client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, stickerMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -422,7 +422,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if videoMedia := msg.GetVideoMessage(); videoMedia != nil {
-		if isAutoDownloadMediaEnabledForClient(client) {
+		if isAutoDownloadMediaEnabledForClient(ctx, client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, videoMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -441,7 +441,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if ptvMedia := msg.GetPtvMessage(); ptvMedia != nil {
-		if isAutoDownloadMediaEnabledForClient(client) {
+		if isAutoDownloadMediaEnabledForClient(ctx, client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, ptvMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -487,7 +487,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 // header.GetLocationMessage()/GetProductMessage()/GetJPEGThumbnail() are not
 // handled: no existing payload field/attachment path covers them here.
 func collectInteractiveMedia(ctx context.Context, client *whatsmeow.Client, im *waE2E.InteractiveMessage) []string {
-	if im == nil || !isAutoDownloadMediaEnabledForClient(client) {
+	if im == nil || !isAutoDownloadMediaEnabledForClient(ctx, client) {
 		return nil
 	}
 

--- a/src/infrastructure/whatsapp/event_message.go
+++ b/src/infrastructure/whatsapp/event_message.go
@@ -348,7 +348,7 @@ func buildOptionalFields(ctx context.Context, client *whatsmeow.Client, evt *eve
 
 func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.Message, payload map[string]any) error {
 	if audioMedia := msg.GetAudioMessage(); audioMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
+		if isAutoDownloadMediaEnabledForClient(client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, audioMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -366,7 +366,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if documentMedia := msg.GetDocumentMessage(); documentMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
+		if isAutoDownloadMediaEnabledForClient(client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, documentMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -385,7 +385,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if imageMedia := msg.GetImageMessage(); imageMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
+		if isAutoDownloadMediaEnabledForClient(client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, imageMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -404,7 +404,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if stickerMedia := msg.GetStickerMessage(); stickerMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
+		if isAutoDownloadMediaEnabledForClient(client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, stickerMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -422,7 +422,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if videoMedia := msg.GetVideoMessage(); videoMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
+		if isAutoDownloadMediaEnabledForClient(client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, videoMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -441,7 +441,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 	}
 
 	if ptvMedia := msg.GetPtvMessage(); ptvMedia != nil {
-		if config.WhatsappAutoDownloadMedia {
+		if isAutoDownloadMediaEnabledForClient(client) {
 			extracted, err := utils.ExtractMedia(ctx, client, config.PathMedia, ptvMedia)
 			if err != nil {
 				// Media expired/unavailable: skip the attachment but keep
@@ -487,7 +487,7 @@ func buildMediaFields(ctx context.Context, client *whatsmeow.Client, msg *waE2E.
 // header.GetLocationMessage()/GetProductMessage()/GetJPEGThumbnail() are not
 // handled: no existing payload field/attachment path covers them here.
 func collectInteractiveMedia(ctx context.Context, client *whatsmeow.Client, im *waE2E.InteractiveMessage) []string {
-	if im == nil || !config.WhatsappAutoDownloadMedia {
+	if im == nil || !isAutoDownloadMediaEnabledForClient(client) {
 		return nil
 	}
 

--- a/src/infrastructure/whatsapp/event_message_handler.go
+++ b/src/infrastructure/whatsapp/event_message_handler.go
@@ -34,18 +34,24 @@ func handleMessage(ctx context.Context, evt *events.Message, chatStorageRepo dom
 	evt = materializeSecretEditMessage(ctx, evt, client)
 	pollPayload := preparePollWebhookPayload(ctx, client, chatStorageRepo, evt)
 
+	chatStorageEnabled := isChatStorageEnabledForClient(client)
+
 	if isReactionMessage(evt) {
-		if err := chatStorageRepo.CreateReaction(ctx, evt); err != nil {
-			log.Errorf("Failed to store incoming reaction %s: %v", evt.Info.ID, err)
+		if chatStorageEnabled {
+			if err := chatStorageRepo.CreateReaction(ctx, evt); err != nil {
+				log.Errorf("Failed to store incoming reaction %s: %v", evt.Info.ID, err)
+			}
 		}
 
 		handleWebhookForward(ctx, evt, client, pollPayload)
 		return
 	}
 
-	if err := chatStorageRepo.CreateMessage(ctx, evt); err != nil {
-		// Log storage errors to avoid silent failures that could lead to data loss
-		log.Errorf("Failed to store incoming message %s: %v", evt.Info.ID, err)
+	if chatStorageEnabled {
+		if err := chatStorageRepo.CreateMessage(ctx, evt); err != nil {
+			// Log storage errors to avoid silent failures that could lead to data loss
+			log.Errorf("Failed to store incoming message %s: %v", evt.Info.ID, err)
+		}
 	}
 
 	// Handle image message if present
@@ -79,7 +85,7 @@ func buildMessageMetaParts(evt *events.Message) []string {
 }
 
 func handleImageMessage(ctx context.Context, evt *events.Message, client *whatsmeow.Client) {
-	if !config.WhatsappAutoDownloadMedia {
+	if !isAutoDownloadMediaEnabledForClient(client) {
 		return
 	}
 	if client == nil {

--- a/src/infrastructure/whatsapp/event_message_handler.go
+++ b/src/infrastructure/whatsapp/event_message_handler.go
@@ -32,9 +32,13 @@ func handleMessage(ctx context.Context, evt *events.Message, chatStorageRepo dom
 	// edit-handling paths unchanged. No-op when the envelope is absent or when
 	// decryption fails.
 	evt = materializeSecretEditMessage(ctx, evt, client)
-	pollPayload := preparePollWebhookPayload(ctx, client, chatStorageRepo, evt)
 
-	chatStorageEnabled := isChatStorageEnabledForClient(client)
+	// Resolve the chat_storage policy before preparing the poll payload: a poll
+	// creation/edit/add-option must not persist poll data when the device has
+	// chat_storage=false, the same rule handleMessage applies below to messages
+	// and reactions.
+	chatStorageEnabled := isChatStorageEnabledForClient(ctx, client)
+	pollPayload := preparePollWebhookPayload(ctx, client, chatStorageRepo, evt, chatStorageEnabled)
 
 	if isReactionMessage(evt) {
 		if chatStorageEnabled {
@@ -85,7 +89,7 @@ func buildMessageMetaParts(evt *events.Message) []string {
 }
 
 func handleImageMessage(ctx context.Context, evt *events.Message, client *whatsmeow.Client) {
-	if !isAutoDownloadMediaEnabledForClient(client) {
+	if !isAutoDownloadMediaEnabledForClient(ctx, client) {
 		return
 	}
 	if client == nil {

--- a/src/infrastructure/whatsapp/event_message_handler.go
+++ b/src/infrastructure/whatsapp/event_message_handler.go
@@ -16,6 +16,8 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
+var extractIncomingMedia = utils.ExtractMedia
+
 func handleMessage(ctx context.Context, evt *events.Message, chatStorageRepo domainChatStorage.IChatStorageRepository, client *whatsmeow.Client) {
 	// Log message metadata
 	metaParts := buildMessageMetaParts(evt)
@@ -96,7 +98,7 @@ func handleImageMessage(ctx context.Context, evt *events.Message, client *whatsm
 		return
 	}
 	if img := evt.Message.GetImageMessage(); img != nil {
-		if extracted, err := utils.ExtractMedia(ctx, client, config.PathStorages, img); err != nil {
+		if extracted, err := extractIncomingMedia(ctx, client, config.PathStorages, img); err != nil {
 			log.Errorf("Failed to download image: %v", err)
 		} else {
 			log.Infof("Image downloaded to %s", extracted.MediaPath)

--- a/src/infrastructure/whatsapp/event_message_handler_test.go
+++ b/src/infrastructure/whatsapp/event_message_handler_test.go
@@ -2,18 +2,104 @@ package whatsapp
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
 	domainChatStorage "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/pkg/utils"
+	"go.mau.fi/whatsmeow"
 	"go.mau.fi/whatsmeow/proto/waCommon"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
 )
+
+func TestHandleMessageSettingsLookupErrorSkipsStorageAndMediaSideEffects(t *testing.T) {
+	originalWebhookURLs := config.WhatsappWebhook
+	originalWebhookEvents := config.WhatsappWebhookEvents
+	originalAutoReply := config.WhatsappAutoReplyMessage
+	originalAutoMarkRead := config.WhatsappAutoMarkRead
+	originalAutoDownloadMedia := config.WhatsappAutoDownloadMedia
+	originalExtractMedia := extractIncomingMedia
+	originalLog := log
+	t.Cleanup(func() {
+		config.WhatsappWebhook = originalWebhookURLs
+		config.WhatsappWebhookEvents = originalWebhookEvents
+		config.WhatsappAutoReplyMessage = originalAutoReply
+		config.WhatsappAutoMarkRead = originalAutoMarkRead
+		config.WhatsappAutoDownloadMedia = originalAutoDownloadMedia
+		extractIncomingMedia = originalExtractMedia
+		log = originalLog
+	})
+
+	log = waLog.Noop
+	config.WhatsappWebhook = nil
+	config.WhatsappWebhookEvents = nil
+	config.WhatsappAutoReplyMessage = ""
+	config.WhatsappAutoMarkRead = false
+	config.WhatsappAutoDownloadMedia = true
+
+	const deviceID = "device-settings-error"
+	lookupCount := 0
+	withDeviceStorageSettingsForTest(t, func(gotDeviceID string) (*domainChatStorage.DeviceStorageSettings, error) {
+		lookupCount++
+		if gotDeviceID != deviceID {
+			t.Fatalf("settings lookup used device ID %q, want %q", gotDeviceID, deviceID)
+		}
+		return nil, errors.New("settings unavailable")
+	})
+
+	extractCalls := 0
+	extractIncomingMedia = func(context.Context, *whatsmeow.Client, string, whatsmeow.DownloadableMessage) (utils.ExtractedMedia, error) {
+		extractCalls++
+		return utils.ExtractedMedia{}, nil
+	}
+
+	statusChat := types.NewJID("status", types.BroadcastServer)
+	tests := []struct {
+		name string
+		evt  *events.Message
+	}{
+		{name: "message", evt: textEventForTest("message-settings-error", statusChat)},
+		{name: "reaction", evt: reactionEventForTest("reaction-settings-error", "target-message", "thumbs-up")},
+		{name: "image media", evt: &events.Message{
+			Info: types.MessageInfo{
+				MessageSource: types.MessageSource{Chat: statusChat},
+				ID:            "image-settings-error",
+				Timestamp:     time.Date(2026, time.September, 13, 10, 0, 0, 0, time.UTC),
+			},
+			Message: &waE2E.Message{ImageMessage: &waE2E.ImageMessage{}},
+		}},
+	}
+
+	ctx := ContextWithDevice(context.Background(), NewDeviceInstance(deviceID, nil, nil))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.evt.Info.Chat = statusChat
+			repo := &messageHandlerRepoSpy{}
+			beforeExtractCalls := extractCalls
+
+			handleMessage(ctx, tt.evt, repo, &whatsmeow.Client{})
+
+			if got := repo.createMessageCount(); got != 0 {
+				t.Fatalf("CreateMessage called %d times after settings lookup error", got)
+			}
+			if got := repo.createReactionCount(); got != 0 {
+				t.Fatalf("CreateReaction called %d times after settings lookup error", got)
+			}
+			if extractCalls != beforeExtractCalls {
+				t.Fatalf("ExtractMedia called after settings lookup error")
+			}
+		})
+	}
+	if lookupCount == 0 {
+		t.Fatal("expected device settings lookup")
+	}
+}
 
 func TestHandleMessageReactionStoresReactionAndForwardsWebhook(t *testing.T) {
 	originalWebhookURLs := config.WhatsappWebhook

--- a/src/infrastructure/whatsapp/history_sync.go
+++ b/src/infrastructure/whatsapp/history_sync.go
@@ -49,8 +49,10 @@ func handleHistorySync(ctx context.Context, evt *events.HistorySync, chatStorage
 
 	log.Infof("Wrote history sync to %s", fileName)
 
-	// Process history sync data to database
-	if chatStorageRepo != nil {
+	// Process history sync data to database. Skipped for devices with a chat_storage=false
+	// override, same as live messages in handleMessage — a device kept out of chat storage
+	// should not backfill history into it either.
+	if chatStorageRepo != nil && isChatStorageEnabledForClient(client) {
 		if err := processHistorySync(ctx, evt.Data, chatStorageRepo, client); err != nil {
 			log.Errorf("Failed to process history sync to database: %v", err)
 		}

--- a/src/infrastructure/whatsapp/history_sync.go
+++ b/src/infrastructure/whatsapp/history_sync.go
@@ -52,7 +52,7 @@ func handleHistorySync(ctx context.Context, evt *events.HistorySync, chatStorage
 	// Process history sync data to database. Skipped for devices with a chat_storage=false
 	// override, same as live messages in handleMessage — a device kept out of chat storage
 	// should not backfill history into it either.
-	if chatStorageRepo != nil && isChatStorageEnabledForClient(client) {
+	if chatStorageRepo != nil && isChatStorageEnabledForClient(ctx, client) {
 		if err := processHistorySync(ctx, evt.Data, chatStorageRepo, client); err != nil {
 			log.Errorf("Failed to process history sync to database: %v", err)
 		}

--- a/src/infrastructure/whatsapp/poll_event.go
+++ b/src/infrastructure/whatsapp/poll_event.go
@@ -208,7 +208,7 @@ func resolvePollSelections(definition *domainChatStorage.PollDefinition, selecte
 	return names, hashes, pollResolutionResolved
 }
 
-func preparePollWebhookPayload(ctx context.Context, client *whatsmeow.Client, store pollDefinitionStore, evt *events.Message) *webhookPollPayload {
+func preparePollWebhookPayload(ctx context.Context, client *whatsmeow.Client, store pollDefinitionStore, evt *events.Message, chatStorageEnabled bool) *webhookPollPayload {
 	if evt == nil || evt.Message == nil {
 		return nil
 	}
@@ -228,7 +228,7 @@ func preparePollWebhookPayload(ctx context.Context, client *whatsmeow.Client, st
 
 	if poll, version := utils.ExtractPollCreationMessage(msg); poll != nil {
 		definition := pollDefinitionFromCreation(deviceID, chatJID, evt.Info.ID, version, poll, evt.Info.Timestamp)
-		if store != nil && definition.DeviceID != "" && definition.ChatJID != "" {
+		if chatStorageEnabled && store != nil && definition.DeviceID != "" && definition.ChatJID != "" {
 			if err := store.UpsertPollDefinition(definition); err != nil {
 				logrus.Warnf("Failed to persist poll definition %s: %v", evt.Info.ID, err)
 			}
@@ -265,7 +265,7 @@ func preparePollWebhookPayload(ctx context.Context, client *whatsmeow.Client, st
 		if definition := loadPollDefinition(store, deviceID, add.GetPollCreationMessageKey().GetID(), addChatIDs...); definition != nil {
 			addChatID = definition.ChatJID
 		}
-		return preparePollAddOptionPayload(store, deviceID, addChatID, add)
+		return preparePollAddOptionPayload(store, deviceID, addChatID, add, chatStorageEnabled)
 	}
 
 	secret := msg.GetSecretEncryptedMessage()
@@ -299,7 +299,7 @@ func preparePollWebhookPayload(ctx context.Context, client *whatsmeow.Client, st
 			if definition := loadPollDefinition(store, deviceID, pollID, updateChatIDs...); definition != nil {
 				addChatID = definition.ChatJID
 			}
-			return preparePollAddOptionPayload(store, deviceID, addChatID, add, pollID)
+			return preparePollAddOptionPayload(store, deviceID, addChatID, add, chatStorageEnabled, pollID)
 		}
 		return degraded()
 	}
@@ -311,7 +311,7 @@ func preparePollWebhookPayload(ctx context.Context, client *whatsmeow.Client, st
 		chatJID = existing.ChatJID
 	}
 	definition := pollDefinitionFromCreation(deviceID, chatJID, pollID, version, poll, evt.Info.Timestamp)
-	if store != nil {
+	if chatStorageEnabled && store != nil {
 		if err := store.UpsertPollDefinition(definition); err != nil {
 			logrus.Warnf("Failed to persist edited poll definition %s: %v", pollID, err)
 		}
@@ -319,7 +319,7 @@ func preparePollWebhookPayload(ctx context.Context, client *whatsmeow.Client, st
 	return webhookPollFromDefinition("edit", definition)
 }
 
-func preparePollAddOptionPayload(store pollDefinitionStore, deviceID, chatJID string, add *waE2E.PollAddOptionMessage, fallbackPollID ...string) *webhookPollPayload {
+func preparePollAddOptionPayload(store pollDefinitionStore, deviceID, chatJID string, add *waE2E.PollAddOptionMessage, chatStorageEnabled bool, fallbackPollID ...string) *webhookPollPayload {
 	if add == nil {
 		return nil
 	}
@@ -329,7 +329,7 @@ func preparePollAddOptionPayload(store pollDefinitionStore, deviceID, chatJID st
 	}
 	option := domainChatStorage.PollOption{Name: add.GetAddOption().GetOptionName()}
 	option.Hash = pollOptionHash(option.Name)
-	if store != nil && option.Name != "" {
+	if chatStorageEnabled && store != nil && option.Name != "" {
 		if err := store.AppendPollOption(deviceID, chatJID, pollID, option); err != nil {
 			logrus.Warnf("Failed to append option to poll %s: %v", pollID, err)
 		}

--- a/src/infrastructure/whatsapp/poll_event_test.go
+++ b/src/infrastructure/whatsapp/poll_event_test.go
@@ -101,7 +101,7 @@ func TestPreparePollWebhookPayloadStoresCreation(t *testing.T) {
 		}},
 	}
 
-	payload := preparePollWebhookPayload(ctx, nil, store, evt)
+	payload := preparePollWebhookPayload(ctx, nil, store, evt, true)
 	if payload == nil || payload.Type != "creation" || payload.PollID != "POLL-1" || payload.Question != "Lunch?" {
 		t.Fatalf("unexpected payload: %+v", payload)
 	}
@@ -112,6 +112,129 @@ func TestPreparePollWebhookPayloadStoresCreation(t *testing.T) {
 	if err != nil || stored == nil || stored.Version != "v3" || len(stored.Options) != 2 {
 		t.Fatalf("stored definition=%+v err=%v", stored, err)
 	}
+}
+
+// TestPreparePollWebhookPayloadCreationSkipsPersistenceWhenChatStorageDisabled
+// covers the maintainer's P1: a poll creation must not persist the poll
+// definition when the device has chat_storage=false, the same rule handleMessage
+// applies to messages and reactions. Regression for #833.
+func TestPreparePollWebhookPayloadCreationSkipsPersistenceWhenChatStorageDisabled(t *testing.T) {
+	store := newMemoryPollStore()
+	ctx := ContextWithDevice(context.Background(), NewDeviceInstance("device-a", nil, nil))
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: types.NewJID("120363000000", types.GroupServer)},
+			ID:            "POLL-DISABLED-1",
+		},
+		Message: &waE2E.Message{PollCreationMessageV3: &waE2E.PollCreationMessage{
+			Name:                   proto.String("Lunch?"),
+			SelectableOptionsCount: proto.Uint32(1),
+			Options:                []*waE2E.PollCreationMessage_Option{{OptionName: proto.String("Pizza")}},
+		}},
+	}
+
+	payload := preparePollWebhookPayload(ctx, nil, store, evt, false)
+	if payload == nil || payload.Type != "creation" || payload.Question != "Lunch?" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	stored, err := store.GetPollDefinition("device-a", evt.Info.Chat.String(), "POLL-DISABLED-1")
+	if err != nil {
+		t.Fatalf("GetPollDefinition: %v", err)
+	}
+	if stored != nil {
+		t.Fatalf("expected poll definition not persisted when chat storage is disabled, got %+v", stored)
+	}
+}
+
+// TestPreparePollWebhookPayloadAddOptionSkipsPersistenceWhenChatStorageDisabled
+// covers the maintainer's P1 for add-option events. Regression for #833.
+func TestPreparePollWebhookPayloadAddOptionSkipsPersistenceWhenChatStorageDisabled(t *testing.T) {
+	store := newMemoryPollStore()
+	deviceID := "device-a"
+	chat := types.NewJID("120363000000", types.GroupServer)
+	ctx := ContextWithDevice(context.Background(), NewDeviceInstance(deviceID, nil, nil))
+	if err := store.UpsertPollDefinition(&domainChatStorage.PollDefinition{
+		DeviceID: deviceID, ChatJID: chat.String(), PollMessageID: "POLL-ADD-DISABLED-1", Question: "Lunch?",
+		Options: []domainChatStorage.PollOption{{Name: "Pizza", Hash: pollOptionHash("Pizza")}},
+	}); err != nil {
+		t.Fatalf("UpsertPollDefinition: %v", err)
+	}
+	evt := &events.Message{
+		Info: types.MessageInfo{MessageSource: types.MessageSource{Chat: chat}, ID: "ADD-DISABLED-1"},
+		Message: &waE2E.Message{PollAddOptionMessage: &waE2E.PollAddOptionMessage{
+			PollCreationMessageKey: &waCommon.MessageKey{ID: proto.String("POLL-ADD-DISABLED-1")},
+			AddOption:              &waE2E.PollCreationMessage_Option{OptionName: proto.String("Sushi")},
+		}},
+	}
+
+	payload := preparePollWebhookPayload(ctx, nil, store, evt, false)
+	if payload == nil || payload.Type != "add_option" {
+		t.Fatalf("unexpected add-option payload: %+v", payload)
+	}
+	definition, err := store.GetPollDefinition(deviceID, chat.String(), "POLL-ADD-DISABLED-1")
+	if err != nil || definition == nil {
+		t.Fatalf("definition=%+v err=%v", definition, err)
+	}
+	if len(definition.Options) != 1 {
+		t.Fatalf("expected the option not appended when chat storage is disabled, got %+v", definition.Options)
+	}
+}
+
+// TestPreparePollWebhookPayloadEditSkipsPersistenceWhenChatStorageDisabled covers
+// the maintainer's P1 for encrypted poll-edit events: a successfully decrypted
+// edit must still build the webhook payload but must not overwrite the stored
+// poll definition when the device has chat_storage=false. Regression for #833.
+func TestPreparePollWebhookPayloadEditSkipsPersistenceWhenChatStorageDisabled(t *testing.T) {
+	ctx := context.Background()
+	voter := types.NewJID("628222", types.DefaultUserServer)
+	client := newPollCryptoClient(t, "poll-event-edit-disabled-test", voter)
+	chat := types.NewJID("120363000000", types.GroupServer)
+	pollID := "POLL-EDIT-DISABLED-1"
+	secret := bytes.Repeat([]byte{0x55}, 32)
+	require.NoError(t, client.Store.MsgSecrets.PutMessageSecret(ctx, chat, voter, pollID, secret))
+
+	store := newMemoryPollStore()
+	require.NoError(t, store.UpsertPollDefinition(&domainChatStorage.PollDefinition{
+		DeviceID: voter.String(), ChatJID: chat.String(), PollMessageID: pollID, Question: "Old question",
+		Options: []domainChatStorage.PollOption{{Name: "Pizza", Hash: pollOptionHash("Pizza")}},
+	}))
+
+	// Encrypt a real poll-creation edit, using the same "Poll Edit" secret
+	// derivation whatsmeow applies to POLL_EDIT.
+	plaintext, err := proto.Marshal(&waE2E.Message{PollCreationMessageV3: &waE2E.PollCreationMessage{
+		Name:                   proto.String("New question"),
+		SelectableOptionsCount: proto.Uint32(1),
+		Options: []*waE2E.PollCreationMessage_Option{
+			{OptionName: proto.String("Pizza")},
+			{OptionName: proto.String("Sushi")},
+		},
+	}})
+	require.NoError(t, err)
+	useCaseSecret := pollID + voter.ToNonAD().String() + voter.ToNonAD().String() + "Poll Edit"
+	secretKey := hkdfutil.SHA256(secret, nil, []byte(useCaseSecret), 32)
+	iv := bytes.Repeat([]byte{0x22}, 12)
+	ciphertext, err := gcmutil.Encrypt(secretKey, iv, plaintext, nil)
+	require.NoError(t, err)
+
+	payload := preparePollWebhookPayload(ctx, client, store, &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: voter, IsGroup: true, IsFromMe: true},
+			ID:            "EDIT-DISABLED-1",
+		},
+		Message: &waE2E.Message{SecretEncryptedMessage: &waE2E.SecretEncryptedMessage{
+			SecretEncType:    waE2E.SecretEncryptedMessage_POLL_EDIT.Enum(),
+			TargetMessageKey: &waCommon.MessageKey{RemoteJID: proto.String(chat.String()), FromMe: proto.Bool(true), ID: proto.String(pollID)},
+			EncIV:            iv,
+			EncPayload:       ciphertext,
+		}},
+	}, false)
+	require.NotNil(t, payload)
+	assert.Equal(t, "edit", payload.Type)
+
+	stored, err := store.GetPollDefinition(voter.String(), chat.String(), pollID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "Old question", stored.Question, "edit must not persist when chat storage is disabled")
 }
 
 func TestResolvePollSelectionsStatuses(t *testing.T) {
@@ -208,7 +331,7 @@ func TestPreparePollWebhookPayloadDecryptsRealVote(t *testing.T) {
 			ID:            "VOTE-1",
 		},
 		Message: voteMessage,
-	})
+	}, true)
 	if payload == nil || payload.ResolutionStatus != "resolved" || payload.SelectedOptions == nil || len(*payload.SelectedOptions) != 1 || (*payload.SelectedOptions)[0] != "Sushi" {
 		t.Fatalf("unexpected decrypted payload: %+v", payload)
 	}
@@ -238,7 +361,7 @@ func TestPreparePollWebhookPayloadDecryptsRealVote(t *testing.T) {
 			ID:            "VOTE-FAILED-1",
 		},
 		Message: voteMessage,
-	})
+	}, true)
 	if failed == nil || failed.ResolutionStatus != pollResolutionDecryptFailed || failed.Question != "Lunch?" || failed.SelectedOptions != nil || failed.SelectedOptionHashes != nil {
 		t.Fatalf("unexpected authentication-failure payload: %+v", failed)
 	}
@@ -299,7 +422,7 @@ func TestPreparePollWebhookPayloadDecryptsVoteAfterHandlerContextCanceled(t *tes
 			ID:            "VOTE-CANCELED-CTX-1",
 		},
 		Message: voteMessage,
-	})
+	}, true)
 	require.NotNil(t, payload)
 	assert.Equal(t, pollResolutionResolved, payload.ResolutionStatus)
 	require.NotNil(t, payload.SelectedOptions)
@@ -342,7 +465,7 @@ func TestPreparePollWebhookPayloadDegradesAddOptionWithoutInnerMessage(t *testin
 			EncIV:            iv,
 			EncPayload:       ciphertext,
 		}},
-	})
+	}, true)
 	require.NotNil(t, payload)
 	assert.Equal(t, "add_option", payload.Type)
 	assert.Equal(t, pollID, payload.PollID)
@@ -400,7 +523,7 @@ func TestPreparePollWebhookPayloadDecryptsLIDGroupVote(t *testing.T) {
 			ID:            "VOTE-LID-1",
 		},
 		Message: voteMessage,
-	})
+	}, true)
 	if payload == nil || payload.ResolutionStatus != pollResolutionResolved || payload.SelectedOptions == nil || len(*payload.SelectedOptions) != 1 || (*payload.SelectedOptions)[0] != "Yes" {
 		t.Fatalf("unexpected LID payload: %+v", payload)
 	}
@@ -454,7 +577,7 @@ func TestPreparePollWebhookPayloadFindsDefinitionStoredBeforeLIDMapping(t *testi
 			ID: "VOTE-LATE-LID-1",
 		},
 		Message: voteMessage,
-	})
+	}, true)
 	require.NotNil(t, payload)
 	assert.Equal(t, pollResolutionResolved, payload.ResolutionStatus)
 	require.NotNil(t, payload.SelectedOptions)
@@ -508,7 +631,7 @@ func TestPreparePollWebhookPayloadFindsPNDefinitionForUnmappedLIDVote(t *testing
 			ID: "VOTE-UNMAPPED-LID-1",
 		},
 		Message: voteMessage,
-	})
+	}, true)
 	require.NotNil(t, payload)
 	assert.Equal(t, pollResolutionResolved, payload.ResolutionStatus)
 	require.NotNil(t, payload.SelectedOptions)
@@ -535,7 +658,7 @@ func TestPreparePollWebhookPayloadAppliesAddOptionIdempotently(t *testing.T) {
 	}
 
 	for range 2 {
-		payload := preparePollWebhookPayload(ctx, nil, store, evt)
+		payload := preparePollWebhookPayload(ctx, nil, store, evt, true)
 		if payload == nil || payload.Type != "add_option" || payload.AddedOption == nil || payload.AddedOption.Name != "Sushi" {
 			t.Fatalf("unexpected add-option payload: %+v", payload)
 		}
@@ -562,7 +685,7 @@ func TestPreparePollWebhookPayloadDegradesEncryptedPollUpdateWithoutClient(t *te
 			SecretEncType:    waE2E.SecretEncryptedMessage_POLL_EDIT.Enum(),
 			TargetMessageKey: &waCommon.MessageKey{ID: proto.String("POLL-EDIT-1")},
 		}},
-	})
+	}, true)
 	if payload == nil || payload.Type != "edit" || payload.PollID != "POLL-EDIT-1" || payload.Question != "Old question" || payload.ResolutionStatus != pollResolutionDecryptFailed {
 		t.Fatalf("unexpected degraded payload: %+v", payload)
 	}
@@ -601,7 +724,7 @@ func TestPreparePollAddOptionPayloadUsesEncryptedEnvelopePollID(t *testing.T) {
 	}
 	payload := preparePollAddOptionPayload(store, deviceID, chatJID, &waE2E.PollAddOptionMessage{
 		AddOption: &waE2E.PollCreationMessage_Option{OptionName: proto.String("New")},
-	}, "POLL-FALLBACK-1")
+	}, true, "POLL-FALLBACK-1")
 	if payload == nil || payload.PollID != "POLL-FALLBACK-1" || payload.Question != "Q" {
 		t.Fatalf("unexpected payload: %+v", payload)
 	}

--- a/src/ui/rest/device.go
+++ b/src/ui/rest/device.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/aldinokemal/go-whatsapp-web-multidevice/config"
@@ -30,6 +31,8 @@ func InitRestDevice(app fiber.Router, service device.IDeviceUsecase) Device {
 	app.Get("/devices/:device_id/status", rest.Status)
 	app.Patch("/devices/:device_id/webhook", rest.UpdateDeviceWebhook)
 	app.Get("/devices/:device_id/webhook", rest.GetDeviceWebhook)
+	app.Patch("/devices/:device_id/settings", rest.UpdateDeviceStorageSettings)
+	app.Get("/devices/:device_id/settings", rest.GetDeviceStorageSettings)
 
 	return rest
 }
@@ -291,4 +294,110 @@ func (handler *Device) GetDeviceWebhook(c fiber.Ctx) error {
 			}(),
 		},
 	})
+}
+
+// UpdateDeviceStorageSettings handles PATCH /devices/:device_id/settings.
+//
+// The body is parsed as a raw JSON object (rather than a struct of *bool fields)
+// so a field that is absent (leave the stored override untouched) can be told
+// apart from a field explicitly sent as null (clear the override, follow the
+// instance default): a struct field of type *bool decodes to nil in both cases.
+func (handler *Device) UpdateDeviceStorageSettings(c fiber.Ctx) error {
+	deviceID := c.Params("device_id")
+
+	var raw map[string]json.RawMessage
+	if err := c.Bind().Body(&raw); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(utils.ResponseData{
+			Status:  400,
+			Code:    "BAD_REQUEST",
+			Message: "Invalid request body",
+			Results: nil,
+		})
+	}
+
+	var patch chatstorage.DeviceStoragePatch
+
+	if rawValue, ok := raw["chat_storage"]; ok {
+		var value *bool
+		if err := json.Unmarshal(rawValue, &value); err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(utils.ResponseData{
+				Status:  400,
+				Code:    "BAD_REQUEST",
+				Message: "chat_storage must be a boolean or null",
+				Results: nil,
+			})
+		}
+		patch.HasChatStorage = true
+		patch.ChatStorage = value
+	}
+
+	if rawValue, ok := raw["auto_download_media"]; ok {
+		var value *bool
+		if err := json.Unmarshal(rawValue, &value); err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(utils.ResponseData{
+				Status:  400,
+				Code:    "BAD_REQUEST",
+				Message: "auto_download_media must be a boolean or null",
+				Results: nil,
+			})
+		}
+		patch.HasAutoDownloadMedia = true
+		patch.AutoDownloadMedia = value
+	}
+
+	if !patch.HasChatStorage && !patch.HasAutoDownloadMedia {
+		return c.Status(fiber.StatusBadRequest).JSON(utils.ResponseData{
+			Status:  400,
+			Code:    "BAD_REQUEST",
+			Message: "at least one of chat_storage or auto_download_media is required",
+			Results: nil,
+		})
+	}
+
+	err := handler.Service.SetDeviceStorageSettings(c.Context(), deviceID, patch)
+	utils.PanicIfNeeded(err)
+
+	settings, err := handler.Service.GetDeviceStorageSettings(c.Context(), deviceID)
+	utils.PanicIfNeeded(err)
+
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: "Device storage settings updated",
+		Results: deviceStorageSettingsResult(deviceID, settings),
+	})
+}
+
+// GetDeviceStorageSettings handles GET /devices/:device_id/settings.
+func (handler *Device) GetDeviceStorageSettings(c fiber.Ctx) error {
+	deviceID := c.Params("device_id")
+	settings, err := handler.Service.GetDeviceStorageSettings(c.Context(), deviceID)
+	utils.PanicIfNeeded(err)
+
+	return c.JSON(utils.ResponseData{
+		Status:  200,
+		Code:    "SUCCESS",
+		Message: "Device storage settings retrieved",
+		Results: deviceStorageSettingsResult(deviceID, settings),
+	})
+}
+
+// deviceStorageSettingsResult builds the JSON-serializable response body shared
+// by GET and PATCH /devices/:device_id/settings. A nil field means the device
+// has no override and follows the instance-wide default.
+func deviceStorageSettingsResult(deviceID string, settings *chatstorage.DeviceStorageSettings) map[string]any {
+	var chatStorage, autoDownloadMedia any
+	if settings != nil {
+		if settings.ChatStorage != nil {
+			chatStorage = *settings.ChatStorage
+		}
+		if settings.AutoDownloadMedia != nil {
+			autoDownloadMedia = *settings.AutoDownloadMedia
+		}
+	}
+	return map[string]any{
+		"device_id":           deviceID,
+		"chat_storage":        chatStorage,
+		"auto_download_media": autoDownloadMedia,
+	}
 }

--- a/src/ui/rest/device_storage_settings_test.go
+++ b/src/ui/rest/device_storage_settings_test.go
@@ -1,0 +1,195 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/domains/chatstorage"
+	domainDevice "github.com/aldinokemal/go-whatsapp-web-multidevice/domains/device"
+	"github.com/aldinokemal/go-whatsapp-web-multidevice/ui/rest/middleware"
+	"github.com/gofiber/fiber/v3"
+)
+
+// storageSettingsStubUsecase implements domainDevice.IDeviceUsecase, recording the
+// patch received by SetDeviceStorageSettings and serving a fixed GetDeviceStorageSettings
+// result so PATCH's read-after-write response can be asserted too.
+type storageSettingsStubUsecase struct {
+	domainDevice.IDeviceUsecase
+	receivedPatch chatstorage.DeviceStoragePatch
+	settings      *chatstorage.DeviceStorageSettings
+	getErr        error
+}
+
+func (s *storageSettingsStubUsecase) SetDeviceStorageSettings(_ context.Context, _ string, patch chatstorage.DeviceStoragePatch) error {
+	s.receivedPatch = patch
+	return nil
+}
+
+func (s *storageSettingsStubUsecase) GetDeviceStorageSettings(_ context.Context, _ string) (*chatstorage.DeviceStorageSettings, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.settings == nil {
+		return &chatstorage.DeviceStorageSettings{}, nil
+	}
+	return s.settings, nil
+}
+
+func newDeviceStorageSettingsTestApp(stub *storageSettingsStubUsecase) *fiber.App {
+	app := fiber.New()
+	app.Use(middleware.Recovery())
+	controller := Device{Service: stub}
+	app.Patch("/devices/:device_id/settings", controller.UpdateDeviceStorageSettings)
+	app.Get("/devices/:device_id/settings", controller.GetDeviceStorageSettings)
+	return app
+}
+
+func TestUpdateDeviceStorageSettings_SetsBothFields(t *testing.T) {
+	stub := &storageSettingsStubUsecase{}
+	app := newDeviceStorageSettingsTestApp(stub)
+
+	req := httptest.NewRequest(http.MethodPatch, "/devices/dev1/settings", strings.NewReader(`{"chat_storage": false, "auto_download_media": true}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	if !stub.receivedPatch.HasChatStorage || stub.receivedPatch.ChatStorage == nil || *stub.receivedPatch.ChatStorage != false {
+		t.Fatalf("expected chat_storage=false to be forwarded, got %+v", stub.receivedPatch)
+	}
+	if !stub.receivedPatch.HasAutoDownloadMedia || stub.receivedPatch.AutoDownloadMedia == nil || *stub.receivedPatch.AutoDownloadMedia != true {
+		t.Fatalf("expected auto_download_media=true to be forwarded, got %+v", stub.receivedPatch)
+	}
+}
+
+// A field explicitly sent as null must be forwarded as "present but nil" (clear the
+// override), not silently dropped as if absent.
+func TestUpdateDeviceStorageSettings_ExplicitNullClearsOverride(t *testing.T) {
+	stub := &storageSettingsStubUsecase{}
+	app := newDeviceStorageSettingsTestApp(stub)
+
+	req := httptest.NewRequest(http.MethodPatch, "/devices/dev1/settings", strings.NewReader(`{"chat_storage": null}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	if !stub.receivedPatch.HasChatStorage {
+		t.Fatal("expected chat_storage to be marked present even though its value is null")
+	}
+	if stub.receivedPatch.ChatStorage != nil {
+		t.Fatalf("expected chat_storage value to be nil (clear), got %v", *stub.receivedPatch.ChatStorage)
+	}
+	if stub.receivedPatch.HasAutoDownloadMedia {
+		t.Fatal("expected auto_download_media to be left untouched (absent from the request)")
+	}
+}
+
+// An empty body (neither field present) is rejected: there is nothing to update.
+func TestUpdateDeviceStorageSettings_EmptyBodyRejected(t *testing.T) {
+	stub := &storageSettingsStubUsecase{}
+	app := newDeviceStorageSettingsTestApp(stub)
+
+	req := httptest.NewRequest(http.MethodPatch, "/devices/dev1/settings", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", resp.StatusCode)
+	}
+}
+
+// A non-boolean, non-null value for either field is rejected with 400 rather than
+// silently coerced.
+func TestUpdateDeviceStorageSettings_InvalidTypeRejected(t *testing.T) {
+	stub := &storageSettingsStubUsecase{}
+	app := newDeviceStorageSettingsTestApp(stub)
+
+	req := httptest.NewRequest(http.MethodPatch, "/devices/dev1/settings", strings.NewReader(`{"chat_storage": "yes"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetDeviceStorageSettings_NoOverrideReturnsNulls(t *testing.T) {
+	stub := &storageSettingsStubUsecase{settings: &chatstorage.DeviceStorageSettings{}}
+	app := newDeviceStorageSettingsTestApp(stub)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/devices/dev1/settings", nil))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Results map[string]any `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if parsed.Results["chat_storage"] != nil {
+		t.Fatalf("expected chat_storage null, got %v", parsed.Results["chat_storage"])
+	}
+	if parsed.Results["auto_download_media"] != nil {
+		t.Fatalf("expected auto_download_media null, got %v", parsed.Results["auto_download_media"])
+	}
+	if parsed.Results["device_id"] != "dev1" {
+		t.Fatalf("expected device_id dev1, got %v", parsed.Results["device_id"])
+	}
+}
+
+func TestGetDeviceStorageSettings_WithOverrideReturnsValues(t *testing.T) {
+	chatStorage := false
+	autoDownload := true
+	stub := &storageSettingsStubUsecase{settings: &chatstorage.DeviceStorageSettings{
+		ChatStorage:       &chatStorage,
+		AutoDownloadMedia: &autoDownload,
+	}}
+	app := newDeviceStorageSettingsTestApp(stub)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/devices/dev1/settings", nil))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Results map[string]any `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if parsed.Results["chat_storage"] != false {
+		t.Fatalf("expected chat_storage=false, got %v", parsed.Results["chat_storage"])
+	}
+	if parsed.Results["auto_download_media"] != true {
+		t.Fatalf("expected auto_download_media=true, got %v", parsed.Results["auto_download_media"])
+	}
+}

--- a/src/usecase/device.go
+++ b/src/usecase/device.go
@@ -315,6 +315,65 @@ func (s *serviceDevice) GetDeviceWebhookConfig(ctx context.Context, deviceID str
 	return config, nil
 }
 
+// SetDeviceStorageSettings applies a partial update to a device's chat_storage /
+// auto_download_media overrides.
+func (s *serviceDevice) SetDeviceStorageSettings(ctx context.Context, deviceID string, patch chatstorage.DeviceStoragePatch) error {
+	if s.manager == nil {
+		return fmt.Errorf("device manager not initialized")
+	}
+
+	_, ok := s.manager.GetDevice(deviceID)
+	if !ok {
+		return pkgError.ErrDeviceNotFound
+	}
+
+	storage := s.manager.GetStorage()
+	if storage == nil {
+		return fmt.Errorf("storage not available")
+	}
+
+	if err := storage.SetDeviceStorageSettings(deviceID, patch); err != nil {
+		return fmt.Errorf("failed to set device storage settings: %w", err)
+	}
+
+	websocket.Broadcast <- websocket.BroadcastMessage{
+		Code:    "DEVICE_STORAGE_SETTINGS_UPDATED",
+		Message: fmt.Sprintf("Device %s storage settings updated", deviceID),
+		Result: map[string]any{
+			"device_id": deviceID,
+		},
+	}
+
+	return nil
+}
+
+// GetDeviceStorageSettings retrieves a device's chat_storage / auto_download_media overrides.
+func (s *serviceDevice) GetDeviceStorageSettings(ctx context.Context, deviceID string) (*chatstorage.DeviceStorageSettings, error) {
+	if s.manager == nil {
+		return nil, fmt.Errorf("device manager not initialized")
+	}
+
+	_, ok := s.manager.GetDevice(deviceID)
+	if !ok {
+		return nil, pkgError.ErrDeviceNotFound
+	}
+
+	storage := s.manager.GetStorage()
+	if storage == nil {
+		return nil, fmt.Errorf("storage not available")
+	}
+
+	settings, err := storage.GetDeviceStorageSettings(deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get device storage settings: %w", err)
+	}
+	if settings == nil {
+		settings = &chatstorage.DeviceStorageSettings{}
+	}
+
+	return settings, nil
+}
+
 func convertInstance(inst *whatsapp.DeviceInstance) domainDevice.Device {
 	if inst == nil {
 		return domainDevice.Device{}

--- a/src/usecase/device.go
+++ b/src/usecase/device.go
@@ -336,6 +336,13 @@ func (s *serviceDevice) SetDeviceStorageSettings(ctx context.Context, deviceID s
 		return fmt.Errorf("failed to set device storage settings: %w", err)
 	}
 
+	// A patch with neither field flagged as present is a no-op at the repository
+	// layer (nothing changed), so skip the notification rather than telling
+	// clients a setting was updated when it wasn't.
+	if !patch.HasChatStorage && !patch.HasAutoDownloadMedia {
+		return nil
+	}
+
 	websocket.Broadcast <- websocket.BroadcastMessage{
 		Code:    "DEVICE_STORAGE_SETTINGS_UPDATED",
 		Message: fmt.Sprintf("Device %s storage settings updated", deviceID),


### PR DESCRIPTION
## Context

- Add per-device `chat_storage` and `auto_download_media` overrides, following the per-device webhook mechanism from #671, exposed as `GET`/`PATCH /devices/{device_id}/settings`.
- Motivation: when one instance hosts many devices, chat storage and `--auto-download-media` are all-or-nothing. Some devices (notification-only accounts, high-volume media chats) should be lighter without changing behavior for every other device on the instance.
- Defaults are unchanged. Both columns are nullable and `NULL` means "no override": chat storage stays always-on (there is no global chat-storage flag since the SQLite migration), and `auto_download_media` keeps following `--auto-download-media` / `WHATSAPP_AUTO_DOWNLOAD_MEDIA`. A device-level `true`/`false` wins over the global flag only when explicitly set.
- `PATCH` is a partial update: omitted fields are left untouched, a field sent as `null` clears the override, and at least one field is required. The body is parsed as raw JSON so "absent" and "null" can be told apart (a `*bool` struct field decodes to `nil` in both cases).
- `chat_storage=false` gates the inbound path only: `CreateMessage`/`CreateReaction` in `event_message_handler.go`, `CreateIncomingCallRecord` in `event_call.go`, the auto-reply's own sent-message record in `auto_reply.go`, and history sync backfill. Outbound writes from the send/edit/delete use cases are intentionally still recorded, since those are actions the API caller asked for.
- `auto_download_media` replaces the direct `config.WhatsappAutoDownloadMedia` checks in `event_message.go` / `event_message_handler.go` with a per-client resolver that falls back to the global flag.
- Lookup is uncached, same as `getWebhookConfigForDevice`; `GetDeviceRecordByJID` now returns the two new columns alongside the webhook ones it already selected.
- Migrations 45 and 46 add `devices.chat_storage` and `devices.auto_download_media` (`BOOLEAN DEFAULT NULL`).
- Documented in `readme.md` and `docs/openapi.yaml`. No UI change: the embedded device manager was removed in #766, so this only adds the API for `gowa-ui` to wire up later.

### API

```
GET   /devices/{device_id}/settings
PATCH /devices/{device_id}/settings   {"chat_storage": false, "auto_download_media": true}
PATCH /devices/{device_id}/settings   {"chat_storage": null}   # clear one override, leave the other alone
```

Response `results`: `{"device_id": "...", "chat_storage": bool|null, "auto_download_media": bool|null}`.

## Test Results

- `go build ./...`, `go vet ./...` clean.
- `go test ./... -count=1`: all 13 packages `ok`.
- 24 new tests:
  - `infrastructure/chatstorage` (7): schema round-trip, partial update leaves the other field untouched, explicit `nil` clears vs empty patch is a no-op, unknown device, `GetDeviceRecordByJID` surfaces the new columns.
  - `infrastructure/whatsapp` (11): resolver rules for both flags — no device id, device not found, no override, explicit true/false, override wins over the global flag, lookup error falls back to the default.
  - `ui/rest` (6): PATCH with both fields, explicit `null` vs absent field, empty body rejected, non-bool value rejected, GET with and without an override.
