### PR TITLE
fix(mcp): mount GET /mcp for streamable-HTTP client handshake

### DIFF
--- a/src/cmd/mcp_route_test.go
+++ b/src/cmd/mcp_route_test.go
@@ -98,8 +98,9 @@ func TestMcpEndpointRequiresBasicAuth(t *testing.T) {
 // TestMcpEndpointGetDoesNotHang guards C1: a GET on /mcp must not reach
 // mcp-go's standalone SSE notification stream, which blocks forever behind
 // the fasthttp adaptor (ctx.Done() only fires on server shutdown, never on
-// client disconnect). Only POST and DELETE are mounted, so GET must come
-// back as a client error without app.Test's default timeout ever tripping.
+// client disconnect). Streaming is disabled and the server is stateless, so
+// the GET handshake is answered immediately with a minimal 200; app.Test's
+// default timeout below guards that it does not hang.
 func TestMcpEndpointGetDoesNotHang(t *testing.T) {
 	app := newMcpTestApp(false)
 
@@ -109,8 +110,11 @@ func TestMcpEndpointGetDoesNotHang(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.True(t, resp.StatusCode == fiber.StatusNotFound || resp.StatusCode == fiber.StatusMethodNotAllowed,
-		"GET /mcp returned %d, want 404 or 405", resp.StatusCode)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode, "GET /mcp returned %d, want 200", resp.StatusCode)
+	assert.Equal(t, "2025-03-26", resp.Header.Get("MCP-Protocol-Version"))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Empty(t, body)
 }
 
 // TestMcpToolCallRejectsInvalidArgumentsViaSchema guards I1: with

--- a/src/ui/mcp/route.go
+++ b/src/ui/mcp/route.go
@@ -59,9 +59,15 @@ func Register(router fiber.Router, dm *whatsapp.DeviceManager, deps Deps) {
 
 	handler := adaptor.HTTPHandler(httpServer)
 	// POST carries JSON-RPC calls; DELETE is part of the streamable-HTTP
-	// session lifecycle. GET is intentionally not mounted: with streaming
-	// disabled mcp-go would just 405 it, so Fiber's own 404 for an
-	// unmounted method is equivalent and keeps the route surface narrow.
+	// session lifecycle. GET is required by the streamable-HTTP handshake:
+	// clients such as Claude Code or Cursor perform a GET first to agree on
+	// MCP-Protocol-Version before their initial POST, and drop the server on
+	// any non-2xx. With streaming disabled (and the server stateless) there
+	// are no server-initiated messages, so a minimal 200 is spec-compliant.
+	router.Get("/mcp", func(c fiber.Ctx) error {
+		c.Set("MCP-Protocol-Version", "2025-03-26")
+		return c.SendString("")
+	})
 	router.Post("/mcp", handler)
 	router.Delete("/mcp", handler)
 }


### PR DESCRIPTION
Fixes #839

## Problem

Streamable-HTTP clients — notably **Claude Code** and Cursor — perform a `GET /mcp` before their first `POST initialize` to agree on `MCP-Protocol-Version`. GOWA only mounted `POST`/`DELETE`, so the GET returned `405` and the client dropped the server silently (no WhatsApp tools appear).

## Fix

Mount `GET /mcp` returning a minimal `200` with the `MCP-Protocol-Version` response header. This is stateless and streaming is already disabled, so there are no server-initiated notifications to stream — an empty 200 satisfies the spec for whitespace handshake consumers.

`WithDisableStreaming(true)` is kept as-is: re-enabling streaming would pin goroutines/FDs through the fasthttp adaptor (see the comment in `Register()`).

## Test

- `GET /mcp` now returns `200` (was `405`) with `MCP-Protocol-Version: 2025-03-26`.
- `POST initialize` unchanged (`200`, `serverInfo: WhatsApp Web Multidevice MCP Server`).